### PR TITLE
Various updates to logging if no execution payload is found, website, and not saving blocks in memory in builder API

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,4 @@
+# https://golangci-lint.run/usage/linters
 linters:
   enable-all: true
   disable:
@@ -58,6 +59,9 @@ linters-settings:
   gosec:
     excludes:
       - G108
+
+  gocognit:
+    min-complexity: 34 # default: 30
 
   tagliatelle:
     case:

--- a/beaconclient/multi_beacon_client.go
+++ b/beaconclient/multi_beacon_client.go
@@ -197,7 +197,7 @@ func (c *MultiBeaconClient) PublishBlock(block *types.SignedBeaconBlock) (code i
 		log.Debug("publishing block")
 
 		if code, err = client.PublishBlock(block); err != nil {
-			log.WithField("statusCode", code).WithError(err).Error("failed to publish block")
+			log.WithField("statusCode", code).WithError(err).Warn("failed to publish block")
 			continue
 		}
 
@@ -205,5 +205,6 @@ func (c *MultiBeaconClient) PublishBlock(block *types.SignedBeaconBlock) (code i
 		return code, nil
 	}
 
+	log.WithField("statusCode", code).WithError(err).Error("failed to publish block on any CL node")
 	return code, err
 }

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -672,6 +672,11 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
+	if payload.Message == nil || payload.ExecutionPayload == nil {
+		api.RespondError(w, http.StatusBadRequest, "missing parts of the payload")
+		return
+	}
+
 	log = log.WithFields(logrus.Fields{
 		"slot":          payload.Message.Slot,
 		"builderPubkey": payload.Message.BuilderPubkey.String(),

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -603,6 +603,7 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 	}
 
 	// Get the response - from memory, Redis or DB
+	// note that mev-boost might send getPayload for bids of other relays, thus this code wouldn't find anything
 	getPayloadResp, err := api.datastore.GetGetPayloadResponse(slot, proposerPubkey.String(), blockHash.String())
 	if err != nil {
 		log.WithError(err).Error("failed getting execution payload from db")
@@ -611,7 +612,7 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 	}
 
 	if getPayloadResp == nil {
-		log.Error("failed getting execution payload")
+		log.Info("failed getting execution payload")
 		api.RespondError(w, http.StatusBadRequest, "no execution payload for this request")
 		return
 	}


### PR DESCRIPTION
## 📝 Summary

* [log only info level if no execution payload found](https://github.com/flashbots/mev-boost-relay/commit/104a951ab2da9f80ee24eb271b748ba7aed6a769)
* [builder api: don't save blocks in memory if memory store is disabled](https://github.com/flashbots/mev-boost-relay/commit/c7c3522042ffb89ce1411b4ca8baec8d87f04e3c)
* [website table update](https://github.com/flashbots/mev-boost-relay/commit/01a526313cbef1861040d0aadc8e612bb00d3eed)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
