### PR TITLE
Validator registrations storage refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 You can generate a static version of the website with `go run scripts/website-staticgen/main.go` (update the values in `testdata/website-htmldata.json` accordingly).
 
 
+### System startup
+
+First the housekeeper updates Redis with the main information for the API:
+1. Update known validators in Redis (source: beacon node)
+1. Update proposer duties in Redis (source: beacon node (duties) + Redis (validator registrations))
+1. Update validator registrations in Redis (source: database)
+1. Update builder status in Redis (source: database)
+
+Then the API can start and function.
+
+Aftwareds, there's important ongoing, regular housekeeper tasks:
+
+1. Update known validators and proposer duties in Redis
+2. Update active validators in database (source: Redis)
+
+
 # Maintainers
 
 - [@metachris](https://github.com/metachris)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ curl -X POST localhost:9062/eth/v1/builder/validators -d @testdata/valreg2.json
 redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:validators-registration-timestamp
 ```
 
+
 ### Environment variables
 
 * `DB_TABLE_PREFIX` - prefix to use for db tables (default uses `dev`)
@@ -96,6 +97,7 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `DISABLE_LOWPRIO_BUILDERS` - reject block submissions by low-prio builders
 * `DISABLE_BID_MEMORY_CACHE` - disable bids to go through in-memory cache. forces to go through redis/db
 * `DISABLE_BID_REDIS_CACHE` - disable bids to go through redis cache. forces to go through memory/db
+
 
 ### Updating the website
 
@@ -117,6 +119,12 @@ Aftwareds, there's important ongoing, regular housekeeper tasks:
 1. Update known validators and proposer duties in Redis
 2. Update active validators in database (source: Redis)
 
+
+### Tradeoffs
+
+- Validator registrations in are only saved to the database if `feeRecipient` changes. If a registration has a newer timestamp but same `feeRecipient` it is not saved, to avoid filling up the database with unnecessary data. (Some CL clients create a new validator registration every epoch, not just if the `feeRecipient` changes, as was the original idea).
+
+---
 
 # Maintainers
 

--- a/common/utils.go
+++ b/common/utils.go
@@ -94,7 +94,7 @@ func GetIPXForwardedFor(r *http.Request) string {
 }
 
 // GetMevBoostVersionFromUserAgent returns the mev-boost version from an user agent string
-// Example ua: "mev-boost/1.0.1 go-http-client" -> returns "1.0.1"
+// Example ua: "mev-boost/1.0.1 go-http-client" -> returns "1.0.1". If no version is found, returns "-"
 func GetMevBoostVersionFromUserAgent(ua string) string {
 	parts := strings.Split(ua, " ")
 	if strings.HasPrefix(parts[0], "mev-boost") {
@@ -103,5 +103,5 @@ func GetMevBoostVersionFromUserAgent(ua string) string {
 			return parts2[1]
 		}
 	}
-	return ""
+	return "-"
 }

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -26,8 +26,8 @@ func TestGetMevBoostVersionFromUserAgent(t *testing.T) {
 		ua      string
 		version string
 	}{
-		{ua: "", version: ""},
-		{ua: "mev-boost", version: ""},
+		{ua: "", version: "-"},
+		{ua: "mev-boost", version: "-"},
 		{ua: "mev-boost/v1.0.0", version: "v1.0.0"},
 		{ua: "mev-boost/v1.0.0 ", version: "v1.0.0"},
 		{ua: "mev-boost/v1.0.0 test", version: "v1.0.0"},

--- a/database/mockdb.go
+++ b/database/mockdb.go
@@ -8,6 +8,18 @@ func (db MockDB) SaveValidatorRegistration(registration types.SignedValidatorReg
 	return nil
 }
 
+func (db MockDB) GetValidatorRegistration(pubkey string) (*ValidatorRegistrationEntry, error) {
+	return nil, nil
+}
+
+func (db MockDB) GetValidatorRegistrationsForPubkeys(pubkeys []string) (entries []*ValidatorRegistrationEntry, err error) {
+	return nil, nil
+}
+
+func (db MockDB) GetLatestValidatorRegistrations(timestampOnly bool) ([]*ValidatorRegistrationEntry, error) {
+	return nil, nil
+}
+
 func (db MockDB) SaveBuilderBlockSubmission(payload *types.BuilderSubmitBlockRequest, simError error, isMostProfitable bool) (entry *BuilderBlockSubmissionEntry, err error) {
 	return nil, nil
 }

--- a/database/schema.go
+++ b/database/schema.go
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS ` + TableValidatorRegistration + ` (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS ` + TableValidatorRegistration + `_pubkey_feerec_idx ON ` + TableValidatorRegistration + `(pubkey, fee_recipient);
+CREATE INDEX IF NOT EXISTS ` + TableValidatorRegistration + `_pubkey_timestamp_idx ON ` + TableValidatorRegistration + `(pubkey, timestamp DESC);
 
 
 CREATE TABLE IF NOT EXISTS ` + TableExecutionPayload + ` (

--- a/database/types.go
+++ b/database/types.go
@@ -3,6 +3,8 @@ package database
 import (
 	"database/sql"
 	"time"
+
+	"github.com/flashbots/go-boost-utils/types"
 )
 
 func NewNullInt64(i int64) sql.NullInt64 {
@@ -48,6 +50,33 @@ type ValidatorRegistrationEntry struct {
 	Timestamp    uint64 `db:"timestamp"`
 	GasLimit     uint64 `db:"gas_limit"`
 	Signature    string `db:"signature"`
+}
+
+func (reg ValidatorRegistrationEntry) ToSignedValidatorRegistration() (*types.SignedValidatorRegistration, error) {
+	pubkey, err := types.HexToPubkey(reg.Pubkey)
+	if err != nil {
+		return nil, err
+	}
+
+	feeRec, err := types.HexToAddress(reg.FeeRecipient)
+	if err != nil {
+		return nil, err
+	}
+
+	sig, err := types.HexToSignature(reg.Signature)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.SignedValidatorRegistration{
+		Message: &types.RegisterValidatorRequestMessage{
+			Pubkey:       pubkey,
+			FeeRecipient: feeRec,
+			Timestamp:    reg.Timestamp,
+			GasLimit:     reg.GasLimit,
+		},
+		Signature: sig,
+	}, nil
 }
 
 type ExecutionPayloadEntry struct {

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -121,7 +121,7 @@ func (ds *Datastore) GetValidatorRegistrationTimestamp(pubkeyHex types.PubkeyHex
 // SaveValidatorRegistration saves a validator registration into both Redis and the database
 func (ds *Datastore) SaveValidatorRegistration(entry types.SignedValidatorRegistration) error {
 	pk := types.NewPubkeyHex(entry.Message.Pubkey.String())
-	err := ds.redis.SetValidatorRegistrationTimestamp(pk, entry.Message.Timestamp)
+	err := ds.redis.SetValidatorRegistrationTimestampIfNewer(pk, entry.Message.Timestamp)
 	if err != nil {
 		ds.log.WithError(err).WithField("registration", fmt.Sprintf("%+v", entry)).Error("error updating validator registration")
 		return err

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -114,19 +114,14 @@ func (ds *Datastore) NumRegisteredValidators() (int64, error) {
 	return ds.redis.NumRegisteredValidators()
 }
 
-// GetValidatorRegistration returns the validator registration for the given proposerPubkey. If not found then it returns (nil, nil). If
-// there's a datastore error, then an error will be returned.
-func (ds *Datastore) GetValidatorRegistration(pubkeyHex types.PubkeyHex) (*types.SignedValidatorRegistration, error) {
-	return ds.redis.GetValidatorRegistration(pubkeyHex)
-}
-
 func (ds *Datastore) GetValidatorRegistrationTimestamp(pubkeyHex types.PubkeyHex) (uint64, error) {
 	return ds.redis.GetValidatorRegistrationTimestamp(pubkeyHex)
 }
 
-// SetValidatorRegistration saves a validator registration into both Redis and the database
-func (ds *Datastore) SetValidatorRegistration(entry types.SignedValidatorRegistration) error {
-	err := ds.redis.SetValidatorRegistration(entry)
+// SaveValidatorRegistration saves a validator registration into both Redis and the database
+func (ds *Datastore) SaveValidatorRegistration(entry types.SignedValidatorRegistration) error {
+	pk := types.NewPubkeyHex(entry.Message.Pubkey.String())
+	err := ds.redis.SetValidatorRegistrationTimestamp(pk, entry.Message.Timestamp)
 	if err != nil {
 		ds.log.WithError(err).WithField("registration", fmt.Sprintf("%+v", entry)).Error("error updating validator registration")
 		return err

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -39,8 +39,8 @@ func TestProdProposerValidatorRegistration(t *testing.T) {
 	// Set known validator and save registration
 	err = ds.redis.SetKnownValidator(key, 1)
 	require.NoError(t, err)
-	err = ds.redis.SetValidatorRegistration(reg1)
-	require.NoError(t, err)
+	// err = ds.redis.SetValidatorRegistration(reg1)
+	// require.NoError(t, err)
 
 	// Check if validator is known
 	cnt, err := ds.RefreshKnownValidators()

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -138,6 +138,17 @@ func (r *RedisCache) GetValidatorRegistrationTimestamp(proposerPubkey types.Pubk
 	return timestamp, err
 }
 
+func (r *RedisCache) SetValidatorRegistrationTimestampIfNewer(proposerPubkey types.PubkeyHex, timestamp uint64) error {
+	knownTimestamp, err := r.GetValidatorRegistrationTimestamp(proposerPubkey)
+	if err != nil {
+		return err
+	}
+	if knownTimestamp >= timestamp {
+		return nil
+	}
+	return r.SetValidatorRegistrationTimestamp(proposerPubkey, timestamp)
+}
+
 func (r *RedisCache) SetValidatorRegistrationTimestamp(proposerPubkey types.PubkeyHex, timestamp uint64) error {
 	return r.client.HSet(context.Background(), r.keyValidatorRegistrationTimestamp, proposerPubkey.String(), timestamp).Err()
 }

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -28,18 +28,19 @@ func TestRedisValidatorRegistration(t *testing.T) {
 	t.Run("Can save and get validator registration from cache", func(t *testing.T) {
 		key := common.ValidPayloadRegisterValidator.Message.Pubkey
 		value := common.ValidPayloadRegisterValidator
-		err := cache.SetValidatorRegistration(value)
+		pkHex := types.NewPubkeyHex(key.String())
+		err := cache.SetValidatorRegistrationTimestamp(pkHex, value.Message.Timestamp)
 		require.NoError(t, err)
-		result, err := cache.GetValidatorRegistration(key.PubkeyHex())
+		result, err := cache.GetValidatorRegistrationTimestamp(key.PubkeyHex())
 		require.NoError(t, err)
-		require.Equal(t, *result, value)
+		require.Equal(t, result, value.Message.Timestamp)
 	})
 
 	t.Run("Returns nil if validator registration is not in cache", func(t *testing.T) {
 		key := types.PublicKey{}
-		result, err := cache.GetValidatorRegistration(key.PubkeyHex())
+		result, err := cache.GetValidatorRegistrationTimestamp(key.PubkeyHex())
 		require.NoError(t, err)
-		require.Nil(t, result)
+		require.Equal(t, uint64(0), result)
 	})
 }
 
@@ -88,16 +89,18 @@ func TestRedisValidatorRegistrations(t *testing.T) {
 			},
 			Signature: types.Signature{},
 		}
-		err = cache.SetValidatorRegistration(entry)
+
+		pkHex := types.NewPubkeyHex(entry.Message.Pubkey.String())
+		err = cache.SetValidatorRegistrationTimestamp(pkHex, entry.Message.Timestamp)
 		require.NoError(t, err)
 
 		numReg, err = cache.NumRegisteredValidators()
 		require.NoError(t, err)
 		require.Equal(t, int64(1), numReg)
 
-		reg, err := cache.GetValidatorRegistration(key1)
+		reg, err := cache.GetValidatorRegistrationTimestamp(key1)
 		require.NoError(t, err)
-		require.Equal(t, pubkey1.String(), reg.Message.Pubkey.String())
+		require.Equal(t, uint64(0xffffffff), reg)
 	})
 }
 

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -42,6 +42,37 @@ func TestRedisValidatorRegistration(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), result)
 	})
+
+	t.Run("test SetValidatorRegistrationTimestampIfNewer", func(t *testing.T) {
+		key := common.ValidPayloadRegisterValidator.Message.Pubkey
+		value := common.ValidPayloadRegisterValidator
+
+		pkHex := types.NewPubkeyHex(key.String())
+		timestamp := value.Message.Timestamp
+
+		err := cache.SetValidatorRegistrationTimestampIfNewer(pkHex, timestamp)
+		require.NoError(t, err)
+
+		result, err := cache.GetValidatorRegistrationTimestamp(key.PubkeyHex())
+		require.NoError(t, err)
+		require.Equal(t, result, timestamp)
+
+		// Try to set an older timestamp (should not work)
+		timestamp2 := timestamp - 10
+		err = cache.SetValidatorRegistrationTimestampIfNewer(pkHex, timestamp2)
+		require.NoError(t, err)
+		result, err = cache.GetValidatorRegistrationTimestamp(key.PubkeyHex())
+		require.NoError(t, err)
+		require.Equal(t, result, timestamp)
+
+		// Try to set an older timestamp (should not work)
+		timestamp3 := timestamp + 10
+		err = cache.SetValidatorRegistrationTimestampIfNewer(pkHex, timestamp3)
+		require.NoError(t, err)
+		result, err = cache.GetValidatorRegistrationTimestamp(key.PubkeyHex())
+		require.NoError(t, err)
+		require.Equal(t, result, timestamp3)
+	})
 }
 
 func TestRedisKnownValidators(t *testing.T) {

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -176,10 +176,10 @@ func TestRegisterValidator(t *testing.T) {
 		require.Equal(t, http.StatusOK, rr.Code)
 		time.Sleep(20 * time.Millisecond) // registrations are processed asynchronously
 
-		req, err := backend.datastore.GetValidatorRegistration(pubkeyHex)
-		require.NoError(t, err)
-		require.NotNil(t, req)
-		require.Equal(t, pubkeyHex, req.Message.Pubkey.PubkeyHex())
+		// req, err := backend.datastore.GetValidatorRegistration(pubkeyHex)
+		// require.NoError(t, err)
+		// require.NotNil(t, req)
+		// require.Equal(t, pubkeyHex, req.Message.Pubkey.PubkeyHex())
 	})
 
 	t.Run("not a known validator", func(t *testing.T) {

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -314,7 +314,7 @@ func (hk *Housekeeper) updateValidatorRegistrationsInRedis() {
 	timeStarted := time.Now()
 
 	for _, reg := range regs {
-		err = hk.redis.SetValidatorRegistrationTimestamp(types.PubkeyHex(reg.Pubkey), reg.Timestamp)
+		err = hk.redis.SetValidatorRegistrationTimestampIfNewer(types.PubkeyHex(reg.Pubkey), reg.Timestamp)
 		if err != nil {
 			hk.log.WithError(err).Error("failed to set validator registration")
 			continue

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -17,6 +17,7 @@ import (
 	"github.com/flashbots/go-boost-utils/types"
 	"github.com/flashbots/mev-boost-relay/beaconclient"
 	"github.com/flashbots/mev-boost-relay/common"
+	"github.com/flashbots/mev-boost-relay/database"
 	"github.com/flashbots/mev-boost-relay/datastore"
 	"github.com/sirupsen/logrus"
 	uberatomic "go.uber.org/atomic"
@@ -25,6 +26,7 @@ import (
 type HousekeeperOpts struct {
 	Log          *logrus.Entry
 	Redis        *datastore.RedisCache
+	DB           database.IDatabaseService
 	BeaconClient beaconclient.IMultiBeaconClient
 }
 
@@ -33,6 +35,7 @@ type Housekeeper struct {
 	log  *logrus.Entry
 
 	redis        *datastore.RedisCache
+	db           database.IDatabaseService
 	beaconClient beaconclient.IMultiBeaconClient
 
 	isStarted                uberatomic.Bool
@@ -51,6 +54,7 @@ func NewHousekeeper(opts *HousekeeperOpts) *Housekeeper {
 		opts:                  opts,
 		log:                   opts.Log,
 		redis:                 opts.Redis,
+		db:                    opts.DB,
 		beaconClient:          opts.BeaconClient,
 		proposersAlreadySaved: make(map[string]bool),
 	}
@@ -71,6 +75,10 @@ func (hk *Housekeeper) Start() (err error) {
 		return err
 	}
 
+	// Start initial tasks
+	go hk.updateValidatorRegistrationsInRedis()
+
+	// go hk.test()
 	// Start the periodic task loops
 	go hk.periodicTaskUpdateKnownValidators()
 	go hk.periodicTaskLogNumRegisteredValidators()
@@ -233,43 +241,47 @@ func (hk *Housekeeper) updateProposerDuties(headSlot uint64) {
 		log.WithError(err).Error("failed to get proposer duties for all beacon nodes")
 		return
 	}
-
 	entries := r.Data
 
 	// Query next epoch
 	r2, err := hk.beaconClient.GetProposerDuties(epoch + 1)
-	if r2 != nil {
-		entries = append(entries, r2.Data...)
-	} else {
+	if err != nil {
 		log.WithError(err).Error("failed to get proposer duties for next epoch for all beacon nodes")
+	} else if r2 != nil {
+		entries = append(entries, r2.Data...)
 	}
 
-	// Validator registrations are queried in parallel, and this is the result struct
-	type result struct {
-		val types.BuilderGetValidatorsResponseEntry
-		err error
+	// Get registrations from database
+	pubkeys := []string{}
+	for _, entry := range entries {
+		pubkeys = append(pubkeys, entry.Pubkey)
+	}
+	validatorRegistrationEntries, err := hk.db.GetValidatorRegistrationsForPubkeys(pubkeys)
+	if err != nil {
+		log.WithError(err).Error("failed to get validator registrations")
+		return
 	}
 
-	// Scatter requests to Redis to get validator registrations
-	c := make(chan result, len(entries))
-	for i := 0; i < cap(c); i++ {
-		go func(duty beaconclient.ProposerDutiesResponseData) {
-			reg, err := hk.redis.GetValidatorRegistration(types.NewPubkeyHex(duty.Pubkey))
-			c <- result{types.BuilderGetValidatorsResponseEntry{
+	// Convert db entries to signed validator registration type
+	signedValidatorRegistrations := make(map[string]*types.SignedValidatorRegistration)
+	for _, regEntry := range validatorRegistrationEntries {
+		signedEntry, err := regEntry.ToSignedValidatorRegistration()
+		if err != nil {
+			log.WithError(err).Error("failed to convert validator registration entry to signed validator registration")
+			continue
+		}
+		signedValidatorRegistrations[regEntry.Pubkey] = signedEntry
+	}
+
+	// Prepare proposer duties
+	proposerDuties := []types.BuilderGetValidatorsResponseEntry{}
+	for _, duty := range entries {
+		reg := signedValidatorRegistrations[duty.Pubkey]
+		if reg != nil {
+			proposerDuties = append(proposerDuties, types.BuilderGetValidatorsResponseEntry{
 				Slot:  duty.Slot,
 				Entry: reg,
-			}, err}
-		}(entries[i])
-	}
-
-	// Gather results
-	proposerDuties := make([]types.BuilderGetValidatorsResponseEntry, 0)
-	for i := 0; i < cap(c); i++ {
-		res := <-c
-		if res.err != nil {
-			log.WithError(res.err).Error("error in loading validator registration from redis")
-		} else if res.val.Entry != nil { // only if a known registration
-			proposerDuties = append(proposerDuties, res.val)
+			})
 		}
 	}
 
@@ -288,4 +300,25 @@ func (hk *Housekeeper) updateProposerDuties(headSlot uint64) {
 	}
 	sort.Strings(_duties)
 	log.WithField("numDuties", len(_duties)).Infof("proposer duties updated: %s", strings.Join(_duties, ", "))
+}
+
+// updateValidatorRegistrationsInRedis saves all latest validator registrations from the database to Redis
+func (hk *Housekeeper) updateValidatorRegistrationsInRedis() {
+	regs, err := hk.db.GetLatestValidatorRegistrations(true)
+	if err != nil {
+		hk.log.WithError(err).Error("failed to get latest validator registrations")
+		return
+	}
+
+	hk.log.Infof("updating %d validator registrations in Redis...", len(regs))
+	timeStarted := time.Now()
+
+	for _, reg := range regs {
+		err = hk.redis.SetValidatorRegistrationTimestamp(types.PubkeyHex(reg.Pubkey), reg.Timestamp)
+		if err != nil {
+			hk.log.WithError(err).Error("failed to set validator registration")
+			continue
+		}
+	}
+	hk.log.Infof("updating %d validator registrations in Redis done - %f sec", len(regs), time.Since(timeStarted).Seconds())
 }


### PR DESCRIPTION
## 📝 Summary

- Don't store full validator registrations in Redis, only the timestamps
- Housekeeper updates validator registrations in Redis on startup (from database)

Important!

- Database access is now required for for housekeeper (using the same `-db` flag as the other services)!
- Unused Redis keys that need to be manually cleaned up:
  -  `boost-relay/NETWORK:validators-registration-timestamp`
  -  `boost-relay/NETWORK:validators-registration`
- New Redis key for validator registrations: `boost-relay/NETWORK:validator-registration-timestamp`

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
