### PR TITLE
Make build reproducible in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.18 as builder
 ARG VERSION
 WORKDIR /build
 ADD . /build/
-RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux go build -ldflags "-X cmd.Version=$VERSION -X main.Version=$VERSION" -v -o boost-relay .
+RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux go build -trimpath -ldflags "-s -X cmd.Version=$VERSION -X main.Version=$VERSION" -v -o boost-relay .
 
 FROM alpine
 RUN apk add --no-cache libstdc++ libc6-compat

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 	git clean -fdx
 
 build:
-	go build -ldflags "-X cmd.Version=${VERSION} -X main.Version=${VERSION}" -v -o boost-relay .
+	go build -trimpath -ldflags "-s -X cmd.Version=${VERSION} -X main.Version=${VERSION}" -v -o boost-relay .
 
 test:
 	go test ./...


### PR DESCRIPTION
## 📝 Summary

* Add the `-s` (omit the symbol table and debug information) linker flag to the build command.
  * This doesn't affect backtraces, just won't be able to run `gdb` on the binary.
* Add the `-trimpath` build flag because it seems reasonable. Didn't affect reproducibility either way.
* Extra benefit of smaller binary sizes (16mb -> 11mb for the system I tested).

## ⛱ Motivation and Context

Previously, each time I would build the binary would be slightly different and would have a different hash.

```
$ make && sha256sum boost-relay
git clean -fdx
Removing boost-relay
go build -ldflags "-X cmd.Version=v0.6.1 -X main.Version=v0.6.1" -v -o boost-relay .
e4b37a44f43e68a11739e2b21d34fc5f11c2f307db9843c2194d556bb88bd060  boost-relay

$ make && sha256sum boost-relay
git clean -fdx
Removing boost-relay
go build -ldflags "-X cmd.Version=v0.6.1 -X main.Version=v0.6.1" -v -o boost-relay .
23f85948c8b02a329fbd5750d97fe1c1295868c8203a564ac7d877106a980306  boost-relay

$ make && sha256sum boost-relay
git clean -fdx
Removing boost-relay
go build -ldflags "-X cmd.Version=v0.6.1 -X main.Version=v0.6.1" -v -o boost-relay .
2e2ee285e55b113a6c7f604843612d026f7eef0faee58fa2d461c8ec394a18fb  boost-relay
```

I found that stripping the binary made the build reproducible. Keep in mind, this will only be reproducible if the system (architecture, kernel, golang, etc) are all the same so this really only applies to the docker image which can be controlled.

To test this out locally, I modified the Dockerfile to print the binary hash:

```diff
-ENTRYPOINT ["/app/boost-relay"]
+CMD ["sha256sum", "/app/boost-relay"]
```

Then ran these commands on two entirely different systems (arm64 & amd64):

```
$ make docker-image-amd && docker run flashbots/mev-boost-relay
43b42c8a5f8e0726f4078570a71feaed79c1b3d78d61e8f7914fc6935a56e3f4  /app/boost-relay
```

They both had the same hash so I'm reasonable sure that it's a deterministic build!

Associated with #110.

## 📚 References

* https://reproducible-builds.org
* https://pkg.go.dev/cmd/link
* https://stackoverflow.com/a/63831759
* https://groups.google.com/g/Golang-nuts/c/6K5Ca3GZF5k

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
