### PR TITLE
Parse Redis URLs

### DIFF
--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -45,9 +45,15 @@ func PubkeyHexToLowerStr(pk types.PubkeyHex) string {
 }
 
 func connectRedis(redisURI string) (*redis.Client, error) {
-	redisClient := redis.NewClient(&redis.Options{
-		Addr: redisURI,
-	})
+	// Handle both URIs and full URLs, assume unencrypted connections
+	if !strings.HasPrefix(redisURI, "redis://") && !strings.HasPrefix(redisURI, "rediss://") {
+		redisURI = "redis://" + redisURI
+	}
+	opt, err := redis.ParseURL(redisURI)
+	if err != nil {
+		return nil, err
+	}
+	redisClient := redis.NewClient(opt)
 	if _, err := redisClient.Ping(context.Background()).Result(); err != nil {
 		// unable to connect to redis
 		return nil, err


### PR DESCRIPTION
## 📝 Summary

PR for #251 .  Uses `redis.ParseURL` to extract options from the argument passed to `--redis-uri`. Backwards-compatible with hostname:port arguments. Added new tests, which currently pass.

## ⛱ Motivation and Context

Allows connection to Redis servers with TLS or authentication credentials. More details in linked issue.

## 📚 References

[redis.ParseURL](https://pkg.go.dev/github.com/go-redis/redis?utm_source=godoc#ParseURL)

---

## ✅ I have run these commands

* [✅] `make lint`
* [✅] `make test-race`
* [✅] `go mod tidy`
* [✅] I have seen and agree to `CONTRIBUTING.md`

Note: `make lint` returns error, with `go version go1.19.3 linux/amd64`:
> -: cannot import "go.uber.org/atomic" (type parameter bound more than once), export data is newer version - update tool (compile)
