### PR TITLE
tool cmd to export api data

### DIFF
--- a/cmd/tool.go
+++ b/cmd/tool.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/flashbots/mev-boost-relay/common"
+	"github.com/flashbots/mev-boost-relay/database"
+	"github.com/spf13/cobra"
+)
+
+var (
+	toolOutfile string
+	idFirst     uint64
+	idLast      uint64
+	dateStart   string
+	dateEnd     string
+)
+
+func init() {
+	toolDataAPIExportPayloads.Flags().StringVar(&toolOutfile, "out", "", "output filename")
+	toolDataAPIExportPayloads.Flags().StringVar(&postgresDSN, "db", defaultPostgresDSN, "PostgreSQL DSN")
+	toolDataAPIExportPayloads.Flags().Uint64Var(&idFirst, "id-from", 0, "start id (inclusive")
+	toolDataAPIExportPayloads.Flags().Uint64Var(&idLast, "id-to", 0, "end id (inclusive)")
+	toolDataAPIExportPayloads.Flags().StringVar(&dateStart, "date-start", "", "start date (inclusive)")
+	toolDataAPIExportPayloads.Flags().StringVar(&dateEnd, "date-end", "", "end date (exclusive)")
+	_ = toolDataAPIExportPayloads.MarkFlagRequired("out")
+
+	toolCmd.AddCommand(toolDataAPIExportPayloads)
+	rootCmd.AddCommand(toolCmd)
+}
+
+var log = common.LogSetup(false, "info")
+
+var toolCmd = &cobra.Command{
+	Use: "tool",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Error: please use a valid subcommand")
+		_ = cmd.Help()
+	},
+}
+
+var toolDataAPIExportPayloads = &cobra.Command{
+	Use: "data-api-export-payloads",
+	Run: func(cmd *cobra.Command, args []string) {
+		if toolOutfile == "" {
+			log.Fatal("no output file specified")
+		}
+		log.Infof("exporting data-api payloads to %s", toolOutfile)
+
+		if (idFirst == 0 && dateStart == "") || (idLast == 0 && dateEnd == "") {
+			log.Fatal("must specify start and end id or date")
+		}
+
+		// Connect to Postgres
+		dbURL, err := url.Parse(postgresDSN)
+		if err != nil {
+			log.WithError(err).Fatalf("couldn't read db URL")
+		}
+		log.Infof("Connecting to Postgres database at %s%s ...", dbURL.Host, dbURL.Path)
+		db, err := database.NewDatabaseService(postgresDSN)
+		if err != nil {
+			log.WithError(err).Fatalf("Failed to connect to Postgres database at %s%s", dbURL.Host, dbURL.Path)
+		}
+
+		// if date, then find corresponding id
+		if dateStart != "" {
+			// find first enrty at or after dateStart
+			query := `SELECT id FROM ` + database.TableDeliveredPayload + ` WHERE inserted_at::date >= date '` + dateStart + `' ORDER BY id ASC LIMIT 1;`
+			err = db.DB.QueryRow(query).Scan(&idFirst)
+			if err != nil {
+				log.WithError(err).Fatalf("failed to find start id for date %s", dateStart)
+			}
+		}
+		if dateEnd != "" {
+			// find last enry before dateEnd
+			query := `SELECT id FROM ` + database.TableDeliveredPayload + ` WHERE inserted_at::date < date '` + dateEnd + `' ORDER BY id DESC LIMIT 1;`
+			err = db.DB.QueryRow(query).Scan(&idLast)
+			if err != nil {
+				log.WithError(err).Fatalf("failed to find end id for date %s", dateEnd)
+			}
+		}
+		log.Infof("exporting ids %d to %d", idFirst, idLast)
+
+		deliveredPayloads, err := db.GetDeliveredPayloads(idFirst, idLast)
+		if err != nil {
+			log.WithError(err).Fatal("error getting recent payloads")
+		}
+
+		log.Infof("got %d payloads", len(deliveredPayloads))
+		entries := make([]common.BidTraceJSON, len(deliveredPayloads))
+		for i, payload := range deliveredPayloads {
+			entries[i] = database.DeliveredPayloadEntryToBidTraceJSON(payload)
+		}
+
+		if len(entries) == 0 {
+			return
+		}
+
+		f, err := os.Create(toolOutfile)
+		if err != nil {
+			log.WithError(err).Fatal("failed to open file")
+		}
+		defer f.Close()
+
+		if strings.HasSuffix(toolOutfile, ".csv") {
+			// write CSV
+			w := csv.NewWriter(f)
+			defer w.Flush()
+			if err := w.Write(entries[0].CSVHeader()); err != nil {
+				log.WithError(err).Fatal("error writing record to file")
+			}
+			for _, record := range entries {
+				if err := w.Write(record.ToCSVRecord()); err != nil {
+					log.WithError(err).Fatal("error writing record to file")
+				}
+			}
+		} else {
+			// write JSON
+			encoder := json.NewEncoder(f)
+			err = encoder.Encode(entries)
+			if err != nil {
+				log.WithError(err).Fatal("failed to write json to file")
+			}
+		}
+		log.Infof("Wrote %d entries to %s", len(entries), toolOutfile)
+	},
+}

