### PR TITLE
block submission cancellation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -100,3 +100,9 @@ linters-settings:
       - 'MockBeaconClient'
       - 'RelayAPI'
       - 'Webserver'
+
+issues:
+  exclude-rules:
+    - path: (.+)_test.go
+      linters:
+        - exhaustruct

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -164,3 +164,57 @@ func TestActiveValidators(t *testing.T) {
 	require.Equal(t, 1, len(vals))
 	require.True(t, vals[pk1])
 }
+
+func _buildGetHeaderResponse(value uint64) *types.GetHeaderResponse {
+	return &types.GetHeaderResponse{
+		Version: "bellatrix",
+		Data: &types.SignedBuilderBid{
+			Message: &types.BuilderBid{
+				Header: &types.ExecutionPayloadHeader{},
+				Value:  types.IntToU256(value),
+				Pubkey: types.PublicKey{0x01},
+			},
+			Signature: types.Signature{0x01},
+		},
+	}
+}
+
+func TestBuilderBids(t *testing.T) {
+	cache := setupTestRedis(t)
+
+	slot := uint64(123)
+	parentHash := "0xa1"
+	proposerPk := "0xa2"
+	builder1pk := "0xb1"
+	builder2pk := "0xb2"
+	builder3pk := "0xb3"
+
+	// 2 initial bids: 99 and 100 value
+	err := cache.SaveLatestBuilderBid(slot, builder1pk, parentHash, proposerPk, _buildGetHeaderResponse(100))
+	require.NoError(t, err)
+	err = cache.SaveLatestBuilderBid(slot, builder2pk, parentHash, proposerPk, _buildGetHeaderResponse(99))
+	require.NoError(t, err)
+	err = cache.UpdateTopBid(slot, parentHash, proposerPk)
+	require.NoError(t, err)
+	topBid, err := cache.GetBestBid(slot, parentHash, proposerPk)
+	require.NoError(t, err)
+	require.Equal(t, "100", topBid.Data.Message.Value.String())
+
+	// new top bid by builder3: 101
+	err = cache.SaveLatestBuilderBid(slot, builder3pk, parentHash, proposerPk, _buildGetHeaderResponse(101))
+	require.NoError(t, err)
+	err = cache.UpdateTopBid(slot, parentHash, proposerPk)
+	require.NoError(t, err)
+	topBid, err = cache.GetBestBid(slot, parentHash, proposerPk)
+	require.NoError(t, err)
+	require.Equal(t, "101", topBid.Data.Message.Value.String())
+
+	// builder3 cancels 101 bid, by sending 100 value
+	err = cache.SaveLatestBuilderBid(slot, builder3pk, parentHash, proposerPk, _buildGetHeaderResponse(99))
+	require.NoError(t, err)
+	err = cache.UpdateTopBid(slot, parentHash, proposerPk)
+	require.NoError(t, err)
+	topBid, err = cache.GetBestBid(slot, parentHash, proposerPk)
+	require.NoError(t, err)
+	require.Equal(t, "100", topBid.Data.Message.Value.String())
+}


### PR DESCRIPTION
## 📝 Summary

Always use the latest block by a builder, even if less profitable. Allows a builder to cancel/override any previous submission with a new one.

Now forces all bids to go through redis (removed in-memory cache) to reduce code complexity by a lot. In practice, builder API and proposer API are deployed separately anyway.

Closes #202 and closes #51

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
