### PR TITLE
Enable thelper check

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,7 +25,6 @@ linters:
     - revive
     - tagliatelle
     - testpackage
-    - thelper
     - unparam
     - varnamelen
     - whitespace

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func setupTestDatastore(t *testing.T) *Datastore {
+	t.Helper()
 	var err error
 
 	redisTestServer, err := miniredis.Run()

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func setupTestRedis(t *testing.T) *RedisCache {
+	t.Helper()
 	var err error
 
 	redisTestServer, err := miniredis.Run()


### PR DESCRIPTION
## 📝 Summary

* Enables the `thelper` check which ensures helper functions call `t.Helper()`.
  * See the referenced link for details.

## ⛱ Motivation and Context

Just going through each of the linters. I was unaware of this problem. Cool check.

## 📚 References

* https://github.com/kulti/thelper#why

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
