### PR TITLE
Log headSlot in all getPayload logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY go.mod ./
 COPY go.sum ./
 RUN go mod download
 
-# Now adding all the code and building
+# Now adding all the code and start building
 ADD . .
 RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux go build -trimpath -ldflags "-s -X cmd.Version=$VERSION -X main.Version=$VERSION" -v -o mev-boost-relay .
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -735,6 +735,7 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 		"ua":            ua,
 		"mevBoostV":     common.GetMevBoostVersionFromUserAgent(ua),
 		"contentLength": req.ContentLength,
+		"headSlot":      api.headSlot.Load(),
 	})
 
 	payload := new(types.SignedBlindedBeaconBlock)


### PR DESCRIPTION
## 📝 Summary

in particular helpful to know when payload decoding fails, and slot is unknown otherwise

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
