### PR TITLE
Remove unnecessary/default staticcheck options

### DIFF
--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,5 +1,1 @@
 checks = ["all"]
-# checks = ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-ST1023"]
-initialisms = ["ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"]
-dot_import_whitelist = ["github.com/mmcloughlin/avo/build", "github.com/mmcloughlin/avo/operand", "github.com/mmcloughlin/avo/reg"]
-http_status_code_whitelist = ["200", "400", "404", "500"]


### PR DESCRIPTION
## 📝 Summary

Looks like the configuration for `staticcheck` was essentially copy pasted from example configuration in the quick start guide. We don't need to specify many of those options. We're fine with the default settings.

## ⛱ Motivation and Context

Just cleans things up.

## 📚 References

* https://staticcheck.io/docs/configuration/#example-configuration

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
