### PR TITLE
Allow boost relay to connect to multiple BNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ docker-compose up
 
 (you can now visit adminer on http://localhost:8093/?username=postgres)
 
-The services need access to a beacon node for event subscriptions and the beacon API (by default using `localhost:3500` which is the Prysm default beacon-API port). You can proxy the port from a server like this:
+The services need access to a beacon node for event subscriptions. You can also specify multiple beacon nodes by providing a comma separated list of beacon node URIs. The beacon API by default is using `localhost:3500` (the Prysm default beacon-API port). You can proxy the port from a server like this:
 
 ```bash
 ssh -L 3500:localhost:3500 your_server

--- a/beaconclient/beacon_client.go
+++ b/beaconclient/beacon_client.go
@@ -7,6 +7,7 @@ type BeaconNodeClient interface {
 	SyncStatus() (*SyncStatusPayloadData, error)
 	CurrentSlot() (uint64, error)
 	SubscribeToHeadEvents(slotC chan HeadEventData)
-	FetchValidators() (map[types.PubkeyHex]ValidatorResponseEntry, error)
+	FetchValidators(headSlot uint64) (map[types.PubkeyHex]ValidatorResponseEntry, error)
 	GetProposerDuties(epoch uint64) (*ProposerDutiesResponse, error)
+	GetURI() string
 }

--- a/beaconclient/beacon_client_test.go
+++ b/beaconclient/beacon_client_test.go
@@ -16,7 +16,7 @@ func TestBeaconValidators(t *testing.T) {
 	srv := httptest.NewServer(r)
 	bc := NewProdBeaconClient(common.TestLog, srv.URL)
 
-	r.HandleFunc("/eth/v1/beacon/states/head/validators", func(w http.ResponseWriter, _ *http.Request) {
+	r.HandleFunc("/eth/v1/beacon/states/1/validators", func(w http.ResponseWriter, _ *http.Request) {
 		resp := []byte(`{
   "execution_optimistic": false,
   "data": [
@@ -41,7 +41,7 @@ func TestBeaconValidators(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	vals, err := bc.FetchValidators()
+	vals, err := bc.FetchValidators(1)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(vals))
 	require.Contains(t, vals, types.PubkeyHex("0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"))

--- a/beaconclient/mock_beacon_client.go
+++ b/beaconclient/mock_beacon_client.go
@@ -42,7 +42,7 @@ func (c *MockBeaconClient) NumValidators() uint64 {
 	return uint64(len(c.validatorSet))
 }
 
-func (c *MockBeaconClient) FetchValidators() (map[types.PubkeyHex]ValidatorResponseEntry, error) {
+func (c *MockBeaconClient) FetchValidators(headSlot uint64) (map[types.PubkeyHex]ValidatorResponseEntry, error) {
 	return c.validatorSet, nil
 }
 
@@ -64,3 +64,5 @@ func (c *MockBeaconClient) GetProposerDuties(epoch uint64) (*ProposerDutiesRespo
 		Data: []ProposerDutiesResponseData{},
 	}, nil
 }
+
+func (c *MockBeaconClient) GetURI() string { return "" }

--- a/beaconclient/prod_beacon_client.go
+++ b/beaconclient/prod_beacon_client.go
@@ -53,8 +53,8 @@ func (c *ProdBeaconClient) SubscribeToHeadEvents(slotC chan HeadEventData) {
 	}
 }
 
-func (c *ProdBeaconClient) FetchValidators() (map[types.PubkeyHex]ValidatorResponseEntry, error) {
-	vd, err := fetchAllValidators(c.beaconURI)
+func (c *ProdBeaconClient) FetchValidators(headSlot uint64) (map[types.PubkeyHex]ValidatorResponseEntry, error) {
+	vd, err := fetchAllValidators(c.beaconURI, headSlot)
 	if err != nil {
 		return nil, err
 	}
@@ -82,9 +82,8 @@ type AllValidatorsResponse struct {
 	Data []ValidatorResponseEntry
 }
 
-func fetchAllValidators(endpoint string) (*AllValidatorsResponse, error) {
-	uri := endpoint + "/eth/v1/beacon/states/head/validators?status=active,pending"
-
+func fetchAllValidators(endpoint string, headSlot uint64) (*AllValidatorsResponse, error) {
+	uri := fmt.Sprintf("%s/eth/v1/beacon/states/%d/validators?status=active,pending", endpoint, headSlot)
 	// https://ethereum.github.io/beacon-APIs/#/Beacon/getStateValidators
 	vd := new(AllValidatorsResponse)
 	err := fetchBeacon(uri, "GET", vd)
@@ -180,4 +179,8 @@ func (c *ProdBeaconClient) GetBlock() (*GetBlockResponse, error) {
 	resp := new(GetBlockResponse)
 	err := fetchBeacon(uri, "GET", resp)
 	return resp, err
+}
+
+func (c *ProdBeaconClient) GetURI() string {
+	return c.beaconURI
 }

--- a/beaconclient/util.go
+++ b/beaconclient/util.go
@@ -28,7 +28,7 @@ func fetchBeacon(url, method string, dst any) error {
 		return fmt.Errorf("could not read response body for %s: %w", url, err)
 	}
 
-	if resp.StatusCode >= 300 {
+	if resp.StatusCode >= http.StatusMultipleChoices {
 		ec := &struct {
 			Code    int    `json:"code"`
 			Message string `json:"message"`

--- a/cmd/housekeeper.go
+++ b/cmd/housekeeper.go
@@ -47,7 +47,7 @@ var housekeeperCmd = &cobra.Command{
 			log.Fatalf("no beacon endpoints specified")
 		}
 		log.Infof("Using beacon endpoints: %s", strings.Join(beaconNodeURIs, ","))
-		var beaconClients []*beaconclient.ProdBeaconClient
+		var beaconClients []beaconclient.BeaconNodeClient
 		for _, uri := range beaconNodeURIs {
 			beaconClients = append(beaconClients, beaconclient.NewProdBeaconClient(log, uri))
 		}

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -7,14 +7,14 @@ import (
 )
 
 var (
-	defaultBeaconURI = common.GetEnv("BEACON_URI", "http://localhost:3500")
-	defaultredisURI  = common.GetEnv("REDIS_URI", "localhost:6379")
-	defaultLogJSON   = os.Getenv("LOG_JSON") != ""
-	defaultLogLevel  = common.GetEnv("LOG_LEVEL", "info")
+	defaultBeaconURIs = common.GetSliceEnv("BEACON_URI", []string{"http://localhost:3500"})
+	defaultredisURI   = common.GetEnv("REDIS_URI", "localhost:6379")
+	defaultLogJSON    = os.Getenv("LOG_JSON") != ""
+	defaultLogLevel   = common.GetEnv("LOG_LEVEL", "info")
 
-	beaconNodeURI string
-	redisURI      string
-	postgresDSN   string
+	beaconNodeURIs []string
+	redisURI       string
+	postgresDSN    string
 
 	logJSON  bool
 	logLevel string

--- a/common/utils.go
+++ b/common/utils.go
@@ -75,6 +75,13 @@ func GetEnv(key, defaultValue string) string {
 	return defaultValue
 }
 
+func GetSliceEnv(key string, defaultValue []string) []string {
+	if value, ok := os.LookupEnv(key); ok {
+		return strings.Split(value, ",")
+	}
+	return defaultValue
+}
+
 func GetIPXForwardedFor(r *http.Request) string {
 	forwarded := r.Header.Get("X-Forwarded-For")
 	if forwarded != "" {

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -16,8 +16,7 @@ import (
 var (
 	redisPrefix = "boost-relay"
 
-	expiryBidCache   = 5 * time.Minute
-	expiryBeaconNode = 5 * time.Minute
+	expiryBidCache = 5 * time.Minute
 
 	RedisConfigFieldPubkey    = "pubkey"
 	RedisStatsFieldLatestSlot = "latest-slot"
@@ -50,7 +49,6 @@ type RedisCache struct {
 	keyRelayConfig    string
 	keyStats          string
 	keyProposerDuties string
-	keyBeaconNode     string
 }
 
 func NewRedisCache(redisURI, prefix string) (*RedisCache, error) {
@@ -68,7 +66,6 @@ func NewRedisCache(redisURI, prefix string) (*RedisCache, error) {
 		keyValidatorRegistration:          fmt.Sprintf("%s/%s:validators-registration-timestamp", redisPrefix, prefix),
 		keyValidatorRegistrationTimestamp: fmt.Sprintf("%s/%s:validators-registration", redisPrefix, prefix),
 		keyRelayConfig:                    fmt.Sprintf("%s/%s:relay-config", redisPrefix, prefix),
-		keyBeaconNode:                     fmt.Sprintf("%s/%s:beacon-node", redisPrefix, prefix),
 
 		keyStats:          fmt.Sprintf("%s/%s:stats", redisPrefix, prefix),
 		keyProposerDuties: fmt.Sprintf("%s/%s:proposer-duties", redisPrefix, prefix),
@@ -214,18 +211,4 @@ func (r *RedisCache) GetBid(slot uint64, parentHash, proposerPubkey string) (bid
 		return nil, nil
 	}
 	return bid, err
-}
-
-// SetBeaconNodeIndex sets the last beacon node that sent a successful response
-func (r *RedisCache) SetBeaconNodeIndex(beaconNodeIndex int) (err error) {
-	return r.client.Set(context.Background(), r.keyBeaconNode, beaconNodeIndex, expiryBeaconNode).Err()
-}
-
-// GetBeaconNodeIndex retrieves the last beacon node that sent a successful response
-func (r *RedisCache) GetBeaconNodeIndex() (beaconNodeIndex int, err error) {
-	index, err := r.client.Get(context.Background(), r.keyBeaconNode).Int()
-	if errors.Is(err, redis.Nil) {
-		return 0, nil
-	}
-	return index, err
 }

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -16,7 +16,8 @@ import (
 var (
 	redisPrefix = "boost-relay"
 
-	expiryBidCache = 5 * time.Minute
+	expiryBidCache   = 5 * time.Minute
+	expiryBeaconNode = 5 * time.Minute
 
 	RedisConfigFieldPubkey    = "pubkey"
 	RedisStatsFieldLatestSlot = "latest-slot"
@@ -49,6 +50,7 @@ type RedisCache struct {
 	keyRelayConfig    string
 	keyStats          string
 	keyProposerDuties string
+	keyBeaconNode     string
 }
 
 func NewRedisCache(redisURI, prefix string) (*RedisCache, error) {
@@ -66,6 +68,7 @@ func NewRedisCache(redisURI, prefix string) (*RedisCache, error) {
 		keyValidatorRegistration:          fmt.Sprintf("%s/%s:validators-registration-timestamp", redisPrefix, prefix),
 		keyValidatorRegistrationTimestamp: fmt.Sprintf("%s/%s:validators-registration", redisPrefix, prefix),
 		keyRelayConfig:                    fmt.Sprintf("%s/%s:relay-config", redisPrefix, prefix),
+		keyBeaconNode:                     fmt.Sprintf("%s/%s:beacon-node", redisPrefix, prefix),
 
 		keyStats:          fmt.Sprintf("%s/%s:stats", redisPrefix, prefix),
 		keyProposerDuties: fmt.Sprintf("%s/%s:proposer-duties", redisPrefix, prefix),
@@ -211,4 +214,18 @@ func (r *RedisCache) GetBid(slot uint64, parentHash, proposerPubkey string) (bid
 		return nil, nil
 	}
 	return bid, err
+}
+
+// SetBeaconNodeIndex sets the last beacon node that sent a successful response
+func (r *RedisCache) SetBeaconNodeIndex(beaconNodeIndex int) (err error) {
+	return r.client.Set(context.Background(), r.keyBeaconNode, beaconNodeIndex, expiryBeaconNode).Err()
+}
+
+// GetBeaconNodeIndex retrieves the last beacon node that sent a successful response
+func (r *RedisCache) GetBeaconNodeIndex() (beaconNodeIndex int, err error) {
+	index, err := r.client.Get(context.Background(), r.keyBeaconNode).Int()
+	if errors.Is(err, redis.Nil) {
+		return 0, nil
+	}
+	return index, err
 }

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/flashbots/go-boost-utils/bls"
@@ -60,10 +61,10 @@ type RelayAPIOpts struct {
 	BlockSimURL   string
 	RegValWorkers int // number of workers for validator registration processing
 
-	BeaconClient beaconclient.BeaconNodeClient
-	Datastore    *datastore.Datastore
-	Redis        *datastore.RedisCache
-	DB           database.IDatabaseService
+	BeaconClients []beaconclient.BeaconNodeClient
+	Datastore     *datastore.Datastore
+	Redis         *datastore.RedisCache
+	DB            database.IDatabaseService
 
 	SecretKey *bls.SecretKey // used to sign bids (getHeader responses)
 
@@ -88,10 +89,10 @@ type RelayAPI struct {
 	regValEntriesC       chan types.SignedValidatorRegistration
 	regValWorkersStarted uberatomic.Bool
 
-	beaconClient beaconclient.BeaconNodeClient
-	datastore    *datastore.Datastore
-	redis        *datastore.RedisCache
-	db           database.IDatabaseService
+	beaconClients []beaconclient.BeaconNodeClient
+	datastore     *datastore.Datastore
+	redis         *datastore.RedisCache
+	db            database.IDatabaseService
 
 	headSlot     uint64
 	currentEpoch uint64
@@ -116,7 +117,7 @@ func NewRelayAPI(opts RelayAPIOpts) (*RelayAPI, error) {
 		return nil, ErrMissingLogOpt
 	}
 
-	if opts.BeaconClient == nil {
+	if len(opts.BeaconClients) == 0 {
 		return nil, ErrMissingBeaconClientOpt
 	}
 
@@ -132,7 +133,7 @@ func NewRelayAPI(opts RelayAPIOpts) (*RelayAPI, error) {
 		blsSk:                  opts.SecretKey,
 		publicKey:              &publicKey,
 		datastore:              opts.Datastore,
-		beaconClient:           opts.BeaconClient,
+		beaconClients:          opts.BeaconClients,
 		redis:                  opts.Redis,
 		db:                     opts.DB,
 		proposerDutiesResponse: []types.BuilderGetValidatorsResponseEntry{},
@@ -252,13 +253,10 @@ func (api *RelayAPI) StartServer() (err error) {
 		return ErrServerAlreadyStarted
 	}
 
-	// Check beacon-node sync status, process current slot and start slot updates
-	syncStatus, err := api.beaconClient.SyncStatus()
+	// Get best beacon-node status by head slot, process current slot and start slot updates
+	bestSyncStatus, err := api.getBestSyncStatus()
 	if err != nil {
 		return err
-	}
-	if syncStatus.IsSyncing && !api.ffAllowSyncingBeaconNode {
-		return ErrBeaconNodeSyncing
 	}
 
 	// Start worker pool for validator registration processing
@@ -268,18 +266,20 @@ func (api *RelayAPI) StartServer() (err error) {
 	}
 
 	// Get current proposer duties
-	api.updateProposerDuties(syncStatus.HeadSlot)
+	api.updateProposerDuties(bestSyncStatus.HeadSlot)
 
 	// Update list of known validators, and start refresh loop
 	go api.startKnownValidatorUpdates()
 
 	// Process current slot
-	api.processNewSlot(syncStatus.HeadSlot)
+	api.processNewSlot(bestSyncStatus.HeadSlot)
 
 	// Start regular slot updates
 	go func() {
 		c := make(chan beaconclient.HeadEventData)
-		go api.beaconClient.SubscribeToHeadEvents(c)
+		for _, client := range api.beaconClients {
+			go client.SubscribeToHeadEvents(c)
+		}
 		for {
 			headEvent := <-c
 			api.processNewSlot(headEvent.Slot)
@@ -310,6 +310,48 @@ func (api *RelayAPI) StartServer() (err error) {
 		return nil
 	}
 	return err
+}
+
+func (api *RelayAPI) getBestSyncStatus() (*beaconclient.SyncStatusPayloadData, error) {
+	var bestSyncStatus *beaconclient.SyncStatusPayloadData
+	var mu sync.Mutex
+	var numSyncedNodes uint32
+
+	// Check each beacon-node sync status
+	var wg sync.WaitGroup
+	for _, client := range api.beaconClients {
+		wg.Add(1)
+		go func(client beaconclient.BeaconNodeClient) {
+			defer wg.Done()
+			log := api.log.WithField("uri", client.GetURI())
+			log.Debug("getting sync status")
+
+			syncStatus, err := client.SyncStatus()
+			if err != nil {
+				log.WithError(err).Error("failed to get sync status")
+				return
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if bestSyncStatus == nil || syncStatus.HeadSlot > bestSyncStatus.HeadSlot {
+				bestSyncStatus = syncStatus
+			}
+
+			if !syncStatus.IsSyncing {
+				atomic.AddUint32(&numSyncedNodes, 1)
+			}
+		}(client)
+	}
+
+	// Wait for all requests to complete...
+	wg.Wait()
+
+	if numSyncedNodes == 0 && !api.ffAllowSyncingBeaconNode {
+		return nil, ErrBeaconNodeSyncing
+	}
+	return bestSyncStatus, nil
 }
 
 func (api *RelayAPI) processNewSlot(headSlot uint64) {

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/flashbots/go-boost-utils/bls"
@@ -349,7 +348,7 @@ func (api *RelayAPI) getBestSyncStatus() (*beaconclient.SyncStatusPayloadData, e
 
 			if !syncStatus.IsSyncing {
 				bestSyncStatus = syncStatus
-				atomic.AddUint32(&numSyncedNodes, 1)
+				numSyncedNodes++
 				requestCtxCancel()
 			}
 		}(client)

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -33,10 +33,10 @@ type testBackend struct {
 
 func newTestBackend(t require.TestingT, numBeaconNodes int) *testBackend {
 	mockBeaconClients := make([]*beaconclient.MockBeaconClient, numBeaconNodes)
-	mockBeaconClientsInterface := make([]beaconclient.BeaconNodeClient, numBeaconNodes)
+	clients := make([]beaconclient.BeaconNodeClient, numBeaconNodes)
 	for i := 0; i < numBeaconNodes; i++ {
 		mockBeaconClients[i] = beaconclient.NewMockBeaconClient()
-		mockBeaconClientsInterface[i] = mockBeaconClients[i]
+		clients[i] = mockBeaconClients[i]
 	}
 
 	redisClient, err := miniredis.Run()
@@ -56,7 +56,7 @@ func newTestBackend(t require.TestingT, numBeaconNodes int) *testBackend {
 	opts := RelayAPIOpts{
 		Log:           common.TestLog,
 		ListenAddr:    "localhost:12345",
-		BeaconClients: mockBeaconClientsInterface,
+		BeaconClients: clients,
 		Datastore:     ds,
 		Redis:         redisCache,
 		DB:            db,


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Adding support for relay to specify multiple BN URIs for redundancy. 

TODO: adding tests

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
