### PR TITLE
Fix incorrect redis key name

### DIFF
--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -73,8 +73,8 @@ func NewRedisCache(redisURI, prefix string) (*RedisCache, error) {
 		prefixGetPayloadResponse: fmt.Sprintf("%s/%s:cache-getpayload-response", redisPrefix, prefix),
 
 		keyKnownValidators:                fmt.Sprintf("%s/%s:known-validators", redisPrefix, prefix),
-		keyValidatorRegistration:          fmt.Sprintf("%s/%s:validators-registration-timestamp", redisPrefix, prefix),
-		keyValidatorRegistrationTimestamp: fmt.Sprintf("%s/%s:validators-registration", redisPrefix, prefix),
+		keyValidatorRegistration:          fmt.Sprintf("%s/%s:validators-registration", redisPrefix, prefix),
+		keyValidatorRegistrationTimestamp: fmt.Sprintf("%s/%s:validators-registration-timestamp", redisPrefix, prefix),
 		keyRelayConfig:                    fmt.Sprintf("%s/%s:relay-config", redisPrefix, prefix),
 
 		keyStats:              fmt.Sprintf("%s/%s:stats", redisPrefix, prefix),

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -65,6 +65,7 @@ func TestRedisValidatorRegistrations(t *testing.T) {
 
 	t.Run("Can save and get validator registrations", func(t *testing.T) {
 		key1 := types.NewPubkeyHex("0x1a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249")
+		expectedTimestamp := 0xffffffff
 		require.NoError(t, cache.SetKnownValidator(key1, 1))
 
 		knownVals, err := cache.GetKnownValidators()
@@ -83,7 +84,7 @@ func TestRedisValidatorRegistrations(t *testing.T) {
 			Message: &types.RegisterValidatorRequestMessage{
 				FeeRecipient: types.Address{0x02},
 				GasLimit:     5000,
-				Timestamp:    0xffffffff,
+				Timestamp:    uint64(expectedTimestamp),
 				Pubkey:       pubkey1,
 			},
 			Signature: types.Signature{},
@@ -98,6 +99,9 @@ func TestRedisValidatorRegistrations(t *testing.T) {
 		reg, err := cache.GetValidatorRegistration(key1)
 		require.NoError(t, err)
 		require.Equal(t, pubkey1.String(), reg.Message.Pubkey.String())
+		timestamp, err := cache.GetValidatorRegistrationTimestamp(key1)
+		require.NoError(t, err)
+		require.Equal(t, uint64(expectedTimestamp), timestamp)
 	})
 }
 


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Naming for redis key was incorrect

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
