### PR TITLE
remove async validator registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,7 @@ redis-cli DEL boost-relay/kiln:validators-registration boost-relay/kiln:validato
 Env vars:
 
 * `DB_TABLE_PREFIX` - prefix to use for db tables (default uses `dev`)
-* `ENABLE_ZERO_VALUE_BLOCKS` - allow blocks with 0 value
-* `SYNC_VALIDATOR_REGISTRATIONS` - handle validator registrations synchronously instead of in a background worker pool
 * `BLOCKSIM_MAX_CONCURRENT` - maximum number of concurrent block-sim requests
-* `ALLOW_BLOCK_VERIFICATION_FAIL` - accept block even if block simulation & verification fails
 * `DISABLE_BID_MEMORY_CACHE` - disable bids to go through in-memory cache. forces to go through redis/db
 * `DISABLE_BID_REDIS_CACHE` - disable bids to go through redis cache. forces to go through memory/db
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -87,9 +86,6 @@ type RelayAPI struct {
 	srv        *http.Server
 	srvStarted uberatomic.Bool
 
-	regValEntriesC       chan types.SignedValidatorRegistration
-	regValWorkersStarted uberatomic.Bool
-
 	beaconClients []beaconclient.BeaconNodeClient
 	datastore     *datastore.Datastore
 	redis         *datastore.RedisCache
@@ -108,7 +104,6 @@ type RelayAPI struct {
 	// feature flags
 	ffAllowSyncingBeaconNode     bool
 	ffAllowZeroValueBlocks       bool
-	ffSyncValidatorRegistrations bool
 	ffAllowBlockVerificationFail bool
 }
 
@@ -138,7 +133,6 @@ func NewRelayAPI(opts RelayAPIOpts) (*RelayAPI, error) {
 		redis:                  opts.Redis,
 		db:                     opts.DB,
 		proposerDutiesResponse: []types.BuilderGetValidatorsResponseEntry{},
-		regValEntriesC:         make(chan types.SignedValidatorRegistration, 5000),
 		blockSimRateLimiter:    NewBlockSimulationRateLimiter(opts.BlockSimURL),
 	}
 
@@ -161,11 +155,6 @@ func NewRelayAPI(opts RelayAPIOpts) (*RelayAPI, error) {
 	if os.Getenv("ENABLE_ZERO_VALUE_BLOCKS") != "" {
 		api.log.Warn("env: ENABLE_ZERO_VALUE_BLOCKS: sending blocks with zero value")
 		api.ffAllowZeroValueBlocks = true
-	}
-
-	if os.Getenv("SYNC_VALIDATOR_REGISTRATIONS") != "" {
-		api.log.Warn("env: SYNC_VALIDATOR_REGISTRATIONS: enabling sync validator registrations")
-		api.ffSyncValidatorRegistrations = true
 	}
 
 	if os.Getenv("ALLOW_BLOCK_VERIFICATION_FAIL") != "" {
@@ -206,48 +195,6 @@ func (api *RelayAPI) getRouter() http.Handler {
 	return loggedRouter
 }
 
-// startValidatorRegistrationWorkers starts a number of worker goroutines to handle the expensive part
-// of (already sanity-checked) validator registrations: the signature verification and updating in Redis.
-func (api *RelayAPI) startValidatorRegistrationWorkers() error {
-	if api.regValWorkersStarted.Swap(true) {
-		return ErrRegistrationWorkersAlreadyStarted
-	}
-
-	numWorkers := api.opts.RegValWorkers
-	if numWorkers == 0 {
-		numWorkers = runtime.NumCPU()
-	}
-
-	api.log.Infof("Starting %d registerValidator workers", numWorkers)
-
-	for i := 0; i < numWorkers; i++ {
-		go func() {
-			for {
-				registration := <-api.regValEntriesC
-				log := api.log.WithFields(logrus.Fields{
-					"pubkey": registration.Message.Pubkey.PubkeyHex(),
-				})
-
-				// Verify the signature
-				ok, err := types.VerifySignature(registration.Message, api.opts.EthNetDetails.DomainBuilder, registration.Message.Pubkey[:], registration.Signature[:])
-				if err != nil || !ok {
-					log.WithError(err).Warn("failed to verify registerValidator signature")
-					continue
-				}
-
-				// Save the registration and increment counter
-				go func() {
-					err := api.datastore.SetValidatorRegistration(registration)
-					if err != nil {
-						log.WithError(err).Error("Failed to set validator registration")
-					}
-				}()
-			}
-		}()
-	}
-	return nil
-}
-
 // StartServer starts the HTTP server for this instance
 func (api *RelayAPI) StartServer() (err error) {
 	if api.srvStarted.Swap(true) {
@@ -256,12 +203,6 @@ func (api *RelayAPI) StartServer() (err error) {
 
 	// Get best beacon-node status by head slot, process current slot and start slot updates
 	bestSyncStatus, err := api.getBestSyncStatus()
-	if err != nil {
-		return err
-	}
-
-	// Start worker pool for validator registration processing
-	err = api.startValidatorRegistrationWorkers()
 	if err != nil {
 		return err
 	}
@@ -529,27 +470,23 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 
 		// Send to workers for signature verification and saving
 		numRegNew++
-		if api.ffSyncValidatorRegistrations {
-			// Verify the signature
-			ok, err := types.VerifySignature(registration.Message, api.opts.EthNetDetails.DomainBuilder, registration.Message.Pubkey[:], registration.Signature[:])
-			if err != nil {
-				regLog.WithError(err).Error("error verifying registerValidator signature")
-				continue
-			} else if !ok {
-				api.RespondError(w, http.StatusBadRequest, fmt.Sprintf("failed to verify validator signature for %s", registration.Message.Pubkey.String()))
-				return
-			} else {
-				// Save and increment counter
-				go func(reg types.SignedValidatorRegistration) {
-					err := api.datastore.SetValidatorRegistration(reg)
-					if err != nil {
-						regLog.WithError(err).Error("Failed to set validator registration")
-					}
-				}(registration)
-			}
+
+		// Verify the signature
+		ok, err := types.VerifySignature(registration.Message, api.opts.EthNetDetails.DomainBuilder, registration.Message.Pubkey[:], registration.Signature[:])
+		if err != nil {
+			regLog.WithError(err).Error("error verifying registerValidator signature")
+			continue
+		} else if !ok {
+			api.RespondError(w, http.StatusBadRequest, fmt.Sprintf("failed to verify validator signature for %s", registration.Message.Pubkey.String()))
+			return
 		} else {
-			// Send to channel for async processing
-			api.regValEntriesC <- registration
+			// Save and increment counter
+			go func(reg types.SignedValidatorRegistration) {
+				err := api.datastore.SetValidatorRegistration(reg)
+				if err != nil {
+					regLog.WithError(err).Error("Failed to set validator registration")
+				}
+			}(registration)
 		}
 	}
 

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -67,7 +67,7 @@ func newTestBackend(t require.TestingT, numBeaconNodes int) *testBackend {
 			GenesisForkVersionHex:    genesisForkVersionHex,
 			GenesisValidatorsRootHex: "",
 			BellatrixForkVersionHex:  "0x00000000",
-			DomainBuilder:            types.Domain{},
+			DomainBuilder:            builderSigningDomain,
 			DomainBeaconProposer:     types.Domain{},
 		},
 		SecretKey: sk,
@@ -216,11 +216,9 @@ func TestRegisterValidator(t *testing.T) {
 		t.Skip() // has an error at verifying the sig
 
 		backend := newTestBackend(t, 1)
-		err := backend.relay.startValidatorRegistrationWorkers()
-		require.NoError(t, err)
 		pubkeyHex := common.ValidPayloadRegisterValidator.Message.Pubkey.PubkeyHex()
 		index := uint64(17)
-		err = backend.redis.SetKnownValidator(pubkeyHex, index)
+		err := backend.redis.SetKnownValidator(pubkeyHex, index)
 		require.NoError(t, err)
 
 		// Update datastore
@@ -261,7 +259,7 @@ func TestRegisterValidator(t *testing.T) {
 		require.NoError(t, err)
 
 		rr := backend.request(http.MethodPost, path, []types.SignedValidatorRegistration{*payload})
-		require.Equal(t, http.StatusOK, rr.Code)
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 
 		// Disallow +11 sec
 		td = uint64(time.Now().Unix())


### PR DESCRIPTION
## 📝 Summary

They are poor UX because failures in signature don't get reported back to the caller. Better to fail the request on the first issue. Performance in this case is pretty much the same.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
