### PR TITLE
Update URL parsing in NewBuilderEntry

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -24,14 +24,14 @@ func NewBuilderEntry(builderURL string) (entry *BuilderEntry, err error) {
 		builderURL = "http://" + builderURL
 	}
 
-	url, err := url.Parse(builderURL)
+	parsedURL, err := url.Parse(builderURL)
 	if err != nil {
 		return entry, err
 	}
 
 	entry = &BuilderEntry{
-		URL:     url,
-		Address: entry.URL.Scheme + "://" + entry.URL.Host,
+		URL:     parsedURL,
+		Address: parsedURL.Scheme + "://" + parsedURL.Host,
 	}
 	err = entry.Pubkey.UnmarshalText([]byte(entry.URL.User.Username()))
 	return entry, err


### PR DESCRIPTION
## 📝 Summary

* Rename `url` variable to fix clashing with `net/url` package.
* Use `parsedURL` in `entry.Address` instead of `entry.URL`.
  * If things were moved around later, this could have resulted in a nil dereference.

## ⛱ Motivation and Context

This function isn't even used yet, but I noticed some things that might be confusing later.

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