--- a/common/types.go
+++ b/common/types.go
@@ -170,3 +170,49 @@ type SlotSummary struct {
 	NumPayloadSent        uint64 `json:"num_payload_sent"         db:"num_payload_sent"`
 	NumBuilderBidReceived uint64 `json:"num_builder_bid_received" db:"num_builder_bid_received"`
 }
+
+type BidTraceJSON struct {
+	Slot                 uint64 `json:"slot,string"`
+	ParentHash           string `json:"parent_hash"`
+	BlockHash            string `json:"block_hash"`
+	BuilderPubkey        string `json:"builder_pubkey"`
+	ProposerPubkey       string `json:"proposer_pubkey"`
+	ProposerFeeRecipient string `json:"proposer_fee_recipient"`
+	GasLimit             uint64 `json:"gas_limit,string"`
+	GasUsed              uint64 `json:"gas_used,string"`
+	Value                string `json:"value"`
+}
+
+func (b *BidTraceJSON) CSVHeader() []string {
+	return []string{
+		"slot",
+		"parent_hash",
+		"block_hash",
+		"builder_pubkey",
+		"proposer_pubkey",
+		"proposer_fee_recipient",
+		"gas_limit",
+		"gas_used",
+		"value",
+	}
+}
+
+func (b *BidTraceJSON) ToCSVRecord() []string {
+	return []string{
+		fmt.Sprint(b.Slot),
+		b.ParentHash,
+		b.BlockHash,
+		b.BuilderPubkey,
+		b.ProposerPubkey,
+		b.ProposerFeeRecipient,
+		fmt.Sprint(b.GasLimit),
+		fmt.Sprint(b.GasUsed),
+		b.Value,
+	}
+}
+
+type BidTraceWithTimestampJSON struct {
+	BidTraceJSON
+
+	Timestamp int64 `json:"timestamp,string,omitempty"`
+}

--- a/database/mockdb.go
+++ b/database/mockdb.go
@@ -44,6 +44,10 @@ func (db MockDB) GetRecentDeliveredPayloads(filters GetPayloadsFilters) ([]*Deli
 	return nil, nil
 }
 
+func (db MockDB) GetDeliveredPayloads(idFirst, idLast uint64) (entries []*DeliveredPayloadEntry, err error) {
+	return nil, nil
+}
+
 func (db MockDB) GetNumDeliveredPayloads() (uint64, error) {
 	return 0, nil
 }

--- a/database/typesconv.go
+++ b/database/typesconv.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/flashbots/go-boost-utils/types"
+	"github.com/flashbots/mev-boost-relay/common"
 )
 
 func PayloadToExecPayloadEntry(payload *types.BuilderSubmitBlockRequest) (*ExecutionPayloadEntry, error) {
@@ -20,4 +21,35 @@ func PayloadToExecPayloadEntry(payload *types.BuilderSubmitBlockRequest) (*Execu
 		Version: "bellatrix",
 		Payload: string(_payload),
 	}, nil
+}
+
+func DeliveredPayloadEntryToBidTraceJSON(payload *DeliveredPayloadEntry) common.BidTraceJSON {
+	return common.BidTraceJSON{
+		Slot:                 payload.Slot,
+		ParentHash:           payload.ParentHash,
+		BlockHash:            payload.BlockHash,
+		BuilderPubkey:        payload.BuilderPubkey,
+		ProposerPubkey:       payload.ProposerPubkey,
+		ProposerFeeRecipient: payload.ProposerFeeRecipient,
+		GasLimit:             payload.GasLimit,
+		GasUsed:              payload.GasUsed,
+		Value:                payload.Value,
+	}
+}
+
+func BuilderSubmissionEntryToBidTraceWithTimestampJSON(payload *BuilderBlockSubmissionEntry) common.BidTraceWithTimestampJSON {
+	return common.BidTraceWithTimestampJSON{
+		Timestamp: payload.InsertedAt.Unix(),
+		BidTraceJSON: common.BidTraceJSON{
+			Slot:                 payload.Slot,
+			ParentHash:           payload.ParentHash,
+			BlockHash:            payload.BlockHash,
+			BuilderPubkey:        payload.BuilderPubkey,
+			ProposerPubkey:       payload.ProposerPubkey,
+			ProposerFeeRecipient: payload.ProposerFeeRecipient,
+			GasLimit:             payload.GasLimit,
+			GasUsed:              payload.GasUsed,
+			Value:                payload.Value,
+		},
+	}
 }

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1057,20 +1057,9 @@ func (api *RelayAPI) handleDataProposerPayloadDelivered(w http.ResponseWriter, r
 		return
 	}
 
