### PR TITLE
ensure all log entries have a consistent module

### DIFF
--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -17,7 +17,7 @@ type ProdBeaconInstance struct {
 
 func NewProdBeaconInstance(log *logrus.Entry, beaconURI string) *ProdBeaconInstance {
 	_log := log.WithFields(logrus.Fields{
-		"module":    "beaconInstance",
+		"component": "beaconInstance",
 		"beaconURI": beaconURI,
 	})
 	return &ProdBeaconInstance{_log, beaconURI}

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -58,7 +58,7 @@ var apiCmd = &cobra.Command{
 		}
 
 		common.LogSetup(logJSON, logLevel)
-		log := logrus.WithField("module", "cmd/api")
+		log := logrus.WithField("module", "relay/api")
 		if apiLogTag != "" {
 			log = logrus.WithField("tag", apiLogTag)
 		}

--- a/cmd/housekeeper.go
+++ b/cmd/housekeeper.go
@@ -31,7 +31,7 @@ var housekeeperCmd = &cobra.Command{
 		var err error
 
 		common.LogSetup(logJSON, logLevel)
-		log := logrus.WithField("module", "cmd/housekeeper")
+		log := logrus.WithField("module", "relay/housekeeper")
 		log.Infof("boost-relay %s", Version)
 
 		networkInfo, err := common.NewEthNetworkDetails(network)

--- a/cmd/website.go
+++ b/cmd/website.go
@@ -38,7 +38,7 @@ var websiteCmd = &cobra.Command{
 		var err error
 
 		common.LogSetup(logJSON, logLevel)
-		log := logrus.WithField("module", "cmd/website")
+		log := logrus.WithField("module", "relay/website")
 		log.Infof("boost-relay %s", Version)
 
 		networkInfo, err := common.NewEthNetworkDetails(network)

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -49,7 +49,7 @@ type Datastore struct {
 
 func NewDatastore(log *logrus.Entry, redisCache *RedisCache, db database.IDatabaseService) (ds *Datastore, err error) {
 	ds = &Datastore{
-		log:                     log.WithField("module", "datastore"),
+		log:                     log.WithField("component", "datastore"),
 		db:                      db,
 		redis:                   redisCache,
 		knownValidatorsByPubkey: make(map[types.PubkeyHex]uint64),

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -112,8 +112,6 @@ func NewRelayAPI(opts RelayAPIOpts) (*RelayAPI, error) {
 		return nil, ErrMissingLogOpt
 	}
 
-	log := opts.Log.WithField("module", "relay/api")
-
 	if opts.BeaconClient == nil {
 		return nil, ErrMissingBeaconClientOpt
 	}
@@ -131,7 +129,7 @@ func NewRelayAPI(opts RelayAPIOpts) (*RelayAPI, error) {
 
 		// If using a secret key, ensure it's the correct one
 		publicKey = types.BlsPublicKeyToPublicKey(bls.PublicKeyFromSecretKey(opts.SecretKey))
-		log.Infof("Using BLS key: %s", publicKey.String())
+		opts.Log.Infof("Using BLS key: %s", publicKey.String())
 
 		// ensure pubkey is same across all relay instances
 		_pubkey, err := opts.Redis.GetRelayConfig(datastore.RedisConfigFieldPubkey)
@@ -149,7 +147,7 @@ func NewRelayAPI(opts RelayAPIOpts) (*RelayAPI, error) {
 
 	api := RelayAPI{
 		opts:                   opts,
-		log:                    log,
+		log:                    opts.Log,
 		blsSk:                  opts.SecretKey,
 		publicKey:              &publicKey,
 		datastore:              opts.Datastore,
@@ -161,12 +159,12 @@ func NewRelayAPI(opts RelayAPIOpts) (*RelayAPI, error) {
 	}
 
 	if os.Getenv("FORCE_GET_HEADER_204") == "1" {
-		log.Warn("env: FORCE_GET_HEADER_204 - forcing getHeader to always return 204")
+		api.log.Warn("env: FORCE_GET_HEADER_204 - forcing getHeader to always return 204")
 		api.ffForceGetHeader204 = true
 	}
 
 	if os.Getenv("DISABLE_BLOCK_PUBLISHING") == "1" {
-		log.Warn("env: DISABLE_BLOCK_PUBLISHING - disabling publishing blocks on getPayload")
+		api.log.Warn("env: DISABLE_BLOCK_PUBLISHING - disabling publishing blocks on getPayload")
 		api.ffDisableBlockPublishing = true
 	}
 

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -49,7 +49,7 @@ var ErrServerAlreadyStarted = errors.New("server was already started")
 func NewHousekeeper(opts *HousekeeperOpts) *Housekeeper {
 	server := &Housekeeper{
 		opts:         opts,
-		log:          opts.Log.WithField("module", "relay/housekeeper"),
+		log:          opts.Log,
 		redis:        opts.Redis,
 		datastore:    opts.Datastore,
 		beaconClient: opts.BeaconClient,

--- a/services/website/website.go
+++ b/services/website/website.go
@@ -61,7 +61,7 @@ func NewWebserver(opts *WebserverOpts) (*Webserver, error) {
 	var err error
 	server := &Webserver{
 		opts:  opts,
-		log:   opts.Log.WithField("module", "relay/webserver"),
+		log:   opts.Log,
 		redis: opts.Redis,
 		db:    opts.DB,
 	}


### PR DESCRIPTION
## 📝 Summary

before, `module` was overwritten by individual components. but for log extraction it's important the module tag stays consistent throughout the whole lifecycle.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
