### PR TITLE
keep track of active validators

### DIFF
--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -39,8 +39,6 @@ func TestProdProposerValidatorRegistration(t *testing.T) {
 	// Set known validator and save registration
 	err = ds.redis.SetKnownValidator(key, 1)
 	require.NoError(t, err)
-	// err = ds.redis.SetValidatorRegistration(reg1)
-	// require.NoError(t, err)
 
 	// Check if validator is known
 	cnt, err := ds.RefreshKnownValidators()

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -176,21 +176,6 @@ func (r *RedisCache) SetActiveValidator(pubkeyHex types.PubkeyHex) error {
 	return r.client.Expire(context.Background(), key, expiryActiveValidators).Err()
 }
 
-func (r *RedisCache) NumActiveValidators() (uint64, error) {
-	hours := int(expiryActiveValidators.Hours())
-	now := time.Now()
-	numActiveValidators := uint64(0)
-	for i := 0; i < hours; i++ {
-		key := r.keyActiveValidators(now.Add(time.Duration(-i) * time.Hour))
-		entries, err := r.client.HLen(context.Background(), key).Result()
-		if err != nil {
-			return 0, err
-		}
-		numActiveValidators += uint64(entries)
-	}
-	return numActiveValidators, nil
-}
-
 func (r *RedisCache) GetActiveValidators() (map[types.PubkeyHex]bool, error) {
 	hours := int(expiryActiveValidators.Hours())
 	now := time.Now()

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -17,7 +17,7 @@ var (
 	redisPrefix = "boost-relay"
 
 	expiryBidCache         = 5 * time.Minute
-	expiryActiveValidators = 26 * time.Hour
+	expiryActiveValidators = 6 * time.Hour
 
 	RedisConfigFieldPubkey    = "pubkey"
 	RedisStatsFieldLatestSlot = "latest-slot"
@@ -177,7 +177,7 @@ func (r *RedisCache) SetActiveValidator(pubkeyHex types.PubkeyHex) error {
 }
 
 func (r *RedisCache) NumActiveValidators() (uint64, error) {
-	hours := 2
+	hours := int(expiryActiveValidators.Hours())
 	now := time.Now()
 	numActiveValidators := uint64(0)
 	for i := 0; i < hours; i++ {
@@ -192,7 +192,7 @@ func (r *RedisCache) NumActiveValidators() (uint64, error) {
 }
 
 func (r *RedisCache) GetActiveValidators() (map[types.PubkeyHex]bool, error) {
-	hours := 2
+	hours := int(expiryActiveValidators.Hours())
 	now := time.Now()
 	validators := make(map[types.PubkeyHex]bool)
 	for i := 0; i < hours; i++ {

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -17,7 +17,7 @@ var (
 	redisPrefix = "boost-relay"
 
 	expiryBidCache         = 5 * time.Minute
-	expiryActiveValidators = 6 * time.Hour
+	expiryActiveValidators = 6 * time.Hour // careful with this setting - for each hour a hash set is created with each active proposer as field. for a lot of hours this can take a lot of space in redis.
 
 	RedisConfigFieldPubkey    = "pubkey"
 	RedisStatsFieldLatestSlot = "latest-slot"

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -16,7 +16,8 @@ import (
 var (
 	redisPrefix = "boost-relay"
 
-	expiryBidCache = 5 * time.Minute
+	expiryBidCache         = 5 * time.Minute
+	expiryActiveValidators = 26 * time.Hour
 
 	RedisConfigFieldPubkey    = "pubkey"
 	RedisStatsFieldLatestSlot = "latest-slot"
@@ -49,6 +50,7 @@ type RedisCache struct {
 
 	prefixGetHeaderResponse  string
 	prefixGetPayloadResponse string
+	prefixActiveValidators   string
 
 	keyKnownValidators                string
 	keyValidatorRegistrationTimestamp string
@@ -70,6 +72,7 @@ func NewRedisCache(redisURI, prefix string) (*RedisCache, error) {
 
 		prefixGetHeaderResponse:  fmt.Sprintf("%s/%s:cache-gethead-response", redisPrefix, prefix),
 		prefixGetPayloadResponse: fmt.Sprintf("%s/%s:cache-getpayload-response", redisPrefix, prefix),
+		prefixActiveValidators:   fmt.Sprintf("%s/%s:active-validators", redisPrefix, prefix), // per hour
 
 		keyKnownValidators:                fmt.Sprintf("%s/%s:known-validators", redisPrefix, prefix),
 		keyValidatorRegistrationTimestamp: fmt.Sprintf("%s/%s:validator-registration-timestamp", redisPrefix, prefix),
@@ -87,6 +90,11 @@ func (r *RedisCache) keyCacheGetHeaderResponse(slot uint64, parentHash, proposer
 
 func (r *RedisCache) keyCacheGetPayloadResponse(slot uint64, proposerPubkey, blockHash string) string {
 	return fmt.Sprintf("%s:%d_%s_%s", r.prefixGetPayloadResponse, slot, proposerPubkey, blockHash)
+}
+
+// keyActiveValidators returns the key for the date + hour of the given time
+func (r *RedisCache) keyActiveValidators(t time.Time) string {
+	return fmt.Sprintf("%s:%s", r.prefixActiveValidators, t.UTC().Format("2006-01-02T15"))
 }
 
 func (r *RedisCache) GetObj(key string, obj any) (err error) {
@@ -155,6 +163,50 @@ func (r *RedisCache) SetValidatorRegistrationTimestamp(proposerPubkey types.Pubk
 
 func (r *RedisCache) NumRegisteredValidators() (int64, error) {
 	return r.client.HLen(context.Background(), r.keyValidatorRegistrationTimestamp).Result()
+}
+
+func (r *RedisCache) SetActiveValidator(pubkeyHex types.PubkeyHex) error {
+	key := r.keyActiveValidators(time.Now())
+	err := r.client.HSet(context.Background(), key, PubkeyHexToLowerStr(pubkeyHex), "1").Err()
+	if err != nil {
+		return err
+	}
+
+	// set expiry
+	return r.client.Expire(context.Background(), key, expiryActiveValidators).Err()
+}
+
+func (r *RedisCache) NumActiveValidators() (uint64, error) {
+	hours := 2
+	now := time.Now()
+	numActiveValidators := uint64(0)
+	for i := 0; i < hours; i++ {
+		key := r.keyActiveValidators(now.Add(time.Duration(-i) * time.Hour))
+		entries, err := r.client.HLen(context.Background(), key).Result()
+		if err != nil {
+			return 0, err
+		}
+		numActiveValidators += uint64(entries)
+	}
+	return numActiveValidators, nil
+}
+
+func (r *RedisCache) GetActiveValidators() (map[types.PubkeyHex]bool, error) {
+	hours := 2
+	now := time.Now()
+	validators := make(map[types.PubkeyHex]bool)
+	for i := 0; i < hours; i++ {
+		key := r.keyActiveValidators(now.Add(time.Duration(-i) * time.Hour))
+		entries, err := r.client.HGetAll(context.Background(), key).Result()
+		if err != nil {
+			return nil, err
+		}
+		for pubkey := range entries {
+			validators[types.PubkeyHex(pubkey)] = true
+		}
+	}
+
+	return validators, nil
 }
 
 func (r *RedisCache) SetStats(field string, value any) (err error) {

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -167,10 +167,6 @@ func TestActiveValidators(t *testing.T) {
 	err := cache.SetActiveValidator(pk1)
 	require.NoError(t, err)
 
-	n, err := cache.NumActiveValidators()
-	require.NoError(t, err)
-	require.Equal(t, uint64(1), n)
-
 	vals, err := cache.GetActiveValidators()
 	require.NoError(t, err)
 	require.Equal(t, 1, len(vals))

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -160,3 +160,19 @@ func TestRedisProposerDuties(t *testing.T) {
 	require.Equal(t, 1, len(duties2))
 	require.Equal(t, duties[0].Entry.Message.FeeRecipient, duties2[0].Entry.Message.FeeRecipient)
 }
+
+func TestActiveValidators(t *testing.T) {
+	pk1 := types.NewPubkeyHex("0x8016d3229030424cfeff6c5b813970ea193f8d012cfa767270ca9057d58eddc556e96c14544bf4c038dbed5f24aa8da0")
+	cache := setupTestRedis(t)
+	err := cache.SetActiveValidator(pk1)
+	require.NoError(t, err)
+
+	n, err := cache.NumActiveValidators()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), n)
+
+	vals, err := cache.GetActiveValidators()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(vals))
+	require.True(t, vals[pk1])
+}

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -453,6 +453,14 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 			regLog.WithError(err).Infof("error getting last registration timestamp")
 		}
 
+		// Here is the place to track active validators. Ideally should validate the signature here
+		go func() {
+			err := api.redis.SetActiveValidator(pubkey)
+			if err != nil {
+				regLog.WithError(err).Infof("error setting active validator")
+			}
+		}()
+
 		// Do nothing if the registration is already the latest
 		if prevTimestamp >= registration.Message.Timestamp {
 			continue

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -78,10 +78,9 @@ func (hk *Housekeeper) Start() (err error) {
 	// Start initial tasks
 	go hk.updateValidatorRegistrationsInRedis()
 
-	// go hk.test()
 	// Start the periodic task loops
 	go hk.periodicTaskUpdateKnownValidators()
-	go hk.periodicTaskLogNumRegisteredValidators()
+	go hk.periodicTaskLogValidators()
 	go hk.periodicTaskUpdateBuilderStatusInRedis()
 
 	// Process the current slot
@@ -97,7 +96,7 @@ func (hk *Housekeeper) Start() (err error) {
 	}
 }
 
-func (hk *Housekeeper) periodicTaskLogNumRegisteredValidators() {
+func (hk *Housekeeper) periodicTaskLogValidators() {
 	for {
 		numRegisteredValidators, err := hk.redis.NumRegisteredValidators()
 		if err == nil {
@@ -105,6 +104,14 @@ func (hk *Housekeeper) periodicTaskLogNumRegisteredValidators() {
 		} else {
 			hk.log.WithError(err).Error("failed to get number of registered validators")
 		}
+
+		numActiveValidators, err := hk.redis.NumActiveValidators()
+		if err == nil {
+			hk.log.WithField("numActiveValidators", numActiveValidators).Infof("active validators: %d", numActiveValidators)
+		} else {
+			hk.log.WithError(err).Error("failed to get number of active validators")
+		}
+
 		time.Sleep(common.DurationPerEpoch / 2)
 	}
 }

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -105,9 +105,9 @@ func (hk *Housekeeper) periodicTaskLogValidators() {
 			hk.log.WithError(err).Error("failed to get number of registered validators")
 		}
 
-		numActiveValidators, err := hk.redis.NumActiveValidators()
+		activeValidators, err := hk.redis.GetActiveValidators()
 		if err == nil {
-			hk.log.WithField("numActiveValidators", numActiveValidators).Infof("active validators: %d", numActiveValidators)
+			hk.log.WithField("numActiveValidators", len(activeValidators)).Infof("active validators: %d", len(activeValidators))
 		} else {
 			hk.log.WithError(err).Error("failed to get number of active validators")
 		}


### PR DESCRIPTION
## 📝 Summary

keep track of active validators in redis

* gives insights into current usage
* allows data API to return list of proposers that are active

note: for each hour a hash set is created with each active proposer as field. for a lot of hours this can take a lot of space in redis.

todo later: sync them back into the database from the housekeeper (another PR)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
