### PR TITLE
Enable gofumpt extra checks

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -62,3 +62,6 @@ linters-settings:
     case:
       rules:
         json: snake
+
+  gofumpt:
+    extra-rules: true

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,13 @@ test-race:
 
 lint:
 	gofmt -d -s .
-	gofumpt -d .
+	gofumpt -d -extra .
 	go vet ./...
 	staticcheck ./...
 	golangci-lint run
+
+gofumpt:
+	gofumpt -l -w -extra .
 
 cover:
 	go test -coverprofile=/tmp/boost-relay.cover.tmp ./...

--- a/beaconclient/util.go
+++ b/beaconclient/util.go
@@ -10,7 +10,7 @@ import (
 
 var ErrHTTPErrorResponse = errors.New("got an HTTP error response")
 
-func fetchBeacon(url string, method string, dst any) error {
+func fetchBeacon(url, method string, dst any) error {
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return fmt.Errorf("invalid request for %s: %w", url, err)

--- a/common/utils.go
+++ b/common/utils.go
@@ -57,7 +57,7 @@ func makeRequest(ctx context.Context, client http.Client, method, url string, pa
 }
 
 // ComputeDomain computes the signing domain
-func ComputeDomain(domainType types.DomainType, forkVersionHex string, genesisValidatorsRootHex string) (domain types.Domain, err error) {
+func ComputeDomain(domainType types.DomainType, forkVersionHex, genesisValidatorsRootHex string) (domain types.Domain, err error) {
 	genesisValidatorsRoot := types.Root(common.HexToHash(genesisValidatorsRootHex))
 	forkVersionBytes, err := hexutil.Decode(forkVersionHex)
 	if err != nil || len(forkVersionBytes) > 4 {
@@ -68,7 +68,7 @@ func ComputeDomain(domainType types.DomainType, forkVersionHex string, genesisVa
 	return types.ComputeDomain(domainType, forkVersion, genesisValidatorsRoot), nil
 }
 
-func GetEnv(key string, defaultValue string) string {
+func GetEnv(key, defaultValue string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
 	}

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -174,7 +174,7 @@ func (ds *Datastore) SaveBidAndBlock(slot uint64, proposerPubkey string, signedB
 	return ds.redis.SaveBid(slot, _parentHash, _proposerPubkey, headerResp)
 }
 
-func (ds *Datastore) CleanupOldBidsAndBlocks(headSlot uint64) (numRemoved int, numRemaining int) {
+func (ds *Datastore) CleanupOldBidsAndBlocks(headSlot uint64) (numRemoved, numRemaining int) {
 	ds.bidLock.Lock()
 	for key := range ds.bids {
 		if key.Slot < headSlot-1000 {
@@ -196,7 +196,7 @@ func (ds *Datastore) CleanupOldBidsAndBlocks(headSlot uint64) (numRemoved int, n
 }
 
 // GetBid returns the bid from memory or Redis
-func (ds *Datastore) GetBid(slot uint64, parentHash string, proposerPubkey string) (bid *types.GetHeaderResponse, err error) {
+func (ds *Datastore) GetBid(slot uint64, parentHash, proposerPubkey string) (bid *types.GetHeaderResponse, err error) {
 	_parentHash := strings.ToLower(parentHash)
 	_proposerPubkey := strings.ToLower(proposerPubkey)
 
@@ -221,7 +221,7 @@ func (ds *Datastore) GetBid(slot uint64, parentHash string, proposerPubkey strin
 	return ds.redis.GetBid(slot, _parentHash, _proposerPubkey)
 }
 
-func (ds *Datastore) GetBlockBidAndTrace(slot uint64, proposerPubkey string, blockHash string) (*BlockBidAndTrace, error) {
+func (ds *Datastore) GetBlockBidAndTrace(slot uint64, proposerPubkey, blockHash string) (*BlockBidAndTrace, error) {
 	blockKey := BlockKey{
 		Slot:           slot,
 		ProposerPubkey: strings.ToLower(proposerPubkey),

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -53,7 +53,7 @@ type RedisCache struct {
 	keyProposerDuties string
 }
 
-func NewRedisCache(redisURI string, prefix string) (*RedisCache, error) {
+func NewRedisCache(redisURI, prefix string) (*RedisCache, error) {
 	client, err := connectRedis(redisURI)
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func NewRedisCache(redisURI string, prefix string) (*RedisCache, error) {
 	}, nil
 }
 
-func (r *RedisCache) keyBidCache(slot uint64, parentHash string, proposerPubkey string) string {
+func (r *RedisCache) keyBidCache(slot uint64, parentHash, proposerPubkey string) string {
 	return fmt.Sprintf("%s:%d_%s_%s", r.prefixBidCache, slot, parentHash, proposerPubkey)
 }
 
@@ -230,7 +230,7 @@ func (r *RedisCache) GetProposerDuties() (proposerDuties []types.BuilderGetValid
 	return proposerDuties, err
 }
 
-func (r *RedisCache) SetRelayConfig(field string, value string) (err error) {
+func (r *RedisCache) SetRelayConfig(field, value string) (err error) {
 	return r.client.HSet(context.Background(), r.keyRelayConfig, field, value).Err()
 }
 
@@ -242,13 +242,13 @@ func (r *RedisCache) GetRelayConfig(field string) (string, error) {
 	return res, err
 }
 
-func (r *RedisCache) SaveBid(slot uint64, parentHash string, proposerPubkey string, headerResp *types.GetHeaderResponse) (err error) {
+func (r *RedisCache) SaveBid(slot uint64, parentHash, proposerPubkey string, headerResp *types.GetHeaderResponse) (err error) {
 	key := r.keyBidCache(slot, parentHash, proposerPubkey)
 	return r.SetObj(key, headerResp, expiryBidCache)
 }
 
 // GetBid retrieves a bid from Redis. If not existing, returns nil for both bid and error
-func (r *RedisCache) GetBid(slot uint64, parentHash string, proposerPubkey string) (bid *types.GetHeaderResponse, err error) {
+func (r *RedisCache) GetBid(slot uint64, parentHash, proposerPubkey string) (bid *types.GetHeaderResponse, err error) {
 	key := r.keyBidCache(slot, parentHash, proposerPubkey)
 	bid = new(types.GetHeaderResponse)
 	err = r.GetObj(key, bid)

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -75,7 +75,7 @@ func newTestBackend(t require.TestingT) *testBackend {
 	return &backend
 }
 
-func (be *testBackend) request(method string, path string, payload any) *httptest.ResponseRecorder {
+func (be *testBackend) request(method, path string, payload any) *httptest.ResponseRecorder {
 	var req *http.Request
 	var err error
 


### PR DESCRIPTION
## 📝 Summary

* Enable the [extra](https://github.com/mvdan/gofumpt#extra-rules-behind--extra) rules.
  * Currently, this is just "adjacent parameters with the same type should be grouped together."
* Add `make gofumpt` rule which auto-fixes warnings.

## ⛱ Motivation and Context

This is such a small thing, but might as well, right?

## 📚 References

* https://github.com/mvdan/gofumpt#extra-rules-behind--extra

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
