### PR TITLE
Enable dependabot for dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    reviewers:
+      - "metachris"


### PR DESCRIPTION
Signed-off-by: Luca Georges Francois <luca.georges-francois@kiln.fi>

## 📝 Summary

This PR enables dependabot to check dependencies on a daily basis.
Dependabot will create a PR with @metachris set as the reviewer whenever there's a new version of any of the project's dependency.

## ⛱ Motivation and Context

Resolves #56.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
