### PR TITLE
Handle validator registrations state change

### DIFF
--- a/database/database_test.go
+++ b/database/database_test.go
@@ -1,0 +1,112 @@
+package database
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var runDBTests = os.Getenv("RUN_DB_TESTS") == "1"
+
+func createValidatorRegistration(pubKey string) ValidatorRegistrationEntry {
+	return ValidatorRegistrationEntry{
+		Pubkey:       pubKey,
+		FeeRecipient: "0xffbb8996515293fcd87ca09b5c6ffe5c17f043c6",
+		Timestamp:    1663311456,
+		GasLimit:     30000000,
+		Signature:    "0xab6fa6462f658708f1a9030faeac588d55b1e28cc1f506b3ef938eeeec0171d4209865fb66bbb94e52c0c160a63975e51795ee8d1da38219b3f80d7d14f003421a255d99b744bd71f45f0cb2cd17948afff67ad6c9163fcd20b48f6315dac7cc",
+	}
+}
+
+func TestSaveValidatorRegistration(t *testing.T) {
+	if !runDBTests {
+		t.Skip("Skipping database tests")
+	}
+
+	dsn := "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"
+	db, err := NewDatabaseService(dsn)
+	require.NoError(t, err)
+
+	// reg1 is the initial registration
+	reg1 := createValidatorRegistration("0x8996515293fcd87ca09b5c6ffe5c17f043c6a1a3639cc9494a82ec8eb50a9b55c34b47675e573be40d9be308b1ca2908")
+
+	// reg2 is reg1 with newer timestamp, same fields - should not insert
+	reg2 := createValidatorRegistration("0x8996515293fcd87ca09b5c6ffe5c17f043c6a1a3639cc9494a82ec8eb50a9b55c34b47675e573be40d9be308b1ca2908")
+	reg2.Timestamp = reg1.Timestamp + 1
+
+	// reg3 is reg1 with newer timestamp and new gaslimit - insert
+	reg3 := createValidatorRegistration("0x8996515293fcd87ca09b5c6ffe5c17f043c6a1a3639cc9494a82ec8eb50a9b55c34b47675e573be40d9be308b1ca2908")
+	reg3.Timestamp = reg1.Timestamp + 1
+	reg3.GasLimit = reg1.GasLimit + 1
+
+	// reg4 is reg1 with newer timestamp and new fee_recipient - insert
+	reg4 := createValidatorRegistration("0x8996515293fcd87ca09b5c6ffe5c17f043c6a1a3639cc9494a82ec8eb50a9b55c34b47675e573be40d9be308b1ca2908")
+	reg4.Timestamp = reg1.Timestamp + 2
+	reg4.FeeRecipient = "0xafbb8996515293fcd87ca09b5c6ffe5c17f043c6"
+
+	// reg5 is reg1 with older timestamp and new fee_recipient - should not insert
+	reg5 := createValidatorRegistration("0x8996515293fcd87ca09b5c6ffe5c17f043c6a1a3639cc9494a82ec8eb50a9b55c34b47675e573be40d9be308b1ca2908")
+	reg5.Timestamp = reg1.Timestamp - 1
+	reg5.FeeRecipient = "0x00bb8996515293fcd87ca09b5c6ffe5c17f043c6"
+
+	// Require empty DB
+	cnt, err := db.NumValidatorRegistrationRows()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), cnt, "DB not empty to start")
+
+	// Save reg1
+	err = db.SaveValidatorRegistration(reg1)
+	require.NoError(t, err)
+	regX1, err := db.GetValidatorRegistration(reg1.Pubkey)
+	require.NoError(t, err)
+	require.Equal(t, reg1.FeeRecipient, regX1.FeeRecipient)
+	cnt, err = db.NumValidatorRegistrationRows()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cnt)
+
+	// Save reg2, should not insert
+	err = db.SaveValidatorRegistration(reg2)
+	require.NoError(t, err)
+	regX1, err = db.GetValidatorRegistration(reg1.Pubkey)
+	require.NoError(t, err)
+	require.Equal(t, reg1.Timestamp, regX1.Timestamp)
+	cnt, err = db.NumValidatorRegistrationRows()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cnt)
+
+	// Save reg3, should insert
+	err = db.SaveValidatorRegistration(reg3)
+	require.NoError(t, err)
+	regX1, err = db.GetValidatorRegistration(reg1.Pubkey)
+	require.NoError(t, err)
+	require.Equal(t, reg3.Timestamp, regX1.Timestamp)
+	require.Equal(t, reg3.GasLimit, regX1.GasLimit)
+	cnt, err = db.NumValidatorRegistrationRows()
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), cnt)
+
+	// Save reg4, should insert
+	err = db.SaveValidatorRegistration(reg4)
+	require.NoError(t, err)
+	regX1, err = db.GetValidatorRegistration(reg1.Pubkey)
+	require.NoError(t, err)
+	require.Equal(t, reg4.Timestamp, regX1.Timestamp)
+	require.Equal(t, reg4.GasLimit, regX1.GasLimit)
+	require.Equal(t, reg4.FeeRecipient, regX1.FeeRecipient)
+	cnt, err = db.NumValidatorRegistrationRows()
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), cnt)
+
+	// Save reg5, should not insert
+	err = db.SaveValidatorRegistration(reg5)
+	require.NoError(t, err)
+	regX1, err = db.GetValidatorRegistration(reg1.Pubkey)
+	require.NoError(t, err)
+	require.Equal(t, reg4.Timestamp, regX1.Timestamp)
+	require.Equal(t, reg4.GasLimit, regX1.GasLimit)
+	require.Equal(t, reg4.FeeRecipient, regX1.FeeRecipient)
+	cnt, err = db.NumValidatorRegistrationRows()
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), cnt)
+}

