### PR TITLE
block submissions: store if was most profitable, data api: return only those

### DIFF
--- a/database/mockdb.go
+++ b/database/mockdb.go
@@ -8,7 +8,7 @@ func (db MockDB) SaveValidatorRegistration(registration types.SignedValidatorReg
 	return nil
 }
 
-func (db MockDB) SaveBuilderBlockSubmission(payload *types.BuilderSubmitBlockRequest, simError error) (id int64, err error) {
+func (db MockDB) SaveBuilderBlockSubmission(payload *types.BuilderSubmitBlockRequest, simError error, isMostProfitable bool) (id int64, err error) {
 	return 0, nil
 }
 

--- a/database/schema.go
+++ b/database/schema.go
@@ -70,13 +70,15 @@ CREATE TABLE IF NOT EXISTS ` + TableBuilderBlockSubmission + ` (
 
 	-- helpers
 	epoch        bigint NOT NULL,
-	block_number bigint NOT NULL
+	block_number bigint NOT NULL,
+	was_most_profitable boolean NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS ` + TableBuilderBlockSubmission + `_slot_idx ON ` + TableBuilderBlockSubmission + `("slot");
 CREATE INDEX IF NOT EXISTS ` + TableBuilderBlockSubmission + `_blockhash_idx ON ` + TableBuilderBlockSubmission + `("block_hash");
 CREATE INDEX IF NOT EXISTS ` + TableBuilderBlockSubmission + `_blocknumber_idx ON ` + TableBuilderBlockSubmission + `("block_number");
 CREATE INDEX IF NOT EXISTS ` + TableBuilderBlockSubmission + `_simsuccess_idx ON ` + TableBuilderBlockSubmission + `("sim_success");
+CREATE INDEX IF NOT EXISTS ` + TableBuilderBlockSubmission + `_mostprofit_idx ON ` + TableBuilderBlockSubmission + `("was_most_profitable");
 
 
 CREATE TABLE IF NOT EXISTS ` + TableDeliveredPayload + ` (

--- a/database/types.go
+++ b/database/types.go
@@ -73,8 +73,9 @@ type BuilderBlockSubmissionEntry struct {
 	Value string `db:"value"`
 
 	// Helpers
-	Epoch       uint64 `db:"epoch"`
-	BlockNumber uint64 `db:"block_number"`
+	Epoch             uint64 `db:"epoch"`
+	BlockNumber       uint64 `db:"block_number"`
+	WasMostProfitable bool   `db:"was_most_profitable"`
 }
 
 type DeliveredPayloadEntry struct {

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -108,7 +108,6 @@ func (r *RedisCache) GetKnownValidators() (map[types.PubkeyHex]uint64, error) {
 	}
 	for pubkey, proposerIndexStr := range entries {
 		proposerIndex, err := strconv.ParseUint(proposerIndexStr, 10, 64)
-		// TODO: log on error
 		if err == nil {
 			validators[types.PubkeyHex(pubkey)] = proposerIndex
 		}

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -601,6 +601,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		"slot":          payload.Message.Slot,
 		"builderPubkey": payload.Message.BuilderPubkey.String(),
 		"blockHash":     payload.Message.BlockHash.String(),
+		"parentHash":    payload.Message.ParentHash.String(),
 	})
 
 	if payload.Message.Slot <= api.headSlot.Load() {
@@ -630,22 +631,21 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	// Simulate the block submission and save to db
-	simErr := api.blockSimRateLimiter.send(req.Context(), payload)
-	if simErr != nil {
-		log.WithError(simErr).Error("failed block simulation for block")
-	}
+	var simErr error
+	isMostProfitableBlock := false
 
-	// Save builder submission to database (in the background)
-	go func() {
-		_, err := api.db.SaveBuilderBlockSubmission(payload, simErr)
+	// At end of this function, save builder submission to database (in the background)
+	defer func() {
+		_, err := api.db.SaveBuilderBlockSubmission(payload, simErr, isMostProfitableBlock)
 		if err != nil {
 			log.WithError(err).Error("saving builder block submission to database failed")
 		}
 	}()
 
-	// Return error if block verification failed
+	// Simulate the block submission and save to db
+	simErr = api.blockSimRateLimiter.send(req.Context(), payload)
 	if simErr != nil {
+		log.WithError(simErr).Warn("failed block verification")
 		api.RespondError(w, http.StatusBadRequest, simErr.Error())
 		return
 	}
@@ -653,13 +653,14 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	// Check if there's already a bid
 	prevBid, err := api.datastore.GetGetHeaderResponse(payload.Message.Slot, payload.Message.ParentHash.String(), payload.Message.ProposerPubkey.String())
 	if err != nil {
-		log.WithError(err).Error("could not get best bid")
-		api.RespondError(w, http.StatusBadRequest, err.Error())
+		log.WithError(err).Error("error getting previous bid")
+		api.RespondError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	// If existing bid has same or higher value, do nothing
-	if prevBid != nil && payload.Message.Value.Cmp(&prevBid.Data.Message.Value) < 1 { // todo: use proposer_pubkey as tiebreaker instead of FCFS
+	// Only proceed if this bid is higher than previous one
+	isMostProfitableBlock = prevBid == nil || payload.Message.Value.Cmp(&prevBid.Data.Message.Value) == 1
+	if !isMostProfitableBlock {
 		log.Info("block submission with same or lower value")
 		w.WriteHeader(http.StatusOK)
 		return
@@ -696,15 +697,12 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	}
 
 	log.WithFields(logrus.Fields{
-		"slot":           payload.Message.Slot,
-		"blockHash":      payload.Message.BlockHash.String(),
-		"parentHash":     payload.Message.ParentHash.String(),
 		"proposerPubkey": payload.Message.ProposerPubkey.String(),
 		"value":          payload.Message.Value.String(),
 		"tx":             len(payload.ExecutionPayload.Transactions),
 	}).Info("received block from builder")
 
-	// Respond with OK (TODO: proper response format)
+	// Respond with OK (TODO: proper response response data type https://flashbots.notion.site/Relay-API-Spec-5fb0819366954962bc02e81cb33840f5#fa719683d4ae4a57bc3bf60e138b0dc6)
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -697,9 +697,10 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	}
 
 	log.WithFields(logrus.Fields{
-		"proposerPubkey": payload.Message.ProposerPubkey.String(),
-		"value":          payload.Message.Value.String(),
-		"tx":             len(payload.ExecutionPayload.Transactions),
+		"proposerPubkey":   payload.Message.ProposerPubkey.String(),
+		"value":            payload.Message.Value.String(),
+		"tx":               len(payload.ExecutionPayload.Transactions),
+		"isMostProfitable": isMostProfitableBlock,
 	}).Info("received block from builder")
 
 	// Respond with OK (TODO: proper response response data type https://flashbots.notion.site/Relay-API-Spec-5fb0819366954962bc02e81cb33840f5#fa719683d4ae4a57bc3bf60e138b0dc6)

--- a/services/website/html.go
+++ b/services/website/html.go
@@ -30,10 +30,10 @@ func parseIndexTemplate() (*template.Template, error) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
 
-    <title>Flashbots Boost Relay - {{ .Network }}</title>
+    <title>Flashbots MEV-Boost Relay - {{ .Network }}</title>
 
     <meta name="description"
-        content="Flashbots testing relay for maximal extractable value in Ethereum proof-of-stake.">
+        content="Flashbots mev-bosot relay for maximal extractable value in Ethereum proof-of-stake.">
     <link data-react-helmet="true" rel="shortcut icon" href="https://writings.flashbots.net/img/favicon.ico">
     <meta property="og:image"
         content="https://d33wubrfki0l68.cloudfront.net/ae8530415158fbbbbe17fb033855452f792606c7/fe19f/img/logo.png" />


### PR DESCRIPTION
## 📝 Summary

Store flag whether any builder submission was the most profitable for this blockhash and slot. Return only those in the data API (the others a proposer would never have a chance to see)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
