### PR TITLE
use channel to process active validators during validator registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `DISABLE_LOWPRIO_BUILDERS` - reject block submissions by low-prio builders
 * `DISABLE_BID_MEMORY_CACHE` - disable bids to go through in-memory cache. forces to go through redis/db
 * `DISABLE_BID_REDIS_CACHE` - disable bids to go through redis cache. forces to go through memory/db
-
+* `NUM_ACTIVE_VALIDATOR_PROCESSORS` - proposer API - number of goroutines to listen to the active validators channel
+* `ACTIVE_VALIDATOR_HOURS` - number of hours to track active proposers in redis
 
 ### Updating the website
 


### PR DESCRIPTION
## 📝 Summary

Use a channel and a static number of processors to save active validators to redis. Before it was spinning up one goroutine per validator registration to track the active proposer, which causes slow processing.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
