### PR TITLE
Validate prev_randao of builder submissions, and dd more beacon APIs

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -64,10 +64,10 @@ linters-settings:
     min-complexity: 85 # default: 30
 
   gocyclo:
-    min-complexity: 33 # default: 30
+    min-complexity: 65 # default: 30
 
   maintidx:
-    under: 15
+    under: 5
 
   tagliatelle:
     case:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -61,7 +61,7 @@ linters-settings:
       - G108
 
   gocognit:
-    min-complexity: 45 # default: 30
+    min-complexity: 85 # default: 30
 
   gocyclo:
     min-complexity: 33 # default: 30

--- a/beaconclient/mock_beacon_instance.go
+++ b/beaconclient/mock_beacon_instance.go
@@ -105,3 +105,11 @@ func (c *MockBeaconInstance) PublishBlock(block *types.SignedBeaconBlock) (code 
 func (c *MockBeaconInstance) GetGenesis() (*GetGenesisResponse, error) {
 	return nil, nil
 }
+
+func (c *MockBeaconInstance) GetBlock(blockID string) (block *GetBlockResponse, err error) {
+	return nil, nil
+}
+
+func (c *MockBeaconInstance) GetSpec() (spec *GetSpecResponse, err error) {
+	return nil, nil
+}

--- a/beaconclient/mock_beacon_instance.go
+++ b/beaconclient/mock_beacon_instance.go
@@ -113,3 +113,7 @@ func (c *MockBeaconInstance) GetBlock(blockID string) (block *GetBlockResponse, 
 func (c *MockBeaconInstance) GetSpec() (spec *GetSpecResponse, err error) {
 	return nil, nil
 }
+
+func (c *MockBeaconInstance) GetRandao(slot uint64) (spec *GetRandaoResponse, err error) {
+	return nil, nil
+}

--- a/beaconclient/multi_beacon_client.go
+++ b/beaconclient/multi_beacon_client.go
@@ -283,6 +283,6 @@ func (c *MultiBeaconClient) GetRandao(slot uint64) (randaoResp *GetRandaoRespons
 		return randaoResp, nil
 	}
 
-	c.log.WithField("slot", slot).WithError(err).Error("failed to get randao from any CL node")
+	c.log.WithField("slot", slot).WithError(err).Warn("failed to get randao from any CL node")
 	return nil, err
 }

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -184,11 +184,12 @@ type GetBlockResponse struct {
 	}
 }
 
