### PR TITLE
Use Go v1.20

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,10 +10,10 @@ jobs:
       CGO_CFLAGS_ALLOW: "-O -D__BLST_PORTABLE__"
       CGO_CFLAGS: "-O -D__BLST_PORTABLE__"
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.19
+          go-version: ^1.20
         id: go
 
       - name: Check out code into the Go module directory
@@ -39,23 +39,23 @@ jobs:
       CGO_CFLAGS_ALLOW: "-O -D__BLST_PORTABLE__"
       CGO_CFLAGS: "-O -D__BLST_PORTABLE__"
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.19
+          go-version: ^1.20
         id: go
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
       - name: Install gofumpt
-        run: go install mvdan.cc/gofumpt@latest
+        run: go install mvdan.cc/gofumpt@v0.4.0
 
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.2
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
       - name: Lint
         run: make lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 ARG VERSION
 WORKDIR /build
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flashbots/mev-boost-relay
 
-go 1.19
+go 1.20
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1181,7 +1181,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		"tx":             len(payload.ExecutionPayload.Transactions),
 	}).Info("received block from builder")
 
-	// Respond with OK (TODO: proper response response data type https://flashbots.notion.site/Relay-API-Spec-5fb0819366954962bc02e81cb33840f5#fa719683d4ae4a57bc3bf60e138b0dc6)
+	// Respond with OK (TODO: proper response data type https://flashbots.notion.site/Relay-API-Spec-5fb0819366954962bc02e81cb33840f5#fa719683d4ae4a57bc3bf60e138b0dc6)
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/services/website/html.go
+++ b/services/website/html.go
@@ -19,7 +19,7 @@ var (
 	caser = cases.Title(language.English)
 )
 
-type StatusHTMLData struct {
+type StatusHTMLData struct { //nolint:musttag
 	Network                     string
 	RelayPubkey                 string
 	ValidatorsTotal             uint64


### PR DESCRIPTION
## 📝 Summary

Go v1.20.1 is currently the latest. Up build+test from Go 1.19 to 1.20.x

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