-	response := []BidTraceJSON{}
-	for _, payload := range deliveredPayloads {
-		trace := BidTraceJSON{
-			Slot:                 payload.Slot,
-			ParentHash:           payload.ParentHash,
-			BlockHash:            payload.BlockHash,
-			BuilderPubkey:        payload.BuilderPubkey,
-			ProposerPubkey:       payload.ProposerPubkey,
-			ProposerFeeRecipient: payload.ProposerFeeRecipient,
-			GasLimit:             payload.GasLimit,
-			GasUsed:              payload.GasUsed,
-			Value:                payload.Value,
-		}
-		response = append(response, trace)
+	response := make([]common.BidTraceJSON, len(deliveredPayloads))
+	for i, payload := range deliveredPayloads {
+		response[i] = database.DeliveredPayloadEntryToBidTraceJSON(payload)
 	}
 
 	api.RespondOK(w, response)
@@ -1143,30 +1132,16 @@ func (api *RelayAPI) handleDataBuilderBidsReceived(w http.ResponseWriter, req *h
 		filters.Limit = _limit
 	}
 
-	deliveredPayloads, err := api.db.GetBuilderSubmissions(filters)
+	blockSubmissions, err := api.db.GetBuilderSubmissions(filters)
 	if err != nil {
 		api.log.WithError(err).Error("error getting recent payloads")
 		api.RespondError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	response := []BidTraceWithTimestampJSON{}
-	for _, payload := range deliveredPayloads {
-		trace := BidTraceWithTimestampJSON{
-			Timestamp: payload.InsertedAt.Unix(),
-			BidTraceJSON: BidTraceJSON{
-				Slot:                 payload.Slot,
-				ParentHash:           payload.ParentHash,
-				BlockHash:            payload.BlockHash,
-				BuilderPubkey:        payload.BuilderPubkey,
-				ProposerPubkey:       payload.ProposerPubkey,
-				ProposerFeeRecipient: payload.ProposerFeeRecipient,
-				GasLimit:             payload.GasLimit,
-				GasUsed:              payload.GasUsed,
-				Value:                payload.Value,
-			},
-		}
-		response = append(response, trace)
+	response := make([]common.BidTraceWithTimestampJSON, len(blockSubmissions))
+	for i, payload := range blockSubmissions {
+		response[i] = database.BuilderSubmissionEntryToBidTraceWithTimestampJSON(payload)
 	}
 
 	api.RespondOK(w, response)

--- a/services/api/types.go
+++ b/services/api/types.go
@@ -54,24 +54,6 @@ func BuilderSubmitBlockRequestToSignedBuilderBid(req *types.BuilderSubmitBlockRe
 	}, nil
 }
 
-type BidTraceJSON struct {
-	Slot                 uint64 `json:"slot,string"`
-	ParentHash           string `json:"parent_hash"`
-	BlockHash            string `json:"block_hash"`
-	BuilderPubkey        string `json:"builder_pubkey"`
-	ProposerPubkey       string `json:"proposer_pubkey"`
-	ProposerFeeRecipient string `json:"proposer_fee_recipient"`
-	GasLimit             uint64 `json:"gas_limit,string"`
-	GasUsed              uint64 `json:"gas_used,string"`
-	Value                string `json:"value"`
-}
-
-type BidTraceWithTimestampJSON struct {
-	BidTraceJSON
-
-	Timestamp int64 `json:"timestamp,string,omitempty"`
-}
-
 func SignedBlindedBeaconBlockToBeaconBlock(signedBlindedBeaconBlock *types.SignedBlindedBeaconBlock, executionPayload *types.ExecutionPayload) *types.SignedBeaconBlock {
 	return &types.SignedBeaconBlock{
 		Signature: signedBlindedBeaconBlock.Signature,


### PR DESCRIPTION
## 📝 Summary

Added a `tool` command to export data-api entries. Starting with delivered payloads.

Weekly data dumps are now available at: https://boost-relay-data-public.s3.us-east-2.amazonaws.com/index.html

TODO:
* consider dates instead of `slotStart` and `slotEnd`
* also export builder-block-submission entries

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