-// GetBlock returns the latest block - https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockV2
-func (c *ProdBeaconInstance) GetBlock() (*GetBlockResponse, error) {
-	uri := fmt.Sprintf("%s/eth/v2/beacon/blocks/head", c.beaconURI)
+// GetBlock returns a block - https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockV2
+// blockID can be 'head' or slot number
+func (c *ProdBeaconInstance) GetBlock(blockID string) (block *GetBlockResponse, err error) {
+	uri := fmt.Sprintf("%s/eth/v2/beacon/blocks/%s", c.beaconURI, blockID)
 	resp := new(GetBlockResponse)
-	_, err := fetchBeacon(http.MethodGet, uri, nil, resp)
+	_, err = fetchBeacon(http.MethodGet, uri, nil, resp)
 	return resp, err
 }
 
@@ -222,5 +223,23 @@ func (c *ProdBeaconInstance) GetGenesis() (*GetGenesisResponse, error) {
 	uri := fmt.Sprintf("%s/eth/v1/beacon/genesis", c.beaconURI)
 	resp := new(GetGenesisResponse)
 	_, err := fetchBeacon(http.MethodGet, uri, nil, resp)
+	return resp, err
+}
+
+type GetSpecResponse struct {
+	//	{
+	//	  "DEPOSIT_CONTRACT_ADDRESS": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+	//	  "DEPOSIT_NETWORK_ID": "1",
+	//	  "DOMAIN_AGGREGATE_AND_PROOF": "0x06000000",
+	//	  "INACTIVITY_PENALTY_QUOTIENT": "67108864",
+	//	  "INACTIVITY_PENALTY_QUOTIENT_ALTAIR": "50331648"
+	//	}
+}
+
+// GetSpec - https://ethereum.github.io/beacon-APIs/#/Config/getSpec
+func (c *ProdBeaconInstance) GetSpec() (spec *GetSpecResponse, err error) {
+	uri := fmt.Sprintf("%s/eth/v1/config/spec", c.beaconURI)
+	resp := new(GetSpecResponse)
+	_, err = fetchBeacon(http.MethodGet, uri, nil, resp)
 	return resp, err
 }

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -227,12 +227,12 @@ func (c *ProdBeaconInstance) GetGenesis() (*GetGenesisResponse, error) {
 }
 
 type GetSpecResponse struct {
-	SecondsPerSlot                  uint64 `json:"SECONDS_PER_SLOT,string"`
-	DepositContractAddress          string `json:"DEPOSIT_CONTRACT_ADDRESS"`
-	DepositNetworkID                string `json:"DEPOSIT_NETWORK_ID"`
-	DomainAggregateAndProof         string `json:"DOMAIN_AGGREGATE_AND_PROOF"`
-	InactivityPenaltyQuotient       string `json:"INACTIVITY_PENALTY_QUOTIENT"`
-	InactivityPenaltyQuotientAltair string `json:"INACTIVITY_PENALTY_QUOTIENT_ALTAIR"`
+	SecondsPerSlot                  uint64 `json:"SECONDS_PER_SLOT,string"`            //nolint:tagliatelle
+	DepositContractAddress          string `json:"DEPOSIT_CONTRACT_ADDRESS"`           //nolint:tagliatelle
+	DepositNetworkID                string `json:"DEPOSIT_NETWORK_ID"`                 //nolint:tagliatelle
+	DomainAggregateAndProof         string `json:"DOMAIN_AGGREGATE_AND_PROOF"`         //nolint:tagliatelle
+	InactivityPenaltyQuotient       string `json:"INACTIVITY_PENALTY_QUOTIENT"`        //nolint:tagliatelle
+	InactivityPenaltyQuotientAltair string `json:"INACTIVITY_PENALTY_QUOTIENT_ALTAIR"` //nolint:tagliatelle
 }
 
 // GetSpec - https://ethereum.github.io/beacon-APIs/#/Config/getSpec

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -227,13 +227,12 @@ func (c *ProdBeaconInstance) GetGenesis() (*GetGenesisResponse, error) {
 }
 
 type GetSpecResponse struct {
-	//	{
-	//	  "DEPOSIT_CONTRACT_ADDRESS": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
-	//	  "DEPOSIT_NETWORK_ID": "1",
-	//	  "DOMAIN_AGGREGATE_AND_PROOF": "0x06000000",
-	//	  "INACTIVITY_PENALTY_QUOTIENT": "67108864",
-	//	  "INACTIVITY_PENALTY_QUOTIENT_ALTAIR": "50331648"
-	//	}
+	SecondsPerSlot                  uint64 `json:"SECONDS_PER_SLOT,string"`
+	DepositContractAddress          string `json:"DEPOSIT_CONTRACT_ADDRESS"`
+	DepositNetworkID                string `json:"DEPOSIT_NETWORK_ID"`
+	DomainAggregateAndProof         string `json:"DOMAIN_AGGREGATE_AND_PROOF"`
+	InactivityPenaltyQuotient       string `json:"INACTIVITY_PENALTY_QUOTIENT"`
+	InactivityPenaltyQuotientAltair string `json:"INACTIVITY_PENALTY_QUOTIENT_ALTAIR"`
 }
 
 // GetSpec - https://ethereum.github.io/beacon-APIs/#/Config/getSpec

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -243,3 +243,17 @@ func (c *ProdBeaconInstance) GetSpec() (spec *GetSpecResponse, err error) {
 	_, err = fetchBeacon(http.MethodGet, uri, nil, resp)
 	return resp, err
 }
+
+type GetRandaoResponse struct {
+	Data struct {
+		Randao string `json:"randao"`
+	}
+}
+
+// GetRandao - 3500/eth/v1/beacon/states/<slot>/randao
+func (c *ProdBeaconInstance) GetRandao(slot uint64) (randaoResp *GetRandaoResponse, err error) {
+	uri := fmt.Sprintf("%s/eth/v1/beacon/states/%d/randao", c.beaconURI, slot)
+	resp := new(GetRandaoResponse)
+	_, err = fetchBeacon(http.MethodGet, uri, nil, resp)
+	return resp, err
+}

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -249,7 +249,7 @@ type GetRandaoResponse struct {
 	}
 }
 
-// GetRandao - 3500/eth/v1/beacon/states/<slot>/randao
+// GetRandao - /eth/v1/beacon/states/<slot>/randao
 func (c *ProdBeaconInstance) GetRandao(slot uint64) (randaoResp *GetRandaoResponse, err error) {
 	uri := fmt.Sprintf("%s/eth/v1/beacon/states/%d/randao", c.beaconURI, slot)
 	resp := new(GetRandaoResponse)

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -957,11 +957,12 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	// randao check
+	// randao check 1:
+	// - querying the randao from the BN if payload has a newer slot (might be faster than headSlot event)
+	// - check for validity happens later, again after validation (to use some time for BN request to finish...)
 	api.expectedPrevRandaoLock.RLock()
-	if api.expectedPrevRandao.slot != payload.Message.Slot { // trigger querying the randao now (might be before headSlot event)
+	if payload.Message.Slot > api.expectedPrevRandao.slot {
 		go api.updatedExpectedRandao(payload.Message.Slot - 1)
-		// check for validity happens later, again after validation (to use some time for BN request to finish...)
 	}
 	api.expectedPrevRandaoLock.RUnlock()
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -857,9 +857,10 @@ func (api *RelayAPI) updatedExpectedRandao(slot uint64) {
 	api.expectedPrevRandaoLock.Unlock()
 
 	// get randao from BN
+	api.log.Debugf("- querying BN for randao for slot %d", slot)
 	randao, err := api.beaconClient.GetRandao(slot)
 	if err != nil {
-		api.log.WithField("slot", slot).WithError(err).Error("failed to get randao from beacon node")
+		api.log.WithField("slot", slot).WithError(err).Warn("failed to get randao from beacon node")
 		api.expectedPrevRandaoLock.Lock()
 		api.expectedPrevRandaoUpdating = 0
 		api.expectedPrevRandaoLock.Unlock()


### PR DESCRIPTION
## 📝 Summary

* Validates the `prev_randao` of builder submissions. This uses the `/eth/v1/beacon/states/%d/randao` BN api call, where Prysm needs this patch: https://github.com/prysmaticlabs/prysm/pull/11609
* Adds more beacon API calls: `getBlock`, `getSpec`, `getRandao`

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
