### PR TITLE
more logging on db errors

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -327,7 +327,7 @@ func (s *DatabaseService) GetDeliveredPayloads(idFirst, idLast uint64) (entries 
 	query := `SELECT id, inserted_at, slot, epoch, builder_pubkey, proposer_pubkey, proposer_fee_recipient, parent_hash, block_hash, block_number, num_tx, value, gas_used, gas_limit
 	FROM ` + TableDeliveredPayload + `
 	WHERE id >= $1 AND id <= $2
-	ORDER BY id ASC`
+	ORDER BY slot ASC`
 
 	err = s.DB.Select(&entries, query, idFirst, idLast)
 	return entries, err

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -789,7 +789,7 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 
 		err = api.db.SaveDeliveredPayload(bidTrace, payload)
 		if err != nil {
-			log.WithError(err).Error("failed to save delivered payload")
+			log.WithError(err).WithField("bidTrace", bidTrace).Error("failed to save delivered payload")
 		}
 
 		// Increment builder stats
@@ -821,7 +821,10 @@ func (api *RelayAPI) handleBuilderGetValidators(w http.ResponseWriter, req *http
 }
 
 func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Request) {
-	log := api.log.WithField("method", "submitNewBlock")
+	log := api.log.WithFields(logrus.Fields{
+		"method":        "submitNewBlock",
+		"contentLength": req.ContentLength,
+	})
 
 	payload := new(types.BuilderSubmitBlockRequest)
 	if err := json.NewDecoder(req.Body).Decode(payload); err != nil {
@@ -919,7 +922,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	defer func() {
 		submissionEntry, err := api.db.SaveBuilderBlockSubmission(payload, simErr, isMostProfitableBlock)
 		if err != nil {
-			log.WithError(err).Error("saving builder block submission to database failed")
+			log.WithError(err).WithField("bidTrace", payload.Message).Error("saving builder block submission to database failed")
 			return
 		}
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -789,7 +789,10 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 
 		err = api.db.SaveDeliveredPayload(bidTrace, payload)
 		if err != nil {
-			log.WithError(err).WithField("bidTrace", bidTrace).Error("failed to save delivered payload")
+			log.WithError(err).WithFields(logrus.Fields{
+				"bidTrace": bidTrace,
+				"payload":  payload,
+			}).Error("failed to save delivered payload")
 		}
 
 		// Increment builder stats
@@ -910,7 +913,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	// Verify the signature
 	ok, err := types.VerifySignature(payload.Message, api.opts.EthNetDetails.DomainBuilder, payload.Message.BuilderPubkey[:], payload.Signature[:])
 	if !ok || err != nil {
-		log.WithError(err).Warnf("could not verify builder signature")
+		log.WithError(err).Warn("could not verify builder signature")
 		api.RespondError(w, http.StatusBadRequest, "invalid signature")
 		return
 	}
@@ -922,7 +925,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	defer func() {
 		submissionEntry, err := api.db.SaveBuilderBlockSubmission(payload, simErr, isMostProfitableBlock)
 		if err != nil {
-			log.WithError(err).WithField("bidTrace", payload.Message).Error("saving builder block submission to database failed")
+			log.WithError(err).WithField("payload", payload).Error("saving builder block submission to database failed")
 			return
 		}
 
@@ -937,6 +940,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	simErr = api.blockSimRateLimiter.send(req.Context(), payload, builderIsHighPrio)
 
 	if simErr != nil {
+		log = log.WithField("simErr", simErr.Error())
 		log.WithError(simErr).WithFields(logrus.Fields{
 			"duration":   time.Since(t).Seconds(),
 			"numWaiting": api.blockSimRateLimiter.currentCounter(),


### PR DESCRIPTION
## 📝 Summary

This will allow to backfill delivered payloads from the logs if saving delivered payloads to database failed (i.e. in case of a database downtime or restart)

## ⛱ Motivation and Context

On 2022-10-14 6:14am UTC, Amazon recreated our database, which made the relay unable to save some delivered payloads to the database (after they were successfully delivered).

These are the affected payloads:

------------------------------------------------------------------------------------------------------------------------
|       @timestamp        |  slot   |                             blockHash                              | blockNumber |
|-------------------------|---------|--------------------------------------------------------------------|-------------|
| 2022-10-14 06:21:00.038 | 4908669 | 0xf1ad5ff6bf1cf3de0bbba4d95c796a602650e62a518fe48c91479bd83d5b5a5f | 15744489    |
| 2022-10-14 06:21:01.902 | 4908639 | 0x7009681c683d3a6e5e6d7f26940cc5f58ccab72b8e7b3879add7d1da4cc24571 | 15744459    |
| 2022-10-14 06:21:06.254 | 4908667 | 0x69800f5588cefe1d1d28f84e9fb5e7299a0c0c737cae07d0dd2a2ea6eee848b2 | 15744487    |
| 2022-10-14 06:21:06.438 | 4908662 | 0xdab75c4b0904601918e9794ab2b25b1abe29fc05e9fb74b057a865134870d884 | 15744482    |
| 2022-10-14 06:21:06.510 | 4908657 | 0xddece5d1f73058f699e0dc3778b9086536af71302b979ecd0c8235d09f12a686 | 15744477    |
| 2022-10-14 06:21:07.022 | 4908652 | 0xf6fb5e8286b310addcd56aafd456cb712c1dff66aa15be8181c5d3806899b22c | 15744472    |
| 2022-10-14 06:21:07.974 | 4908642 | 0x34ecbd24c0446b706dc3337e4c6a7249cd776b1ef644f71858d56690972e95f7 | 15744462    |
| 2022-10-14 06:21:10.534 | 4908646 | 0x831853027b6f6b508f27d85cf4d982ff728c3597fcd9c93e6f87020d693d33bb | 15744466    |
| 2022-10-14 06:21:10.538 | 4908651 | 0xf6529682f64b2e9652cd3e5ad6c53f615b55ba3ea77cd1570e810f6d9f283d33 | 15744471    |
| 2022-10-14 06:21:11.307 | 4908641 | 0xa5e81af249095b2e2677fee08e0b2a34d7df4f74b8516b8f1ec28807a179f35a | 15744461    |
| 2022-10-14 06:21:12.656 | 4908655 | 0xb99a55f5d0290521d9c490bbe46b3b342f32f2244f650272ae159b0c2819eff3 | 15744475    |
| 2022-10-14 06:21:13.350 | 4908650 | 0x4c0c8a88ab894c80606ec2208589567aa049b70e472b4a4c4a4b54683ccf480e | 15744470    |
| 2022-10-14 06:21:13.679 | 4908645 | 0x7667af92b2cd7ef09ccc774c6b53a748774cd74775cdf5abe85575ed0bd602dc | 15744465    |
------------------------------------------------------------------------------------------------------------------------

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