--- a/database/mockdb.go
+++ b/database/mockdb.go
@@ -4,7 +4,7 @@ import "github.com/flashbots/go-boost-utils/types"
 
 type MockDB struct{}
 
-func (db MockDB) SaveValidatorRegistration(registration types.SignedValidatorRegistration) error {
+func (db MockDB) SaveValidatorRegistration(entry ValidatorRegistrationEntry) error {
 	return nil
 }
 

--- a/database/schema.go
+++ b/database/schema.go
@@ -26,8 +26,7 @@ CREATE TABLE IF NOT EXISTS ` + TableValidatorRegistration + ` (
 	signature     text NOT NULL
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS ` + TableValidatorRegistration + `_pubkey_feerec_idx ON ` + TableValidatorRegistration + `(pubkey, fee_recipient);
-CREATE INDEX IF NOT EXISTS ` + TableValidatorRegistration + `_pubkey_timestamp_idx ON ` + TableValidatorRegistration + `(pubkey, timestamp DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS ` + TableValidatorRegistration + `_pubkey_timestamp_uidx ON ` + TableValidatorRegistration + `(pubkey, timestamp DESC);
 
 
 CREATE TABLE IF NOT EXISTS ` + TableExecutionPayload + ` (

--- a/database/types.go
+++ b/database/types.go
@@ -79,6 +79,16 @@ func (reg ValidatorRegistrationEntry) ToSignedValidatorRegistration() (*types.Si
 	}, nil
 }
 
+func SignedValidatorRegistrationToEntry(valReg types.SignedValidatorRegistration) ValidatorRegistrationEntry {
+	return ValidatorRegistrationEntry{
+		Pubkey:       valReg.Message.Pubkey.String(),
+		FeeRecipient: valReg.Message.FeeRecipient.String(),
+		Timestamp:    valReg.Message.Timestamp,
+		GasLimit:     valReg.Message.GasLimit,
+		Signature:    valReg.Signature.String(),
+	}
+}
+
 type ExecutionPayloadEntry struct {
 	ID         int64     `db:"id"`
 	InsertedAt time.Time `db:"inserted_at"`

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -127,7 +127,15 @@ func (ds *Datastore) SaveValidatorRegistration(entry types.SignedValidatorRegist
 		return err
 	}
 
-	err = ds.db.SaveValidatorRegistration(entry)
+	regEntry := database.ValidatorRegistrationEntry{
+		Pubkey:       entry.Message.Pubkey.String(),
+		FeeRecipient: entry.Message.FeeRecipient.String(),
+		Timestamp:    entry.Message.Timestamp,
+		GasLimit:     entry.Message.GasLimit,
+		Signature:    entry.Signature.String(),
+	}
+
+	err = ds.db.SaveValidatorRegistration(regEntry)
 	if err != nil {
 		ds.log.WithError(err).Error("failed to save validator registration to database")
 		return err

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -121,13 +121,7 @@ func (ds *Datastore) GetValidatorRegistrationTimestamp(pubkeyHex types.PubkeyHex
 // SaveValidatorRegistration saves a validator registration into both Redis and the database
 func (ds *Datastore) SaveValidatorRegistration(entry types.SignedValidatorRegistration) error {
 	// First save in the database
-	err := ds.db.SaveValidatorRegistration(database.ValidatorRegistrationEntry{
-		Pubkey:       entry.Message.Pubkey.String(),
-		FeeRecipient: entry.Message.FeeRecipient.String(),
-		Timestamp:    entry.Message.Timestamp,
-		GasLimit:     entry.Message.GasLimit,
-		Signature:    entry.Signature.String(),
-	})
+	err := ds.db.SaveValidatorRegistration(database.SignedValidatorRegistrationToEntry(entry))
 	if err != nil {
 		ds.log.WithError(err).Error("failed to save validator registration to database")
 		return err

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -59,6 +59,7 @@ var (
 
 	// number of goroutines to save active validator
 	numActiveValidatorProcessors = cli.GetEnvInt("NUM_ACTIVE_VALIDATOR_PROCESSORS", 10)
+	numValidatorRegProcessors    = cli.GetEnvInt("NUM_VALIDATOR_REG_PROCESSORS", 10)
 )
 
 // RelayAPIOpts contains the options for a relay
@@ -111,7 +112,9 @@ type RelayAPI struct {
 	isUpdatingProposerDuties uberatomic.Bool
 
 	blockSimRateLimiter *BlockSimulationRateLimiter
-	activeValidatorC    chan *types.PubkeyHex
+
+	activeValidatorC chan types.PubkeyHex
+	validatorRegC    chan types.SignedValidatorRegistration
 
 	// Feature flags
 	ffForceGetHeader204      bool
@@ -172,7 +175,9 @@ func NewRelayAPI(opts RelayAPIOpts) (api *RelayAPI, err error) {
 		db:                     opts.DB,
 		proposerDutiesResponse: []types.BuilderGetValidatorsResponseEntry{},
 		blockSimRateLimiter:    NewBlockSimulationRateLimiter(opts.BlockSimURL),
-		activeValidatorC:       make(chan *types.PubkeyHex, 450_000),
+
+		activeValidatorC: make(chan types.PubkeyHex, 450_000),
+		validatorRegC:    make(chan types.SignedValidatorRegistration, 450_000),
 	}
 
 	if os.Getenv("FORCE_GET_HEADER_204") == "1" {
@@ -259,9 +264,15 @@ func (api *RelayAPI) StartServer() (err error) {
 	go api.startKnownValidatorUpdates()
 
 	// Start the active validator processor
-	api.log.Infof("starting %d active validator processor", numActiveValidatorProcessors)
+	api.log.Infof("starting %d active validator processors", numActiveValidatorProcessors)
 	for i := 0; i < numActiveValidatorProcessors; i++ {
 		go api.startActiveValidatorProcessor()
+	}
+
+	// Start the validator registration db-save processor
+	api.log.Infof("starting %d validator registration processors", numValidatorRegProcessors)
+	for i := 0; i < numValidatorRegProcessors; i++ {
+		go api.startValidatorRegistrationDBProcessor()
 	}
 
 	// Process current slot
@@ -306,9 +317,20 @@ func (api *RelayAPI) StartServer() (err error) {
 // startActiveValidatorProcessor keeps listening on the channel and saving active validators to redis
 func (api *RelayAPI) startActiveValidatorProcessor() {
 	for pubkey := range api.activeValidatorC {
-		err := api.redis.SetActiveValidator(*pubkey)
+		err := api.redis.SetActiveValidator(pubkey)
 		if err != nil {
 			api.log.WithError(err).Infof("error setting active validator")
+		}
+	}
+}
+
+// startActiveValidatorProcessor keeps listening on the channel and saving active validators to redis
+func (api *RelayAPI) startValidatorRegistrationDBProcessor() {
+	for valReg := range api.validatorRegC {
+		entry := database.SignedValidatorRegistrationToEntry(valReg)
+		err := api.db.SaveValidatorRegistration(entry)
+		if err != nil {
+			api.log.WithError(err).WithField("proposerPubkey", entry.Pubkey).Infof("error saving validator registration")
 		}
 	}
 }
@@ -483,7 +505,7 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 
 		// Track active validators here
 		select {
-		case api.activeValidatorC <- &pubkey:
+		case api.activeValidatorC <- pubkey:
 		default:
 			regLog.Warn("active validator channel full")
 		}
@@ -505,13 +527,8 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 			api.RespondError(w, http.StatusBadRequest, fmt.Sprintf("failed to verify validator signature for %s", registration.Message.Pubkey.String()))
 			return
 		} else {
-			// Save
-			go func(reg types.SignedValidatorRegistration) {
-				err := api.datastore.SaveValidatorRegistration(reg)
-				if err != nil {
-					regLog.WithError(err).Error("Failed to set validator registration")
-				}
-			}(registration)
+			// Save to database
+			api.validatorRegC <- registration
 		}
 	}
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -507,7 +507,7 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 		select {
 		case api.activeValidatorC <- pubkey:
 		default:
-			regLog.Warn("active validator channel full")
+			regLog.Error("active validator channel full")
 		}
 
 		// Do nothing if the registration is already the latest
@@ -528,7 +528,11 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 			return
 		} else {
 			// Save to database
-			api.validatorRegC <- registration
+			select {
+			case api.validatorRegC <- registration:
+			default:
+				regLog.Error("validator registration channel full")
+			}
 		}
 	}
 

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -206,7 +206,7 @@ func TestRegisterValidator(t *testing.T) {
 
 		// Disallow +11 sec
 		td = uint64(time.Now().Unix())
-		payload, err = generateSignedValidatorRegistration(nil, types.Address{1}, td+11)
+		payload, err = generateSignedValidatorRegistration(nil, types.Address{1}, td+12)
 		require.NoError(t, err)
 		err = backend.redis.SetKnownValidator(payload.Message.Pubkey.PubkeyHex(), 1)
 		require.NoError(t, err)


### PR DESCRIPTION
## 📝 Summary

Handles validator state changes properly.

Important: index change required for table validator_registration: [schema.go](https://github.com/flashbots/mev-boost-relay/pull/167/files#diff-bb86b7e3f9ed597dbe13c87b1c2ab9773a2668a44e2a99f2e366ef81290c2026)

removed indices:
```patch
UNIQUE INDEX IF NOT EXISTS ` + TableValidatorRegistration + `_pubkey_feerec_idx ON ` + TableValidatorRegistration + `(pubkey, fee_recipient);
INDEX IF NOT EXISTS ` + TableValidatorRegistration + `_pubkey_timestamp_idx ON ` + TableValidatorRegistration + `(pubkey, timestamp DESC);
```

new unique index:
```
CREATE UNIQUE INDEX IF NOT EXISTS ` + TableValidatorRegistration + `_pubkey_timestamp_idx ON ` + TableValidatorRegistration + `(pubkey, timestamp DESC);
```

## Rolling this out

1. Manually remove the two previous indices on validator registration
1. Deploy the update (will create the new index)
1. Delete the redis key `validator-registration-timestamp`: `DEL boost-relay/mainnet:validator-registration-timestamp`
1. Then all registrations will be re-saved to both redis and the database
 
---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
