### PR TITLE
database as source of truth for number of validator registrations

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -14,6 +14,7 @@ import (
 )
 
 type IDatabaseService interface {
+	NumRegisteredValidators() (count uint64, err error)
 	SaveValidatorRegistration(entry ValidatorRegistrationEntry) error
 	GetLatestValidatorRegistrations(timestampOnly bool) ([]*ValidatorRegistrationEntry, error)
 	GetValidatorRegistration(pubkey string) (*ValidatorRegistrationEntry, error)
@@ -68,6 +69,14 @@ func NewDatabaseService(dsn string) (*DatabaseService, error) {
 
 func (s *DatabaseService) Close() error {
 	return s.DB.Close()
+}
+
+// NumRegisteredValidators returns the number of unique pubkeys that have registered
+func (s *DatabaseService) NumRegisteredValidators() (count uint64, err error) {
+	query := `SELECT COUNT(*) FROM (SELECT DISTINCT pubkey FROM ` + TableValidatorRegistration + `) AS temp;`
+	row := s.DB.QueryRow(query)
+	err = row.Scan(&count)
+	return count, err
 }
 
 func (s *DatabaseService) NumValidatorRegistrationRows() (count uint64, err error) {

--- a/database/mockdb.go
+++ b/database/mockdb.go
@@ -4,6 +4,10 @@ import "github.com/flashbots/go-boost-utils/types"
 
 type MockDB struct{}
 
+func (db MockDB) NumRegisteredValidators() (count uint64, err error) {
+	return 0, nil
+}
+
 func (db MockDB) SaveValidatorRegistration(entry ValidatorRegistrationEntry) error {
 	return nil
 }

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -110,8 +110,8 @@ func (ds *Datastore) NumKnownValidators() int {
 	return len(ds.knownValidatorsByIndex)
 }
 
-func (ds *Datastore) NumRegisteredValidators() (int64, error) {
-	return ds.redis.NumRegisteredValidators()
+func (ds *Datastore) NumRegisteredValidators() (uint64, error) {
+	return ds.db.NumRegisteredValidators()
 }
 
 func (ds *Datastore) GetValidatorRegistrationTimestamp(pubkeyHex types.PubkeyHex) (uint64, error) {

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -164,10 +164,6 @@ func (r *RedisCache) SetValidatorRegistrationTimestamp(proposerPubkey types.Pubk
 	return r.client.HSet(context.Background(), r.keyValidatorRegistrationTimestamp, proposerPubkey.String(), timestamp).Err()
 }
 
-func (r *RedisCache) NumRegisteredValidators() (int64, error) {
-	return r.client.HLen(context.Background(), r.keyValidatorRegistrationTimestamp).Result()
-}
-
 func (r *RedisCache) SetActiveValidator(pubkeyHex types.PubkeyHex) error {
 	key := r.keyActiveValidators(time.Now())
 	err := r.client.HSet(context.Background(), key, PubkeyHexToLowerStr(pubkeyHex), "1").Err()

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -104,10 +104,6 @@ func TestRedisValidatorRegistrations(t *testing.T) {
 		require.Equal(t, 1, len(knownVals))
 		require.Contains(t, knownVals, key1)
 
-		numReg, err := cache.NumRegisteredValidators()
-		require.NoError(t, err)
-		require.Equal(t, int64(0), numReg)
-
 		// Create a signed registration for key1
 		pubkey1, err := types.HexToPubkey(key1.String())
 		require.NoError(t, err)
@@ -124,10 +120,6 @@ func TestRedisValidatorRegistrations(t *testing.T) {
 		pkHex := types.NewPubkeyHex(entry.Message.Pubkey.String())
 		err = cache.SetValidatorRegistrationTimestamp(pkHex, entry.Message.Timestamp)
 		require.NoError(t, err)
-
-		numReg, err = cache.NumRegisteredValidators()
-		require.NoError(t, err)
-		require.Equal(t, int64(1), numReg)
 
 		reg, err := cache.GetValidatorRegistrationTimestamp(key1)
 		require.NoError(t, err)

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -98,7 +98,7 @@ func (hk *Housekeeper) Start() (err error) {
 
 func (hk *Housekeeper) periodicTaskLogValidators() {
 	for {
-		numRegisteredValidators, err := hk.redis.NumRegisteredValidators()
+		numRegisteredValidators, err := hk.db.NumRegisteredValidators()
 		if err == nil {
 			hk.log.WithField("numRegisteredValidators", numRegisteredValidators).Infof("registered validators: %d", numRegisteredValidators)
 		} else {

--- a/services/website/website.go
+++ b/services/website/website.go
@@ -163,7 +163,7 @@ func (srv *Webserver) updateHTML() {
 		srv.log.WithError(err).Error("error getting known validators in updateStatusHTMLData")
 	}
 
-	_numRegistered, err := srv.redis.NumRegisteredValidators()
+	_numRegistered, err := srv.db.NumRegisteredValidators()
 	if err != nil {
 		srv.log.WithError(err).Error("error getting number of registered validators in updateStatusHTMLData")
 	}


### PR DESCRIPTION
## 📝 Summary

before it was redis, but that's unreliable, in particular if cache is cleaned.

should use the database as source of truth!

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
