### PR TITLE
add millisecond timestamp to builder bids

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -169,5 +169,6 @@ func (b *BidTraceV2JSON) ToCSVRecord() []string {
 
 type BidTraceV2WithTimestampJSON struct {
 	BidTraceV2JSON
-	Timestamp int64 `json:"timestamp,string,omitempty"`
+	Timestamp   int64 `json:"timestamp,string,omitempty"`
+	TimestampMs int64 `json:"timestamp_ms,string,omitempty"`
 }

--- a/database/typesconv.go
+++ b/database/typesconv.go
@@ -41,7 +41,8 @@ func DeliveredPayloadEntryToBidTraceV2JSON(payload *DeliveredPayloadEntry) commo
 
 func BuilderSubmissionEntryToBidTraceV2WithTimestampJSON(payload *BuilderBlockSubmissionEntry) common.BidTraceV2WithTimestampJSON {
 	return common.BidTraceV2WithTimestampJSON{
-		Timestamp: payload.InsertedAt.Unix(),
+		Timestamp:   payload.InsertedAt.Unix(),
+		TimestampMs: payload.InsertedAt.UnixMilli(),
 		BidTraceV2JSON: common.BidTraceV2JSON{
 			Slot:                 payload.Slot,
 			ParentHash:           payload.ParentHash,


### PR DESCRIPTION
## 📝 Summary

Bid timestamps should include millisecond precision, since we allow multiple submissions per second.

This PR adds a `timestamp_ms` field to the bids data API:

```json
{
    "slot": "4153442",
    "parent_hash": "0x167c7f7c7b8f402a8f6a6e3364b2ce7f94e2e9322daa171995a9653f60628467",
    "block_hash": "0x52e8986bb0bb7a3d0985c109d00bae73ab490371cce46733391410fc6c113a60",
    "builder_pubkey": "0xa8575cb8de4a336109f2587145a8a2215bbf9e7124d8bba98bb2069f7a83285d6a2185be3a55ffbc82847cc574c01ebe",
    "proposer_pubkey": "0xb5d69d1a776cd741ad9ee8c4f8487923b422100b4d9be3f0f2e270d2385b1ca1b284c73cb38137cb287305e99a7473e0",
    "proposer_fee_recipient": "0x0000000000000000000000000000000000011111",
    "gas_limit": "30000000",
    "gas_used": "29966286",
    "value": "1072864972455703463",
    "num_tx": "110",
    "block_number": "7807902",
    "timestamp": "1666349304",
    "timestamp_ms": "1666349304804"
}
```

Deployed to Goerli and Sepolia:
* https://boost-relay-sepolia.flashbots.net/relay/v1/data/bidtraces/builder_blocks_received?slot=884602
* https://boost-relay-goerli.flashbots.net/relay/v1/data/bidtraces/builder_blocks_received

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
