### PR TITLE
[WIP] data-api to export active validators with pubkey -- NEEDS DISCUSSION

### DIFF
--- a/database/mockdb.go
+++ b/database/mockdb.go
@@ -20,7 +20,15 @@ func (db MockDB) GetValidatorRegistrationsForPubkeys(pubkeys []string) (entries 
 	return nil, nil
 }
 
-func (db MockDB) GetLatestValidatorRegistrations(timestampOnly bool) ([]*ValidatorRegistrationEntry, error) {
+func (db MockDB) GetLatestValidatorRegistrations() (registrations []*ValidatorRegistrationEntry, err error) {
+	return nil, nil
+}
+
+func (db MockDB) GetLatestValidatorRegistrationsOnlyTimestamp() (registrations []*ValidatorRegistrationEntry, err error) {
+	return nil, nil
+}
+
+func (db MockDB) GetLatestValidatorRegistrationsOnlyFeeRecipient() (registrations []*ValidatorRegistrationEntry, err error) {
 	return nil, nil
 }
 

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -310,7 +310,7 @@ func (hk *Housekeeper) updateProposerDuties(headSlot uint64) {
 
 // updateValidatorRegistrationsInRedis saves all latest validator registrations from the database to Redis
 func (hk *Housekeeper) updateValidatorRegistrationsInRedis() {
-	regs, err := hk.db.GetLatestValidatorRegistrations(true)
+	regs, err := hk.db.GetLatestValidatorRegistrationsOnlyTimestamp()
 	if err != nil {
 		hk.log.WithError(err).Error("failed to get latest validator registrations")
 		return

--- a/services/website/website.go
+++ b/services/website/website.go
@@ -265,6 +265,6 @@ func (srv *Webserver) handleRoot(w http.ResponseWriter, req *http.Request) {
 		_, err = w.Write(*srv.htmlDefault)
 	}
 	if err != nil {
-		srv.log.WithError(err).Error("error writing template")
+		srv.log.WithError(err).Error("error responding to root request")
 	}
 }


### PR DESCRIPTION
## 📝 Summary

New data API: `/relay/v1/data/active_validators`

Exports a list of all active validators, combined with their latest registered feeRecipient

Deployed on Sepolia: https://boost-relay-sepolia.flashbots.net/relay/v1/data/active_validators

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
