### PR TITLE
allow to skip applying the DB schema on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ redis-cli DEL boost-relay/kiln:validators-registration boost-relay/kiln:validato
 Env vars:
 
 * `DB_TABLE_PREFIX` - prefix to use for db tables (default uses `dev`)
+* `DB_DONT_APPLY_SCHEMA` - disable applying DB schema on startup (useful for connecting data API to read-only replica)
 * `BLOCKSIM_MAX_CONCURRENT` - maximum number of concurrent block-sim requests
 * `FORCE_GET_HEADER_204` - force 204 as getHeader response
 * `DISABLE_BLOCK_PUBLISHING` - disable publishing blocks to the beacon node at the end of getPayload

--- a/database/database.go
+++ b/database/database.go
@@ -47,9 +47,11 @@ func NewDatabaseService(dsn string) (*DatabaseService, error) {
 		fmt.Println(schema)
 	}
 
-	_, err = db.Exec(schema)
-	if err != nil {
-		return nil, err
+	if os.Getenv("DB_DONT_APPLY_SCHEMA") == "" {
+		_, err = db.Exec(schema)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &DatabaseService{


### PR DESCRIPTION
## 📝 Summary

Added `DB_DONT_APPLY_SCHEMA` env var to skip applying the DB schema on startup (useful for connecting data API to read-only replica)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
