### PR TITLE
Throw error if forkVersion is fewer than 4 bytes

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -60,7 +60,7 @@ func makeRequest(ctx context.Context, client http.Client, method, url string, pa
 func ComputeDomain(domainType types.DomainType, forkVersionHex, genesisValidatorsRootHex string) (domain types.Domain, err error) {
 	genesisValidatorsRoot := types.Root(common.HexToHash(genesisValidatorsRootHex))
 	forkVersionBytes, err := hexutil.Decode(forkVersionHex)
-	if err != nil || len(forkVersionBytes) > 4 {
+	if err != nil || len(forkVersionBytes) != 4 {
 		return domain, ErrInvalidForkVersion
 	}
 	var forkVersion [4]byte


### PR DESCRIPTION
## 📝 Summary

* Fix a little panic that @asanso found.

## ⛱ Motivation and Context

The `ComputeDomain` function would only throw an error if `forkVersion` was more than 4 bytes. It should also throw an error if it's fewer than 4 bytes. Its panic would look like:

```
panic: runtime error: slice bounds out of range [:4] with capacity 0
```

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
