### PR TITLE
No error logging if no payloads delivered yet, and fixed export-payloads-last-week.sh

### DIFF
--- a/scripts/export-payloads-last-week.sh
+++ b/scripts/export-payloads-last-week.sh
@@ -11,15 +11,14 @@ if [ -z $DB ]; then
         exit 1
 fi
 
-week_last=$(date -d"last week" +%U)
-monday_last_week=$(date -d"last week monday" +%Y-%m-%d)
-monday_this_week=$(date -d"this week monday" +%Y-%m-%d)
+monday_start=$(date -d"last Sunday -6 days" +%Y-%m-%d)
+monday_end=$(date -d"last Sunday +1 days" +%Y-%m-%d)
 fn1=$(date -d"last week" +%Y_w%U.csv)
 fn2=$(date -d"last week" +%Y_w%U.json)
-echo "week $week_last = $monday_last_week to $monday_this_week"
+echo "exporting $monday_start to $monday_end -> $fn1 / $fn2"
 echo $fn1
 echo $fn2
-DB_DONT_APPLY_SCHEMA=1 DB_TABLE_PREFIX=mainnet go run . tool data-api-export-payloads --db $DB --date-start $monday_last_week --date-end $monday_this_week --out $fn1 --out $fn2
+DB_DONT_APPLY_SCHEMA=1 DB_TABLE_PREFIX=mainnet go run . tool data-api-export-payloads --db $DB --date-start $monday_start --date-end $monday_end --out $fn1 --out $fn2
 
 echo "press enter to upload to S3..."
 read -r

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -928,8 +928,10 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 
 	// Reject new submissions once the payload for this slot was delivered
 	slotStr, err := api.redis.GetStats(datastore.RedisStatsFieldSlotLastPayloadDelivered)
-	if err != nil && !errors.Is(err, redis.Nil) {
-		log.WithError(err).Error("failed to get delivered payload slot from redis")
+	if err != nil {
+		if !errors.Is(err, redis.Nil) {
+			log.WithError(err).Error("failed to get delivered payload slot from redis")
+		}
 	} else {
 		slotLastPayloadDelivered, err := strconv.ParseUint(slotStr, 10, 64)
 		if err != nil {


### PR DESCRIPTION
## 📝 Summary

* Don't log error if no payloads delivered yet
* Fixed export-payloads-last-week.sh

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
