### PR TITLE
Data API: timestamp as string

### DIFF
--- a/services/api/types.go
+++ b/services/api/types.go
@@ -69,7 +69,7 @@ type BidTraceJSON struct {
 type BidTraceWithTimestampJSON struct {
 	BidTraceJSON
 
-	Timestamp int64 `json:"timestamp,omitempty"`
+	Timestamp int64 `json:"timestamp,string,omitempty"`
 }
 
 func SignedBlindedBeaconBlockToBeaconBlock(signedBlindedBeaconBlock *types.SignedBlindedBeaconBlock, executionPayload *types.ExecutionPayload) *types.SignedBeaconBlock {


### PR DESCRIPTION
## 📝 Summary

Data API should have timestamp as string in JSON, as all other numeric fields.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
