### PR TITLE
Fast JSON decoding with jsonparser (for registerValidator)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alicebob/miniredis/v2 v2.23.0
+	github.com/buger/jsonparser v1.1.1
 	github.com/ethereum/go-ethereum v1.10.25
 	github.com/flashbots/go-boost-utils v1.2.0
 	github.com/flashbots/go-utils v0.4.8

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku
 github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=


### PR DESCRIPTION
## 📝 Summary

Decoding of the JSON payload is a bottleneck.

This PR uses https://github.com/buger/jsonparser for really fast decoding. In a first step in registerValidator.

This is not applicable to getPayload, because we always need to decode the full object for validating the signature.

---

This change helped us process even the slowest / largest registerValidator call in under the 3 seconds request timeout: 
![Screenshot 2022-10-08 at 15 22 07](https://user-images.githubusercontent.com/116939/194709701-f10a20a7-2baa-4585-bb54-8f4500900a02.png)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
