### PR TITLE
disable internal API by default

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -16,17 +16,20 @@ import (
 )
 
 var (
-	apiDefaultListenAddr   = common.GetEnv("LISTEN_ADDR", "localhost:9062")
-	apiDefaultBlockSim     = common.GetEnv("BLOCKSIM_URI", "http://localhost:8545")
-	apiDefaultSecretKey    = common.GetEnv("SECRET_KEY", "")
-	apiDefaultPprofEnabled = os.Getenv("PPROF") != ""
-	apiDefaultLogTag       = os.Getenv("LOG_TAG")
+	apiDefaultListenAddr = common.GetEnv("LISTEN_ADDR", "localhost:9062")
+	apiDefaultBlockSim   = common.GetEnv("BLOCKSIM_URI", "http://localhost:8545")
+	apiDefaultSecretKey  = common.GetEnv("SECRET_KEY", "")
+	apiDefaultLogTag     = os.Getenv("LOG_TAG")
+
+	apiDefaultPprofEnabled       = os.Getenv("PPROF") == "1"
+	apiDefaultInternalAPIEnabled = os.Getenv("ENABLE_INTERNAL_API") == "1"
 
 	apiListenAddr   string
 	apiPprofEnabled bool
 	apiSecretKey    string
 	apiBlockSimURL  string
 	apiDebug        bool
+	apiInternalAPI  bool
 	apiLogTag       string
 )
 
@@ -42,9 +45,11 @@ func init() {
 	apiCmd.Flags().StringVar(&redisURI, "redis-uri", defaultRedisURI, "redis uri")
 	apiCmd.Flags().StringVar(&postgresDSN, "db", defaultPostgresDSN, "PostgreSQL DSN")
 	apiCmd.Flags().StringVar(&apiSecretKey, "secret-key", apiDefaultSecretKey, "secret key for signing bids")
-	apiCmd.Flags().BoolVar(&apiPprofEnabled, "pprof", apiDefaultPprofEnabled, "enable pprof API")
 	apiCmd.Flags().StringVar(&apiBlockSimURL, "blocksim", apiDefaultBlockSim, "URL for block simulator")
 	apiCmd.Flags().StringVar(&network, "network", defaultNetwork, "Which network to use")
+
+	apiCmd.Flags().BoolVar(&apiPprofEnabled, "pprof", apiDefaultPprofEnabled, "enable pprof API")
+	apiCmd.Flags().BoolVar(&apiInternalAPI, "internal-api", apiDefaultInternalAPIEnabled, "enable internal API (/internal/...)")
 }
 
 var apiCmd = &cobra.Command{
@@ -113,6 +118,7 @@ var apiCmd = &cobra.Command{
 			ProposerAPI:     true,
 			BlockBuilderAPI: true,
 			DataAPI:         true,
+			InternalAPI:     apiInternalAPI,
 			PprofAPI:        apiPprofEnabled,
 		}
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -78,6 +78,7 @@ type RelayAPIOpts struct {
 	BlockBuilderAPI bool
 	DataAPI         bool
 	PprofAPI        bool
+	InternalAPI     bool
 }
 
 // RelayAPI represents a single Relay instance
@@ -182,6 +183,7 @@ func (api *RelayAPI) getRouter() http.Handler {
 
 	// Proposer API
 	if api.opts.ProposerAPI {
+		api.log.Info("proposer API enabled")
 		r.HandleFunc(pathStatus, api.handleStatus).Methods(http.MethodGet)
 		r.HandleFunc(pathRegisterValidator, api.handleRegisterValidator).Methods(http.MethodPost)
 		r.HandleFunc(pathGetHeader, api.handleGetHeader).Methods(http.MethodGet)
@@ -190,12 +192,14 @@ func (api *RelayAPI) getRouter() http.Handler {
 
 	// Builder API
 	if api.opts.BlockBuilderAPI {
+		api.log.Info("block builder API enabled")
 		r.HandleFunc(pathBuilderGetValidators, api.handleBuilderGetValidators).Methods(http.MethodGet)
 		r.HandleFunc(pathSubmitNewBlock, api.handleSubmitNewBlock).Methods(http.MethodPost)
 	}
 
 	// Data API
 	if api.opts.DataAPI {
+		api.log.Info("data API enabled")
 		r.HandleFunc(pathDataProposerPayloadDelivered, api.handleDataProposerPayloadDelivered).Methods(http.MethodGet)
 		r.HandleFunc(pathDataBuilderBidsReceived, api.handleDataBuilderBidsReceived).Methods(http.MethodGet)
 		r.HandleFunc(pathDataValidatorRegistration, api.handleDataValidatorRegistration).Methods(http.MethodGet)
@@ -203,10 +207,15 @@ func (api *RelayAPI) getRouter() http.Handler {
 
 	// Pprof
 	if api.opts.PprofAPI {
+		api.log.Info("pprof API enabled")
 		r.PathPrefix("/debug/pprof/").Handler(http.DefaultServeMux)
 	}
 
-	r.HandleFunc(pathInternalBuilderStatus, api.handleInternalBuilderStatus).Methods(http.MethodGet, http.MethodPost, http.MethodPut)
+	// /internal/...
+	if api.opts.InternalAPI {
+		api.log.Info("internal API enabled")
+		r.HandleFunc(pathInternalBuilderStatus, api.handleInternalBuilderStatus).Methods(http.MethodGet, http.MethodPost, http.MethodPut)
+	}
 
 	// r.Use(mux.CORSMethodMiddleware(r))
 	loggedRouter := httplogger.LoggingMiddlewareLogrus(api.log, r)


### PR DESCRIPTION
## 📝 Summary

Disable internal API by default.

Can be enabled by `ENABLE_INTERNAL_API=1` env var, or `--internal-api` flag

Closes #119 

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
