### PR TITLE
getPayload: log error on i/o timeout

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -734,7 +734,11 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 
 	payload := new(types.SignedBlindedBeaconBlock)
 	if err := json.NewDecoder(req.Body).Decode(payload); err != nil {
-		log.WithError(err).Warn("getPayload request failed to decode")
+		if strings.Contains(err.Error(), "i/o timeout") {
+			log.WithError(err).Error("getPayload request failed to decode (i/o timeout)")
+		} else {
+			log.WithError(err).Warn("getPayload request failed to decode")
+		}
 		api.RespondError(w, http.StatusBadRequest, err.Error())
 		return
 	}


### PR DESCRIPTION
## 📝 Summary

On `getPayload`, if decoding fails, log an error if it's an `i/o timeout`

## ⛱ Motivation and Context

This type of error is an infrastructure error and should be surfaced urgently! It might affect users by missing their slots.

The only "solution" to such an error is mev-boost retrying failed getPayload requests.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
