### PR TITLE
api: graceful shutdown

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -2,6 +2,7 @@
 package api
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -312,6 +313,23 @@ func (api *RelayAPI) StartServer() (err error) {
 		return nil
 	}
 	return err
+}
+
+// StopServer disables sending any bids on getHeader calls, waits a few seconds to catch any remaining getPayload call, and then shuts down the webserver
+func (api *RelayAPI) StopServer() (err error) {
+	api.log.Info("Stopping server...")
+
+	if api.opts.ProposerAPI {
+		// stop sending bids
+		api.ffForceGetHeader204 = true
+		api.log.Info("Disabled sending bids, waiting a few seconds...")
+
+		// wait a few seconds, for any pending getPayload call to complete
+		time.Sleep(5 * time.Second)
+	}
+
+	// shutdown
+	return api.srv.Shutdown(context.Background())
 }
 
 // startActiveValidatorProcessor keeps listening on the channel and saving active validators to redis


### PR DESCRIPTION
## 📝 Summary

Graceful shutdown of proposer API:
1. don't return any more bids at `getHeader` calls
2. wait 5 seconds for any pending `getPayload` call to finish
3. shut down the server

This hopefully eliminates a timing issue when the relay is shutting down between a legitimate getHeader and getPayload request, making it not return the payload when asked for it.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
