### PR TITLE
3s default timeout for block validations, new env var BLOCKSIM_TIMEOUT_MS

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `API_TIMEOUT_READHEADER_MS` - http read header timeout in milliseconds (default: 600)
 * `API_TIMEOUT_WRITE_MS` - http write timeout in milliseconds (default: 10000)
 * `API_TIMEOUT_IDLE_MS` - http idle timeout in milliseconds (default: 3000)
+* `BLOCKSIM_TIMEOUT_MS` - builder block submission validation request timeout (default: 3000)
 
 ### Updating the website
 


### PR DESCRIPTION
## 📝 Summary

* Builder block submission validation - request timeout now by default 3 sec
* Configurable with env var `BLOCKSIM_TIMEOUT_MS`

Helped a lot in reducing the 5xx error responses due to slow validation:
![Screenshot 2023-01-10 at 16 22 05](https://user-images.githubusercontent.com/116939/211592018-4d684069-d3eb-4809-be11-77e8cedeada1.png)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
