### PR TITLE
housekeeper: sync block builder status to redis on startup

### DIFF
--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -29,6 +29,7 @@ var (
 type BlockBuilderStatus string
 
 var (
+	RedisBlockBuilderStatusLowPrio     BlockBuilderStatus = ""
 	RedisBlockBuilderStatusHighPrio    BlockBuilderStatus = "high-prio"
 	RedisBlockBuilderStatusBlacklisted BlockBuilderStatus = "blacklisted"
 )

--- a/datastore/utils.go
+++ b/datastore/utils.go
@@ -1,0 +1,11 @@
+package datastore
+
+func MakeBlockBuilderStatus(isHighPrio, isBlacklisted bool) BlockBuilderStatus {
+	if isBlacklisted {
+		return RedisBlockBuilderStatusBlacklisted
+	} else if isHighPrio {
+		return RedisBlockBuilderStatusHighPrio
+	} else {
+		return RedisBlockBuilderStatusLowPrio
+	}
+}

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -895,14 +895,8 @@ func (api *RelayAPI) handleInternalBuilderStatus(w http.ResponseWriter, req *htt
 			"isBlacklisted": isBlacklisted,
 		}).Info("updating builder status")
 
-		var status datastore.BlockBuilderStatus
-		if isBlacklisted {
-			status = datastore.RedisBlockBuilderStatusBlacklisted
-		} else if isHighPrio {
-			status = datastore.RedisBlockBuilderStatusHighPrio
-		}
-
-		err := api.redis.SetBlockBuilderStatus(builderPubkey, status)
+		newStatus := datastore.MakeBlockBuilderStatus(isHighPrio, isBlacklisted)
+		err := api.redis.SetBlockBuilderStatus(builderPubkey, newStatus)
 		if err != nil {
 			api.log.WithError(err).Error("could not set block builder status in redis")
 		}
@@ -912,7 +906,7 @@ func (api *RelayAPI) handleInternalBuilderStatus(w http.ResponseWriter, req *htt
 			api.log.WithError(err).Error("could not set block builder status in database")
 		}
 
-		api.RespondOK(w, struct{ newStatus string }{newStatus: string(status)})
+		api.RespondOK(w, struct{ newStatus string }{newStatus: string(newStatus)})
 	}
 }
 

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -76,6 +76,7 @@ func (hk *Housekeeper) Start() (err error) {
 	}
 
 	// Start initial tasks
+	go hk.updateBlockBuildersInRedis()
 	go hk.updateValidatorRegistrationsInRedis()
 
 	// Start the periodic task loops
@@ -328,4 +329,22 @@ func (hk *Housekeeper) updateValidatorRegistrationsInRedis() {
 		}
 	}
 	hk.log.Infof("updating %d validator registrations in Redis done - %f sec", len(regs), time.Since(timeStarted).Seconds())
+}
+
+func (hk *Housekeeper) updateBlockBuildersInRedis() {
+	builders, err := hk.db.GetBlockBuilders()
+	if err != nil {
+		hk.log.WithError(err).Error("failed to get block builders from db")
+		return
+	}
+
+	hk.log.Infof("updating %d block builders in Redis...", len(builders))
+	for _, builder := range builders {
+		status := datastore.MakeBlockBuilderStatus(builder.IsHighPrio, builder.IsBlacklisted)
+		hk.log.Infof("updating block builder in Redis: %s - %s", builder.BuilderPubkey, status)
+		err = hk.redis.SetBlockBuilderStatus(builder.BuilderPubkey, status)
+		if err != nil {
+			hk.log.WithError(err).Error("failed to set block builder status in redis")
+		}
+	}
 }


### PR DESCRIPTION
## 📝 Summary

In case of deleting all of redis, it's important for the housekeeper to sync block builder status from DB to Redis.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
