### PR TITLE
Show relay binary hash on website

### DIFF
--- a/services/website/html.go
+++ b/services/website/html.go
@@ -97,7 +97,7 @@ func parseIndexTemplate() (*template.Template, error) {
                 <li>Genesis validators root: <tt>{{ .GenesisValidatorsRoot }}</tt></li>
                 <li>Builder signing domain: <tt>{{ .BuilderSigningDomain }}</tt></li>
                 <li>Beacon proposer signing domain: <tt>{{ .BeaconProposerSigningDomain }}</tt></li>
-                <li>Relay binary hash: <tt>{{.RelayHash}}</tt></li>
+                <li>Relay binary sha256 hash: <tt>{{.RelayHash}}</tt></li>
             </ul>
 
             <p>

--- a/services/website/html.go
+++ b/services/website/html.go
@@ -19,6 +19,7 @@ type StatusHTMLData struct {
 	HeadSlot                    string
 	NumPayloadsDelivered        string
 	Payloads                    []*database.DeliveredPayloadEntry
+	RelayHash                   string
 }
 
 func parseIndexTemplate() (*template.Template, error) {
@@ -96,6 +97,7 @@ func parseIndexTemplate() (*template.Template, error) {
                 <li>Genesis validators root: <tt>{{ .GenesisValidatorsRoot }}</tt></li>
                 <li>Builder signing domain: <tt>{{ .BuilderSigningDomain }}</tt></li>
                 <li>Beacon proposer signing domain: <tt>{{ .BeaconProposerSigningDomain }}</tt></li>
+                <li>Relay binary hash: <tt>{{.RelayHash}}</tt></li>
             </ul>
 
             <p>

--- a/services/website/website.go
+++ b/services/website/website.go
@@ -57,8 +57,6 @@ type Webserver struct {
 	indexTemplate      *template.Template
 	statusHTMLData     StatusHTMLData
 	statusHTMLDataLock sync.RWMutex
-
-	cachedRelayHash *string
 }
 
 func NewWebserver(opts *WebserverOpts) (*Webserver, error) {


### PR DESCRIPTION
## 📝 Summary

Associated with #110 and #111, this shows the relay's binary hash on the website. Looks like:

<img width="965" alt="image" src="https://user-images.githubusercontent.com/95511699/189213114-123cdcd5-6c57-4020-bcf8-6d140e2d771a.png">

## ⛱ Motivation and Context

I think it's a good idea to have a verifiable hash somewhere on the website. I'm not totally sold on the idea of it being in the relay's configuration section. It could also be at the bottom of the page or at a different handler. Thoughts?

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
