### PR TITLE
Add Postgres and database tests to CI 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,8 +19,11 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
+      - name: Run Docker compose to spin up services
+        run: docker compose build && docker compose up -d db
+
       - name: Run unit tests and generate the coverage report
-        run: make test-coverage
+        run: RUN_DB_TESTS=1 make test-coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2


### PR DESCRIPTION
## 📝 Summary

Update GitHub Action workflow `Checks` to fix the issue https://github.com/flashbots/mev-boost-relay/issues/168

## ⛱ Motivation and Context

Due to the Postgres dependency, the tests for the database code were skipped. This PR increments testing coverage by enabling the database tests (`RUN_DB_TESTS=1`).
The docker-compose definition is used to spin up the Postgres service while keeping non-required services down. 

CI Before
```
ok  	github.com/flashbots/mev-boost-relay/database	0.050s	coverage: 0.0% of statements
```

CI After
```
ok  	github.com/flashbots/mev-boost-relay/database	0.143s	coverage: 10.1% of statements
```

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
