### PR TITLE
Data API: BidTraceV2 (with num_tx + block_number)

### DIFF
--- a/cmd/tool.go
+++ b/cmd/tool.go
@@ -92,9 +92,9 @@ var toolDataAPIExportPayloads = &cobra.Command{
 		}
 
 		log.Infof("got %d payloads", len(deliveredPayloads))
-		entries := make([]common.BidTraceJSON, len(deliveredPayloads))
+		entries := make([]common.BidTraceV2JSON, len(deliveredPayloads))
 		for i, payload := range deliveredPayloads {
-			entries[i] = database.DeliveredPayloadEntryToBidTraceJSON(payload)
+			entries[i] = database.DeliveredPayloadEntryToBidTraceV2JSON(payload)
 		}
 
 		if len(entries) == 0 {

--- a/common/types.go
+++ b/common/types.go
@@ -115,63 +115,13 @@ func NewEthNetworkDetails(networkName string) (ret *EthNetworkDetails, err error
 	}, nil
 }
 
-type EpochSummary struct {
-	Epoch uint64 `json:"epoch" db:"epoch"`
-
-	// First and last slots are just derived from the epoch
-	SlotFirst uint64 `json:"slot_first" db:"slot_first"`
-	SlotLast  uint64 `json:"slot_last"  db:"slot_last"`
-
-	// Registered are those that were actually used by the relay (some might be skipped if only one relay and it started in the middle of the epoch)
-	SlotFirstProcessed uint64 `json:"slot_first_processed" db:"slot_first_processed"`
-	SlotLastProcessed  uint64 `json:"slot_last_processed"  db:"slot_last_processed"`
-
-	// Validator stats
-	ValidatorsKnownTotal                     uint64 `json:"validators_known_total"                      db:"validators_known_total"`
-	ValidatorRegistrationsTotal              uint64 `json:"validator_registrations_total"               db:"validator_registrations_total"`
-	ValidatorRegistrationsSaved              uint64 `json:"validator_registrations_saved"               db:"validator_registrations_saved"`
-	ValidatorRegistrationsReceivedUnverified uint64 `json:"validator_registrations_received_unverified" db:"validator_registrations_received_unverified"`
-
-	// The number of requests are the count of all requests to a specific path, even invalid ones
-	NumRegisterValidatorRequests uint64 `json:"num_register_validator_requests" db:"num_register_validator_requests"`
-	NumGetHeaderRequests         uint64 `json:"num_get_header_requests"         db:"num_get_header_requests"`
-	NumGetPayloadRequests        uint64 `json:"num_get_payload_requests"        db:"num_get_payload_requests"`
-
-	// Responses to successful queries
-	NumHeaderSentOk       uint64 `json:"num_header_sent_ok"       db:"num_header_sent_ok"`
-	NumHeaderSent204      uint64 `json:"num_header_sent_204"      db:"num_header_sent_204"`
-	NumPayloadSent        uint64 `json:"num_payload_sent"         db:"num_payload_sent"`
-	NumBuilderBidReceived uint64 `json:"num_builder_bid_received" db:"num_builder_bid_received"`
-
-	// Whether all slots were seen
-	IsComplete bool `json:"is_complete" db:"is_complete"`
+type BidTraceV2 struct {
+	types.BidTrace
+	BlockNumber uint64 `json:"block_number,string" db:"block_number"`
+	NumTx       uint64 `json:"num_tx,string" db:"num_tx"`
 }
 
-type SlotSummary struct {
-	Slot   uint64 `json:"slot"   db:"slot"`
-	Epoch  uint64 `json:"epoch"  db:"epoch"`
-	Missed bool   `json:"missed" db:"missed"`
-
-	// General validator stats
-	ValidatorsKnownTotal        uint64 `json:"validators_known_total"        db:"validators_known_total"`
-	ValidatorRegistrationsTotal uint64 `json:"validator_registrations_total" db:"validator_registrations_total"`
-
-	// Slot proposer details
-	ProposerPubkey       string `json:"proposer_pubkey"        db:"proposer_pubkey"`
-	ProposerIsRegistered bool   `json:"proposer_is_registered" db:"proposer_is_registered"`
-
-	// The number of requests are the count of all requests to a specific path, even invalid ones
-	NumGetHeaderRequests  uint64 `json:"num_get_header_requests"  db:"num_get_header_requests"`
-	NumGetPayloadRequests uint64 `json:"num_get_payload_requests" db:"num_get_payload_requests"`
-
-	// Responses to successful queries
-	NumHeaderSentOk       uint64 `json:"num_header_sent_ok"       db:"num_header_sent_ok"`
-	NumHeaderSent204      uint64 `json:"num_header_sent_204"      db:"num_header_sent_204"`
-	NumPayloadSent        uint64 `json:"num_payload_sent"         db:"num_payload_sent"`
-	NumBuilderBidReceived uint64 `json:"num_builder_bid_received" db:"num_builder_bid_received"`
-}
-
-type BidTraceJSON struct {
+type BidTraceV2JSON struct {
 	Slot                 uint64 `json:"slot,string"`
 	ParentHash           string `json:"parent_hash"`
 	BlockHash            string `json:"block_hash"`
@@ -181,9 +131,11 @@ type BidTraceJSON struct {
 	GasLimit             uint64 `json:"gas_limit,string"`
 	GasUsed              uint64 `json:"gas_used,string"`
 	Value                string `json:"value"`
+	NumTx                uint64 `json:"num_tx,string"`
+	BlockNumber          uint64 `json:"block_number,string"`
 }
 
-func (b *BidTraceJSON) CSVHeader() []string {
+func (b *BidTraceV2JSON) CSVHeader() []string {
 	return []string{
 		"slot",
 		"parent_hash",
@@ -194,10 +146,12 @@ func (b *BidTraceJSON) CSVHeader() []string {
 		"gas_limit",
 		"gas_used",
 		"value",
+		"num_tx",
+		"block_number",
 	}
 }
 
-func (b *BidTraceJSON) ToCSVRecord() []string {
+func (b *BidTraceV2JSON) ToCSVRecord() []string {
 	return []string{
 		fmt.Sprint(b.Slot),
 		b.ParentHash,
@@ -208,17 +162,12 @@ func (b *BidTraceJSON) ToCSVRecord() []string {
 		fmt.Sprint(b.GasLimit),
 		fmt.Sprint(b.GasUsed),
 		b.Value,
+		fmt.Sprint(b.NumTx),
+		fmt.Sprint(b.BlockNumber),
 	}
 }
 
-type BidTraceWithTimestampJSON struct {
-	BidTraceJSON
-
+type BidTraceV2WithTimestampJSON struct {
+	BidTraceV2JSON
 	Timestamp int64 `json:"timestamp,string,omitempty"`
-}
-
-type BidTraceV2 struct {
-	types.BidTrace
-	BlockNumber uint64 `json:"block_number,string" db:"block_number"`
-	NumTx       uint64 `json:"num_tx,string" db:"num_tx"`
 }

--- a/database/typesconv.go
+++ b/database/typesconv.go
@@ -23,8 +23,8 @@ func PayloadToExecPayloadEntry(payload *types.BuilderSubmitBlockRequest) (*Execu
 	}, nil
 }
 
-func DeliveredPayloadEntryToBidTraceJSON(payload *DeliveredPayloadEntry) common.BidTraceJSON {
-	return common.BidTraceJSON{
+func DeliveredPayloadEntryToBidTraceV2JSON(payload *DeliveredPayloadEntry) common.BidTraceV2JSON {
+	return common.BidTraceV2JSON{
 		Slot:                 payload.Slot,
 		ParentHash:           payload.ParentHash,
 		BlockHash:            payload.BlockHash,
@@ -34,13 +34,15 @@ func DeliveredPayloadEntryToBidTraceJSON(payload *DeliveredPayloadEntry) common.
 		GasLimit:             payload.GasLimit,
 		GasUsed:              payload.GasUsed,
 		Value:                payload.Value,
+		NumTx:                payload.NumTx,
+		BlockNumber:          payload.BlockNumber,
 	}
 }
 
-func BuilderSubmissionEntryToBidTraceWithTimestampJSON(payload *BuilderBlockSubmissionEntry) common.BidTraceWithTimestampJSON {
-	return common.BidTraceWithTimestampJSON{
+func BuilderSubmissionEntryToBidTraceV2WithTimestampJSON(payload *BuilderBlockSubmissionEntry) common.BidTraceV2WithTimestampJSON {
+	return common.BidTraceV2WithTimestampJSON{
 		Timestamp: payload.InsertedAt.Unix(),
-		BidTraceJSON: common.BidTraceJSON{
+		BidTraceV2JSON: common.BidTraceV2JSON{
 			Slot:                 payload.Slot,
 			ParentHash:           payload.ParentHash,
 			BlockHash:            payload.BlockHash,
@@ -50,6 +52,8 @@ func BuilderSubmissionEntryToBidTraceWithTimestampJSON(payload *BuilderBlockSubm
 			GasLimit:             payload.GasLimit,
 			GasUsed:              payload.GasUsed,
 			Value:                payload.Value,
+			NumTx:                payload.NumTx,
+			BlockNumber:          payload.BlockNumber,
 		},
 	}
 }

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1141,9 +1141,9 @@ func (api *RelayAPI) handleDataProposerPayloadDelivered(w http.ResponseWriter, r
 		return
 	}
 
-	response := make([]common.BidTraceJSON, len(deliveredPayloads))
+	response := make([]common.BidTraceV2JSON, len(deliveredPayloads))
 	for i, payload := range deliveredPayloads {
-		response[i] = database.DeliveredPayloadEntryToBidTraceJSON(payload)
+		response[i] = database.DeliveredPayloadEntryToBidTraceV2JSON(payload)
 	}
 
 	api.RespondOK(w, response)
@@ -1223,9 +1223,9 @@ func (api *RelayAPI) handleDataBuilderBidsReceived(w http.ResponseWriter, req *h
 		return
 	}
 
-	response := make([]common.BidTraceWithTimestampJSON, len(blockSubmissions))
+	response := make([]common.BidTraceV2WithTimestampJSON, len(blockSubmissions))
 	for i, payload := range blockSubmissions {
-		response[i] = database.BuilderSubmissionEntryToBidTraceWithTimestampJSON(payload)
+		response[i] = database.BuilderSubmissionEntryToBidTraceV2WithTimestampJSON(payload)
 	}
 
 	api.RespondOK(w, response)


### PR DESCRIPTION
## 📝 Summary

Exposes BidTraceV2 on the Data API, which includes `num_tx` and `block_number`

Example: https://boost-relay-sepolia.flashbots.net/relay/v1/data/bidtraces/proposer_payload_delivered?slot=829403

```json
[
    {
        "slot": "829403",
        "parent_hash": "0x985d53dece2acadab4e38d14656e586b16c6d6af47f0b4237831857f0eb6e287",
        "block_hash": "0x493c2f4aac3e7a33b513e5b6202e2f37bfae6604f1f9ed33af4b590de211a102",
        "builder_pubkey": "0x845bd072b7cd566f02faeb0a4033ce9399e42839ced64e8b2adcfc859ed1e8e1a5a293336a49feac6d9a5edb779be53a",
        "proposer_pubkey": "0xab6b47627cf76d9552c723818db5ebee7734542436b50ffe15b3a96e8e7a6b54f9a0965de78405e16e309193f147108d",
        "proposer_fee_recipient": "0x1268ad189526ac0b386faf06effc46779c340ee6",
        "gas_limit": "30000000",
        "gas_used": "218576",
        "value": "942436999118000",
        "num_tx": "8",
        "block_number": "2081196"
    }
]
```

Closes #193 

See also https://collective.flashbots.net/t/relays-data-apis-bidtracev2-which-includes-num-tx-and-block-number/527

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
