### PR TITLE
Collecting two extra timestamps in the block lifecycle

### DIFF
--- a/database/migrations/003_bid_add_eligibleat_payload_add_signedat.go
+++ b/database/migrations/003_bid_add_eligibleat_payload_add_signedat.go
@@ -1,0 +1,18 @@
+package migrations
+
+import (
+	"github.com/flashbots/mev-boost-relay/database/vars"
+	migrate "github.com/rubenv/sql-migrate"
+)
+
+var Migration003AddEligibleAtSignedAt = &migrate.Migration{
+	Id: "003-add-eligibleat-add-signedat",
+	Up: []string{`
+		ALTER TABLE ` + vars.TableBuilderBlockSubmission + ` ADD eligible_at timestamp;
+		ALTER TABLE ` + vars.TableDeliveredPayload + ` ADD signed_at timestamp;
+	`},
+	Down: []string{},
+
+	DisableTransactionUp:   true,
+	DisableTransactionDown: true,
+}

--- a/database/migrations/migration.go
+++ b/database/migrations/migration.go
@@ -9,5 +9,6 @@ var Migrations = migrate.MemoryMigrationSource{
 	Migrations: []*migrate.Migration{
 		Migration001InitDatabase,
 		Migration002RemoveIsBestAddReceivedAt,
+		Migration003AddEligibleAtSignedAt,
 	},
 }

--- a/database/mockdb.go
+++ b/database/mockdb.go
@@ -28,7 +28,7 @@ func (db MockDB) GetLatestValidatorRegistrations(timestampOnly bool) ([]*Validat
 	return nil, nil
 }
 
-func (db MockDB) SaveBuilderBlockSubmission(payload *common.BuilderSubmitBlockRequest, simError error, receivedAt time.Time) (entry *BuilderBlockSubmissionEntry, err error) {
+func (db MockDB) SaveBuilderBlockSubmission(payload *common.BuilderSubmitBlockRequest, simError error, receivedAt, eligibleAt time.Time) (entry *BuilderBlockSubmissionEntry, err error) {
 	return nil, nil
 }
 
@@ -72,7 +72,7 @@ func (db MockDB) GetBuilderSubmissionsBySlots(slotFrom, slotTo uint64) (entries 
 	return nil, nil
 }
 
-func (db MockDB) SaveDeliveredPayload(bidTrace *common.BidTraceV2, signedBlindedBeaconBlock *common.SignedBlindedBeaconBlock) error {
+func (db MockDB) SaveDeliveredPayload(bidTrace *common.BidTraceV2, signedBlindedBeaconBlock *common.SignedBlindedBeaconBlock, signedAt time.Time) error {
 	return nil
 }
 

--- a/database/types.go
+++ b/database/types.go
@@ -127,6 +127,7 @@ type BuilderBlockSubmissionEntry struct {
 	ID         int64        `db:"id"`
 	InsertedAt time.Time    `db:"inserted_at"`
 	ReceivedAt sql.NullTime `db:"received_at"`
+	EligibleAt sql.NullTime `db:"eligible_at"`
 
 	// Delivered ExecutionPayload
 	ExecutionPayloadID sql.NullInt64 `db:"execution_payload_id"`
@@ -158,8 +159,9 @@ type BuilderBlockSubmissionEntry struct {
 }
 
 type DeliveredPayloadEntry struct {
-	ID         int64     `db:"id"`
-	InsertedAt time.Time `db:"inserted_at"`
+	ID         int64        `db:"id"`
+	InsertedAt time.Time    `db:"inserted_at"`
+	SignedAt   sql.NullTime `db:"signed_at"`
 
 	SignedBlindedBeaconBlock sql.NullString `db:"signed_blinded_beacon_block"`
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -858,6 +858,9 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 		}
 	}
 
+	// Once the signature is verified, we know the proposer is committed to this bid.
+	signedAt := time.Now().UTC()
+
 	// Get the response - from memory, Redis or DB
 	// note that mev-boost might send getPayload for bids of other relays, thus this code wouldn't find anything
 	getPayloadResp, err := api.datastore.GetGetPayloadResponse(payload.Slot(), proposerPubkey.String(), payload.BlockHash())
@@ -897,7 +900,7 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 			log.WithError(err).Error("failed to get bidTrace for delivered payload from redis")
 		}
 
-		err = api.db.SaveDeliveredPayload(bidTrace, payload)
+		err = api.db.SaveDeliveredPayload(bidTrace, payload, signedAt)
 		if err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				"bidTrace": bidTrace,
@@ -1221,10 +1224,11 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	}
 
 	var simErr error
+	var eligibleAt time.Time
 
 	// At end of this function, save builder submission to database (in the background)
 	defer func() {
-		submissionEntry, err := api.db.SaveBuilderBlockSubmission(payload, simErr, receivedAt)
+		submissionEntry, err := api.db.SaveBuilderBlockSubmission(payload, simErr, receivedAt, eligibleAt)
 		if err != nil {
 			log.WithError(err).WithField("payload", payload).Error("saving builder block submission to database failed")
 			return
@@ -1330,6 +1334,9 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		api.RespondError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+
+	// after top bid is updated, the bid is eligible to win the auction.
+	eligibleAt = time.Now().UTC()
 
 	//
 	// all done


### PR DESCRIPTION
## 📝 Summary

The exact timing of events is critical in MEV boost. We that relays should collect two additional timestamps 

1) when a bid from a builder becomes "eligible", meaning it could win the auction, and
2) when a signed `getPayload` is verified, meaning the proposer is committed to that header.

## ⛱ Motivation and Context

Currently, the only timestamps collected by the relay are 
a) when a bid is received from the builder,
b) when the bid is inserted into the DB,
c) when the delivered payload is inserted into the DB. 

Since the DB writes happen off the critical path (they are deferred and happen in a separate goroutine), the accuracy of this data is relatively low. For example, you could find that the timestamp for when a delivered payload is inserted into the DB is *before* the timestamp for when the bid is inserted into the DB (if the bid comes right at the end of the slot and wins the auction). By collecting this additional data, we can have strong assurances about the relationship between when events occurred. For example, we can assert that the eligibility timestamp (1 above) **must** come before the signed timestamp (2 above), because a bid must be eligible before it can be retrieved by a call to `getHeader`. This also allows us to accurately determine the time between when a bit became active and when the proposer signed the header associated with that bid. 

In the figure below, we are proposing collecting timestamps for `bid is active` and `get payload` (after signature verification).  

<img width="600" alt="217920211-1730f598-4542-495f-b910-b8ca87d77382" src="https://user-images.githubusercontent.com/24661810/223741918-a2dd42af-ec6f-4f67-bfa6-86b5cd557a35.png">

## 📚 References

This is related to our optimistic relaying work, where we are paying close attention to the latency games associated with mev-boost. See the [proposal](https://github.com/michaelneuder/optimistic-relay-documentation/blob/main/proposal.md) and the [roadmap](https://github.com/michaelneuder/optimistic-relay-documentation/blob/main/towards-epbs.md). Additionally, this related to the study of latency/timing games: [ROP-0](https://efdn.notion.site/ROP-0-Timing-games-in-Proof-of-Stake-385f0f6279374a90b52bf380ed76a85b)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
