### PR TITLE
save new block to redis: first payload then header

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `DISABLE_BLOCK_PUBLISHING` - disable publishing blocks to the beacon node at the end of getPayload
 * `DISABLE_LOWPRIO_BUILDERS` - reject block submissions by low-prio builders
 * `DISABLE_BID_MEMORY_CACHE` - disable bids to go through in-memory cache. forces to go through redis/db
-* `DISABLE_BID_REDIS_CACHE` - disable bids to go through redis cache. forces to go through memory/db
 * `NUM_ACTIVE_VALIDATOR_PROCESSORS` - proposer API - number of goroutines to listen to the active validators channel
 * `ACTIVE_VALIDATOR_HOURS` - number of hours to track active proposers in redis
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -691,13 +691,13 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 	// note that mev-boost might send getPayload for bids of other relays, thus this code wouldn't find anything
 	getPayloadResp, err := api.datastore.GetGetPayloadResponse(slot, proposerPubkey.String(), blockHash.String())
 	if err != nil {
-		log.WithError(err).Error("failed getting execution payload from db")
+		log.WithError(err).Error("failed getting execution payload")
 		api.RespondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
 	if getPayloadResp == nil {
-		log.Info("failed getting execution payload")
+		log.Warn("failed getting execution payload")
 		api.RespondError(w, http.StatusBadRequest, "no execution payload for this request")
 		return
 	}


### PR DESCRIPTION
## 📝 Summary

There could be a race condition, where getHeader information is already in redis, but not the payload. This PR saves the payload first and only then the header information!

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
