### PR TITLE
validate gas_limit

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -967,7 +967,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	}
 	api.expectedPrevRandaoLock.RUnlock()
 
-	// ensure correct feeRecipient is used
+	// ensure correct feeRecipient and gas_limit is used
 	api.proposerDutiesLock.RLock()
 	slotDuty := api.proposerDutiesMap[payload.Message.Slot]
 	api.proposerDutiesLock.RUnlock()
@@ -978,6 +978,10 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	} else if slotDuty.FeeRecipient != payload.Message.ProposerFeeRecipient {
 		log.Info("fee recipient does not match")
 		api.RespondError(w, http.StatusBadRequest, "fee recipient does not match")
+		return
+	} else if slotDuty.GasLimit != payload.Message.GasLimit {
+		log.Info("gas_limit does not match")
+		api.RespondError(w, http.StatusBadRequest, "gas_limit does not match")
 		return
 	}
 


### PR DESCRIPTION
## 📝 Summary

* validate gas_limit temporarily in the relay API
* the proper solution will be to validate it in the validation cluster, as it's doesn't need to be the specific value, but the value or moving in the right direction based on the previous block's gas limit.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
