### PR TITLE
remove payload fee recipient check

### DIFF
--- a/services/api/utils.go
+++ b/services/api/utils.go
@@ -7,9 +7,8 @@ import (
 )
 
 var (
-	ErrBlockHashMismatch    = errors.New("blockHash mismatch")
-	ErrParentHashMismatch   = errors.New("parentHash mismatch")
-	ErrFeeRecipientMismatch = errors.New("feeRecipient mismatch")
+	ErrBlockHashMismatch  = errors.New("blockHash mismatch")
+	ErrParentHashMismatch = errors.New("parentHash mismatch")
 )
 
 func VerifyBuilderBlockSubmission(payload *types.BuilderSubmitBlockRequest) error {
@@ -19,10 +18,6 @@ func VerifyBuilderBlockSubmission(payload *types.BuilderSubmitBlockRequest) erro
 
 	if payload.Message.ParentHash != payload.ExecutionPayload.ParentHash {
 		return ErrParentHashMismatch
-	}
-
-	if payload.Message.ProposerFeeRecipient != payload.ExecutionPayload.FeeRecipient {
-		return ErrFeeRecipientMismatch
 	}
 
 	return nil


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
- Remove payload fee recipient check
## ⛱ Motivation and Context
Before submitting the block, header payload proposer fee recipient and execution payload fee recipient can be different. This check is not needed.
<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [ ] `make test`
* [x] `go mod tidy`
