### PR TITLE
website: show/hide config details

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ redis-cli DEL boost-relay/kiln:validators-registration boost-relay/kiln:validato
 
 ### Updating the website
 
-You can generate a static version of the website with `go run scripts/website-staticgen/main.go`
+You can generate a static version of the website with `go run scripts/website-staticgen/main.go` (update the values in `testdata/website-htmldata.json` accordingly).
 
 
 # Maintainers

--- a/cmd/website.go
+++ b/cmd/website.go
@@ -13,10 +13,12 @@ import (
 )
 
 var (
-	websiteDefaultListenAddr = common.GetEnv("LISTEN_ADDR", "localhost:9060")
+	websiteDefaultListenAddr        = common.GetEnv("LISTEN_ADDR", "localhost:9060")
+	websiteDefaultShowConfigDetails = os.Getenv("SHOW_CONFIG_DETAILS") == "1"
 
-	websiteListenAddr     string
-	websitePubkeyOverride string
+	websiteListenAddr        string
+	websitePubkeyOverride    string
+	websiteShowConfigDetails bool
 )
 
 func init() {
@@ -30,6 +32,7 @@ func init() {
 	websiteCmd.Flags().StringVar(&websitePubkeyOverride, "pubkey-override", os.Getenv("PUBKEY_OVERRIDE"), "override for public key")
 
 	websiteCmd.Flags().StringVar(&network, "network", defaultNetwork, "Which network to use")
+	websiteCmd.Flags().BoolVar(&websiteShowConfigDetails, "show-config-details", websiteDefaultShowConfigDetails, "show config details")
 }
 
 var websiteCmd = &cobra.Command{
@@ -79,12 +82,13 @@ var websiteCmd = &cobra.Command{
 
 		// Create the website service
 		opts := &website.WebserverOpts{
-			ListenAddress:  websiteListenAddr,
-			RelayPubkeyHex: relayPubkey,
-			NetworkDetails: networkInfo,
-			Redis:          redis,
-			DB:             db,
-			Log:            log,
+			ListenAddress:     websiteListenAddr,
+			RelayPubkeyHex:    relayPubkey,
+			NetworkDetails:    networkInfo,
+			Redis:             redis,
+			DB:                db,
+			Log:               log,
+			ShowConfigDetails: websiteShowConfigDetails,
 		}
 
 		srv, err := website.NewWebserver(opts)

--- a/services/website/html.go
+++ b/services/website/html.go
@@ -22,6 +22,7 @@ type StatusHTMLData struct {
 	Payloads                    []*database.DeliveredPayloadEntry
 	ValueLink                   string
 	ValueOrderIcon              string
+	ShowConfigDetails           bool
 }
 
 func weiToEth(wei string) string {
@@ -108,7 +109,6 @@ func ParseIndexTemplate() (*template.Template, error) {
 
 <body>
 
-
     <div class="grids">
         <div class="content">
             <img style="float:right;"
@@ -117,21 +117,21 @@ func ParseIndexTemplate() (*template.Template, error) {
                 Flashbots Boost Relay - {{ .Network }}
             </h1>
 
-            <p>
-                Configuration:
-            </p>
-            <ul>
-                <li>Relay Pubkey: <tt>{{ .RelayPubkey }}</tt></li>
-                <li>Bellatrix fork version: <tt>{{ .BellatrixForkVersion }}</tt></li>
-                <li>Genesis fork version: <tt>{{ .GenesisForkVersion }}</tt></li>
-                <li>Genesis validators root: <tt>{{ .GenesisValidatorsRoot }}</tt></li>
-                <li>Builder signing domain: <tt>{{ .BuilderSigningDomain }}</tt></li>
-                <li>Beacon proposer signing domain: <tt>{{ .BeaconProposerSigningDomain }}</tt></li>
-            </ul>
+            {{if .ShowConfigDetails}}
+                <p>Configuration:</p>
+                <ul>
+                    <li>Relay Pubkey: <tt>{{ .RelayPubkey }}</tt></li>
+                    <li>Bellatrix fork version: <tt>{{ .BellatrixForkVersion }}</tt></li>
+                    <li>Genesis fork version: <tt>{{ .GenesisForkVersion }}</tt></li>
+                    <li>Genesis validators root: <tt>{{ .GenesisValidatorsRoot }}</tt></li>
+                    <li>Builder signing domain: <tt>{{ .BuilderSigningDomain }}</tt></li>
+                    <li>Beacon proposer signing domain: <tt>{{ .BeaconProposerSigningDomain }}</tt></li>
+                </ul>
+            {{else}}
+                <p>Relay public key: <tt>{{ .RelayPubkey }}</tt></p>
+            {{end}}
 
-            <p>
-                More infos, issues &amp; feedback:
-            </p>
+            <p>See also:</p>
             <ul>
                 <li><a href="https://flashbots.notion.site/Relay-API-Spec-5fb0819366954962bc02e81cb33840f5">Relay API
                         docs</a></li>

--- a/services/website/website.go
+++ b/services/website/website.go
@@ -35,12 +35,13 @@ var (
 )
 
 type WebserverOpts struct {
-	ListenAddress  string
-	RelayPubkeyHex string
-	NetworkDetails *common.EthNetworkDetails
-	Redis          *datastore.RedisCache
-	DB             *database.DatabaseService
-	Log            *logrus.Entry
+	ListenAddress     string
+	RelayPubkeyHex    string
+	NetworkDetails    *common.EthNetworkDetails
+	Redis             *datastore.RedisCache
+	DB                *database.DatabaseService
+	Log               *logrus.Entry
+	ShowConfigDetails bool
 }
 
 type Webserver struct {
@@ -95,6 +96,7 @@ func NewWebserver(opts *WebserverOpts) (*Webserver, error) {
 		Payloads:                    []*database.DeliveredPayloadEntry{},
 		ValueLink:                   "",
 		ValueOrderIcon:              "",
+		ShowConfigDetails:           opts.ShowConfigDetails,
 	}
 
 	return server, nil

--- a/testdata/website-htmldata.json
+++ b/testdata/website-htmldata.json
@@ -733,5 +733,6 @@
         }
     ],
     "ValueLink": "/",
-    "ValueDesc": " <svg style=\"width:12px;\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-6 h-6\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M19.5 13.5L12 21m0 0l-7.5-7.5M12 21V3\" /></svg>"
+    "ValueDesc": " <svg style=\"width:12px;\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-6 h-6\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M19.5 13.5L12 21m0 0l-7.5-7.5M12 21V3\" /></svg>",
+    "ShowConfigDetails": true
 }


### PR DESCRIPTION
## 📝 Summary

Website: hide configuration details by default

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
