### PR TITLE
Use time package to check registration timestamp

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -427,7 +427,6 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 	}
 
 	start := time.Now()
-	registrationTimeLowerBound := start.Add(-10 * time.Second)
 	registrationTimeUpperBound := start.Add(10 * time.Second)
 
 	payload := []types.SignedValidatorRegistration{}
@@ -449,10 +448,7 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 		}
 
 		registrationTime := time.Unix(int64(registration.Message.Timestamp), 0)
-		if registrationTime.Before(registrationTimeLowerBound) {
-			respondError(http.StatusBadRequest, "timestamp too far in the past")
-			return
-		} else if registrationTime.After(registrationTimeUpperBound) {
+		if registrationTime.After(registrationTimeUpperBound) {
 			respondError(http.StatusBadRequest, "timestamp too far in the future")
 			return
 		}


### PR DESCRIPTION
## 📝 Summary

* Make the validator registration timestamp processing a little easier to read.
* Properly reject timestamps that are greater than `math.MaxInt64`.

## ⛱ Motivation and Context

Fixes: #35 (partly)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
