### PR TITLE
batch-save validator registrations

### DIFF
--- a/database/mockdb.go
+++ b/database/mockdb.go
@@ -8,6 +8,10 @@ func (db MockDB) SaveValidatorRegistration(registration types.SignedValidatorReg
 	return nil
 }
 
+func (db MockDB) SaveValidatorRegistrations(registrations []types.SignedValidatorRegistration) error {
+	return nil
+}
+
 func (db MockDB) GetValidatorRegistration(pubkey string) (*ValidatorRegistrationEntry, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## 📝 Summary

This change collects valid new registrations, and batch-inserts them at the end of the request. Leading to much better database performance in case of calls with many new registrations.

Before, each validator registration was written to the database immediately (in a goroutine started from the processing loop).

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
