### PR TITLE
Return error for future slot submissions

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1090,6 +1090,18 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		}
 	}
 
+	if payload.Slot() <= api.headSlot.Load() {
+		api.log.Info("submitNewBlock failed: submission for past slot")
+		api.RespondError(w, http.StatusBadRequest, "submission for past slot")
+		return
+	}
+
+	if payload.Slot() > api.headSlot.Load()+1 {
+		api.log.Info("submitNewBlock failed: submission for future slot")
+		api.RespondError(w, http.StatusBadRequest, "submission for future slot")
+		return
+	}
+
 	builderIsHighPrio, builderIsBlacklisted, err := api.redis.GetBlockBuilderStatus(payload.BuilderPubkey().String())
 	log = log.WithFields(logrus.Fields{
 		"builderIsHighPrio":    builderIsHighPrio,
@@ -1106,24 +1118,6 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		api.RespondError(w, http.StatusBadRequest, fmt.Sprintf("incorrect timestamp. got %d, expected %d", payload.Timestamp(), expectedTimestamp))
 		return
 	}
-
-	// randao check 1:
-	// - querying the randao from the BN if payload has a newer slot (might be faster than headSlot event)
-	// - check for validity happens later, again after validation (to use some time for BN request to finish...)
-	api.expectedPrevRandaoLock.RLock()
-	if payload.Slot() > api.expectedPrevRandao.slot {
-		go api.updatedExpectedRandao(payload.Slot() - 1)
-	}
-	api.expectedPrevRandaoLock.RUnlock()
-
-	// withdrawal check:
-	// - querying the withdrawls from the BN if payload has a newer slot (might be faster than headSlot event)
-	// - check for validity happens later, again after validation (to use some time for BN request to finish...)
-	api.expectedWithdrawalsLock.RLock()
-	if payload.Slot() > api.expectedWithdrawalsRoot.slot {
-		go api.updatedExpectedWithdrawals(payload.Slot() - 1)
-	}
-	api.expectedWithdrawalsLock.RUnlock()
 
 	// ensure correct feeRecipient is used
 	api.proposerDutiesLock.RLock()
@@ -1162,12 +1156,6 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		"tx":              payload.NumTx(),
 	})
 
-	if payload.Slot() <= api.headSlot.Load() {
-		api.log.Info("submitNewBlock failed: submission for past slot")
-		api.RespondError(w, http.StatusBadRequest, "submission for past slot")
-		return
-	}
-
 	// Don't accept blocks with 0 value
 	if payload.Value().Cmp(ZeroU256.BigInt()) == 0 || payload.NumTx() == 0 {
 		api.log.Info("submitNewBlock failed: block with 0 value or no txs")
@@ -1183,11 +1171,11 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	// get the latest randao and check again, it might have updated in the meantime)
+	// get the latest randao and check its slot
 	api.expectedPrevRandaoLock.RLock()
 	expectedRandao := api.expectedPrevRandao
 	api.expectedPrevRandaoLock.RUnlock()
-	if expectedRandao.slot != payload.Slot() { // we still don't have the prevrandao yet
+	if expectedRandao.slot != payload.Slot() {
 		log.Warn("prev_randao is not known yet")
 		api.RespondError(w, http.StatusInternalServerError, "prev_randao is not known yet")
 		return
@@ -1210,7 +1198,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 			api.RespondError(w, http.StatusBadRequest, "could not compute withdrawals root")
 			return
 		}
-		if expectedWithdrawalsRoot.slot != payload.Slot() { // we still don't have the withdrawals yet
+		if expectedWithdrawalsRoot.slot != payload.Slot() {
 			log.Warn("withdrawals are not known yet")
 			api.RespondError(w, http.StatusInternalServerError, "withdrawals are not known yet")
 			return


### PR DESCRIPTION
## 📝 Summary

Disallow future slot submissions for incoming blocks. By moving the `payload.Slot()` checking higher in the `submitNewBlock` handler and only allowing blocks for one slot at a time, we can simplify the logic around updating the randao + withdrawals and reduce unnecessary simulation errors. 

## ⛱ Motivation and Context

Right now the logic explicitly checks if blocks are from a past slot and returns an error to the builder in that case. It doesn't specifically disallow future slot blocks, and this can lead to a race condition where the builder submits a block for a new slot, but the relay validation nodes haven't updated their state yet. This results in an error from the simulation nodes, https://github.com/flashbots/block-validation-geth/blob/edb750b94d886d70698c3b20a2248046f8b941b5/core/block_validator.go#L71 where the ancestor block is not known. For ultra sound relay, we have seen 42 instances of this error over the past week. If we simply reject blocks from future slots then this situation won't occur. Further, it allows the removal of `randao check 1` and `withdrawal check 1`, which run redundant:

```
go api.updatedExpectedRandao(payload.Slot() - 1)
go api.updatedExpectedWithdrawals(payload.Slot() - 1)
```

These functions are both called in `processNewSlot`, so they are no longer needed if we enforce the submissions are from the correct slot.

This new error should not impact builders meaningfully, because the future slot submissions could only come right at the beginning of a new slot, so there is plenty of time for them to resubmit once the relay state has been updated to the current slot. Additionally, bids that are submitted so early in the slot are highly unlikely to have enough value to win the auction.


## 📚 References

N/A

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
