### PR TITLE
ci: fix getting tag version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Get tag version
-        id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Test
+        run: |
+          echo $RELEASE_VERSION
+          echo ${{ env.RELEASE_VERSION }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -32,9 +36,9 @@ jobs:
           tags: |
             type=sha
             type=semver,pattern={{version}}
-            type=raw,value=latest,enable=${{ !contains(steps.vars.outputs.tag, '-') }}
-            type=semver,pattern={{major}},enable=${{ !contains(steps.vars.outputs.tag, '-') }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(steps.vars.outputs.tag, '-') }}
+            type=raw,value=latest,enable=${{ !contains($RELEASE_VERSION, '-') }}
+            type=semver,pattern={{major}},enable=${{ !contains($RELEASE_VERSION, '-') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains($RELEASE_VERSION, '-') }}
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
@@ -48,7 +52,7 @@ jobs:
           context: .
           push: true
           build-args: |
-            VERSION=${{ steps.vars.outputs.tag }}
+            VERSION=${{ $RELEASE_VERSION }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## 📝 Summary

See also https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
