### PR TITLE
send gaslimit to validation node

### DIFF
--- a/services/api/blocksim_ratelimiter.go
+++ b/services/api/blocksim_ratelimiter.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/flashbots/go-boost-utils/types"
 	"github.com/flashbots/go-utils/cli"
 	"github.com/flashbots/go-utils/jsonrpc"
 )
@@ -36,7 +35,7 @@ func NewBlockSimulationRateLimiter(blockSimURL string) *BlockSimulationRateLimit
 	}
 }
 
-func (b *BlockSimulationRateLimiter) send(context context.Context, payload *types.BuilderSubmitBlockRequest, isHighPrio bool) error {
+func (b *BlockSimulationRateLimiter) send(context context.Context, payload *BuilderBlockValidationRequest, isHighPrio bool) error {
 	b.cv.L.Lock()
 	cnt := atomic.AddInt64(&b.counter, 1)
 	if maxConcurrentBlocks > 0 && cnt > maxConcurrentBlocks {

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1066,7 +1066,11 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 
 	// Simulate the block submission and save to db
 	t := time.Now()
-	simErr = api.blockSimRateLimiter.send(req.Context(), payload, builderIsHighPrio)
+	validationRequestPayload := &BuilderBlockValidationRequest{
+		BuilderSubmitBlockRequest: *payload,
+		RegisteredGasLimit:        slotDuty.GasLimit,
+	}
+	simErr = api.blockSimRateLimiter.send(req.Context(), validationRequestPayload, builderIsHighPrio)
 
 	if simErr != nil {
 		log = log.WithField("simErr", simErr.Error())

--- a/services/api/types.go
+++ b/services/api/types.go
@@ -77,3 +77,8 @@ func SignedBlindedBeaconBlockToBeaconBlock(signedBlindedBeaconBlock *types.Signe
 		},
 	}
 }
+
+type BuilderBlockValidationRequest struct {
+	types.BuilderSubmitBlockRequest
+	RegisteredGasLimit uint64 `json:"registered_gas_limit,string"`
+}


### PR DESCRIPTION
## 📝 Summary

Check the gas_limit of builder submissions by sending it to the validation nodes.

See also https://github.com/flashbots/block-validation-geth/pull/8

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
