### PR TITLE
Fix some minor problems (mostly typos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ See also:
 The relay consists of several components that are designed to run and scale independently and to be as simple as possible:
 
 1. Housekeeper: update known validators, proposer duties. Soon: save metrics, etc.
-1. API: for proposer, block builder, data
-2. Website: handles the root website requests (information is pulled from Redis and database)
+2. API: for proposer, block builder, data
+3. Website: handles the root website requests (information is pulled from Redis and database)
 
 ## Getting started
 

--- a/beaconclient/util.go
+++ b/beaconclient/util.go
@@ -11,7 +11,7 @@ import (
 func fetchBeacon(url string, method string, dst any) error {
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
-		return fmt.Errorf("invalid reqest for %s: %w", url, err)
+		return fmt.Errorf("invalid request for %s: %w", url, err)
 	}
 	req.Header.Set("accept", "application/json")
 

--- a/cmd/housekeeper.go
+++ b/cmd/housekeeper.go
@@ -185,7 +185,7 @@ var housekeeperCmd = &cobra.Command{
 // 		ValidatorsKnownTotal:                     m.validatorsKnownTotal,
 // 		ValidatorRegistrationsTotal:              m.validatorRegistrationsTotal,
 // 		ValidatorRegistrationsSaved:              m.valToInt(vals, "validator_registrations_saved"),
-// 		ValidatorRegistrationsReceviedUnverified: m.valToInt(vals, "validator_registrations_received_unverified"),
+// 		ValidatorRegistrationsReceivedUnverified: m.valToInt(vals, "validator_registrations_received_unverified"),
 
 // 		NumRegisterValidatorRequests: m.valToInt(vals, "num_register_validator_requests"),
 // 		NumGetHeaderRequests:         m.valToInt(vals, "num_get_header_requests"),

--- a/cmd/website.go
+++ b/cmd/website.go
@@ -55,7 +55,7 @@ var websiteCmd = &cobra.Command{
 
 		relayPubkey, err := redis.GetRelayConfig(datastore.RedisConfigFieldPubkey)
 		if err != nil {
-			log.WithError(err).Fatal("failed getting publey from Redis")
+			log.WithError(err).Fatal("failed getting pubkey from Redis")
 		}
 
 		// Connect to Postgres

--- a/common/types.go
+++ b/common/types.go
@@ -113,7 +113,7 @@ type EpochSummary struct {
 	SlotFirst uint64 `json:"slot_first" db:"slot_first"`
 	SlotLast  uint64 `json:"slot_last"  db:"slot_last"`
 
-	// registered are those that were actually used by the relay (some might be skipped if only one relay and it started in the mmiddle of the epoch)
+	// registered are those that were actually used by the relay (some might be skipped if only one relay and it started in the middle of the epoch)
 	SlotFirstProcessed uint64 `json:"slot_first_processed" db:"slot_first_processed"`
 	SlotLastProcessed  uint64 `json:"slot_last_processed"  db:"slot_last_processed"`
 
@@ -121,7 +121,7 @@ type EpochSummary struct {
 	ValidatorsKnownTotal                     uint64 `json:"validators_known_total"                      db:"validators_known_total"`
 	ValidatorRegistrationsTotal              uint64 `json:"validator_registrations_total"               db:"validator_registrations_total"`
 	ValidatorRegistrationsSaved              uint64 `json:"validator_registrations_saved"               db:"validator_registrations_saved"`
-	ValidatorRegistrationsReceviedUnverified uint64 `json:"validator_registrations_received_unverified" db:"validator_registrations_received_unverified"`
+	ValidatorRegistrationsReceivedUnverified uint64 `json:"validator_registrations_received_unverified" db:"validator_registrations_received_unverified"`
 
 	// The number of requests are the count of all requests to a specific path, even invalid ones
 	NumRegisterValidatorRequests uint64 `json:"num_register_validator_requests" db:"num_register_validator_requests"`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: redis
     restart: always
     ports:
-      - 6379:6379
+      - '6379:6379'
 
   db:
     image: postgres
@@ -17,7 +17,7 @@ services:
     volumes:
       - 'psql_data:/var/lib/postgresql/data'
     ports:
-      - 5432:5432
+      - '5432:5432'
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -29,6 +29,6 @@ services:
     depends_on:
       - db
     ports:
-      - 8093:8080
+      - '8093:8080'
     environment:
       ADMINER_PLUGINS: tables-filter tinymce

--- a/services/api/blocksim_ratelimiter.go
+++ b/services/api/blocksim_ratelimiter.go
@@ -19,7 +19,7 @@ type BlockSimulationRateLimiter struct {
 	blockSimURL string
 }
 
-func NewBlockSimuationRateLimiter(blockSimURL string) *BlockSimulationRateLimiter {
+func NewBlockSimulationRateLimiter(blockSimURL string) *BlockSimulationRateLimiter {
 	return &BlockSimulationRateLimiter{
 		cv:          sync.NewCond(&sync.Mutex{}),
 		counter:     0,

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -128,7 +128,7 @@ func NewRelayAPI(opts RelayAPIOpts) (*RelayAPI, error) {
 		db:                     opts.DB,
 		proposerDutiesResponse: []types.BuilderGetValidatorsResponseEntry{},
 		regValEntriesC:         make(chan types.SignedValidatorRegistration, 5000),
-		blockSimRateLimiter:    NewBlockSimuationRateLimiter(opts.BlockSimURL),
+		blockSimRateLimiter:    NewBlockSimulationRateLimiter(opts.BlockSimURL),
 	}
 
 	api.log.Infof("Using BLS key: %s", publicKey.String())


### PR DESCRIPTION
## 📝 Summary

* Fix some typos throughout the project.
* Specify docker compose port mappings as strings.
* Fix duplicate numbering in readme.

## ⛱ Motivation and Context

* Before digging the trenches, I like to fix all of the minor things first.

## 📚 References

* https://docs.docker.com/compose/compose-file/compose-file-v3/#ports

> When mapping ports in the `HOST:CONTAINER` format, you may experience erroneous results when using a container port lower than 60, because YAML parses numbers in the format `xx:yy` as a base-60 value. For this reason, we recommend always explicitly specifying your port mappings as strings.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
