### PR TITLE
API write timeout: env var + 10 sec default

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `NUM_VALIDATOR_REG_PROCESSORS` - proposer API - number of goroutines to listen to the validator registration channel
 * `ACTIVE_VALIDATOR_HOURS` - number of hours to track active proposers in redis (default: 3)
 * `GETPAYLOAD_RETRY_TIMEOUT_MS` - getPayload retry getting a payload if first try failed (default: 100)
+* `API_TIMEOUT_READ_MS` - http read timeout in milliseconds (default: 1500)
+* `API_TIMEOUT_READHEADER_MS` - http read header timeout in milliseconds (default: 600)
+* `API_TIMEOUT_WRITE_MS` - http write timeout in milliseconds (default: 10000)
+* `API_TIMEOUT_IDLE_MS` - http idle timeout in milliseconds (default: 3000)
 
 ### Updating the website
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -66,6 +66,11 @@ var (
 	numActiveValidatorProcessors = cli.GetEnvInt("NUM_ACTIVE_VALIDATOR_PROCESSORS", 10)
 	numValidatorRegProcessors    = cli.GetEnvInt("NUM_VALIDATOR_REG_PROCESSORS", 10)
 	timeoutGetPayloadRetryMs     = cli.GetEnvInt("GETPAYLOAD_RETRY_TIMEOUT_MS", 100)
+
+	apiReadTimeoutMs       = cli.GetEnvInt("API_TIMEOUT_READ_MS", 1500)
+	apiReadHeaderTimeoutMs = cli.GetEnvInt("API_TIMEOUT_READHEADER_MS", 600)
+	apiWriteTimeoutMs      = cli.GetEnvInt("API_TIMEOUT_WRITE_MS", 10000)
+	apiIdleTimeoutMs       = cli.GetEnvInt("API_TIMEOUT_IDLE_MS", 3000)
 )
 
 // RelayAPIOpts contains the options for a relay
@@ -323,10 +328,10 @@ func (api *RelayAPI) StartServer() (err error) {
 		Addr:    api.opts.ListenAddr,
 		Handler: api.getRouter(),
 
-		ReadTimeout:       1500 * time.Millisecond,
-		ReadHeaderTimeout: 600 * time.Millisecond,
-		WriteTimeout:      3 * time.Second,
-		IdleTimeout:       3 * time.Second,
+		ReadTimeout:       time.Duration(apiReadTimeoutMs) * time.Millisecond,
+		ReadHeaderTimeout: time.Duration(apiReadHeaderTimeoutMs) * time.Millisecond,
+		WriteTimeout:      time.Duration(apiWriteTimeoutMs) * time.Millisecond,
+		IdleTimeout:       time.Duration(apiIdleTimeoutMs) * time.Millisecond,
 	}
 
 	err = api.srv.ListenAndServe()


### PR DESCRIPTION
## 📝 Summary

* make API timeouts configurable with end var
* Increase api write timeout to 10 seconds by default

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
