### PR TITLE
Make server WriteTimeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `NUM_VALIDATOR_REG_PROCESSORS` - proposer API - number of goroutines to listen to the validator registration channel
 * `ACTIVE_VALIDATOR_HOURS` - number of hours to track active proposers in redis (default: 3)
 * `GETPAYLOAD_RETRY_TIMEOUT_MS` - getPayload retry getting a payload if first try failed (default: 100)
+* `SERVER_WRITE_TIMEOUT_MS` - maximum duration before timing out writes of the response (default: 3000)
 
 ### Updating the website
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -66,6 +66,7 @@ var (
 	numActiveValidatorProcessors = cli.GetEnvInt("NUM_ACTIVE_VALIDATOR_PROCESSORS", 10)
 	numValidatorRegProcessors    = cli.GetEnvInt("NUM_VALIDATOR_REG_PROCESSORS", 10)
 	timeoutGetPayloadRetryMs     = cli.GetEnvInt("GETPAYLOAD_RETRY_TIMEOUT_MS", 100)
+	timeoutServerWriteMs         = cli.GetEnvInt("SERVER_WRITE_TIMEOUT_MS", 3000)
 )
 
 // RelayAPIOpts contains the options for a relay
@@ -325,7 +326,7 @@ func (api *RelayAPI) StartServer() (err error) {
 
 		ReadTimeout:       1500 * time.Millisecond,
 		ReadHeaderTimeout: 600 * time.Millisecond,
-		WriteTimeout:      3 * time.Second,
+		WriteTimeout:      time.Duration(timeoutServerWriteMs) * time.Millisecond,
 		IdleTimeout:       3 * time.Second,
 	}
 


### PR DESCRIPTION
## 📝 Summary

Enable configuration of  server's`WriteTimeout` using env var.

## ⛱ Motivation and Context

We were running into an issue on our staging environment where our budget cluster couldn't keep up with a large number of validator registrations. This lead to some requests hitting the 3 second timeout. I increased the timeout and have been running without issues since.

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
