### PR TITLE
website: only show active validators, for clarity

### DIFF
--- a/services/website/website.html
+++ b/services/website/website.html
@@ -190,12 +190,12 @@
                                 <td>Validators total</td>
                                 <td>{{ .ValidatorsTotal | prettyInt }}</td>
                             </tr>
-                            <tr title="Validators who have sent a registration at least once. ">
+                            <!-- <tr title="Validators who have sent a registration at least once. ">
                                 <td>Validators registered</td>
                                 <td>{{ .ValidatorsRegistered| prettyInt }}</td>
-                            </tr>
+                            </tr> -->
                             <tr title="Validators who sent a registration in the last 3 hours.">
-                                <td>Validators active</td>
+                                <td>Validators connected</td>
                                 <td>{{ .ValidatorsActive| prettyInt }}</td>
                             </tr>
                             <tr>

--- a/static/s3/index.html
+++ b/static/s3/index.html
@@ -222,6 +222,9 @@ Copyright (C) 2008 Francesco Pasqualini
 		<a href="https://boost-relay.flashbots.net/">Flashbots Boost Relay</a> - Data
 	</h1>
 
+	<p>
+		<a href="https://flashbots-boost-relay-public.s3.us-east-2.amazonaws.com/">File listing in XML format</a>
+	</p>
 	<br>
 	<br>
 


### PR DESCRIPTION
## 📝 Summary

The number of all-time ever registered validators is irrelevant, better to emphasize the number of currently active (connected) validators..

This PR changes from
![Screenshot 2022-11-17 at 22 48 39](https://user-images.githubusercontent.com/116939/202567092-086df448-6c17-4eba-98ff-539db2d1df31.png)

to 
![Screenshot 2022-11-21 at 09 05 28](https://user-images.githubusercontent.com/116939/202996847-6da22e63-be5a-4e45-b96a-0e0b0d99408d.png)



---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
