### PR TITLE
Builder bid value overflow fix

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -737,20 +737,6 @@ func (b *BuilderSubmitBlockRequest) Message() *apiv1.BidTrace {
 	return nil
 }
 
-func BidTraceToBoostBid(bidTrace *apiv1.BidTrace) *boostTypes.BidTrace {
-	return &boostTypes.BidTrace{
-		BuilderPubkey:        boostTypes.PublicKey(bidTrace.BuilderPubkey),
-		Slot:                 bidTrace.Slot,
-		ProposerPubkey:       boostTypes.PublicKey(bidTrace.ProposerPubkey),
-		ProposerFeeRecipient: boostTypes.Address(bidTrace.ProposerFeeRecipient),
-		BlockHash:            boostTypes.Hash(bidTrace.BlockHash),
-		Value:                boostTypes.IntToU256(bidTrace.Value.Uint64()),
-		ParentHash:           boostTypes.Hash(bidTrace.ParentHash),
-		GasLimit:             bidTrace.GasLimit,
-		GasUsed:              bidTrace.GasUsed,
-	}
-}
-
 func BoostBidToBidTrace(bidTrace *boostTypes.BidTrace) *apiv1.BidTrace {
 	return &apiv1.BidTrace{
 		BuilderPubkey:        phase0.BLSPubKey(bidTrace.BuilderPubkey),
@@ -758,7 +744,7 @@ func BoostBidToBidTrace(bidTrace *boostTypes.BidTrace) *apiv1.BidTrace {
 		ProposerPubkey:       phase0.BLSPubKey(bidTrace.ProposerPubkey),
 		ProposerFeeRecipient: bellatrix.ExecutionAddress(bidTrace.ProposerFeeRecipient),
 		BlockHash:            phase0.Hash32(bidTrace.BlockHash),
-		Value:                uint256.NewInt(bidTrace.Value.BigInt().Uint64()),
+		Value:                uint256.NewInt(0).SetBytes(reverse(bidTrace.Value[:])),
 		ParentHash:           phase0.Hash32(bidTrace.ParentHash),
 		GasLimit:             bidTrace.GasLimit,
 		GasUsed:              bidTrace.GasUsed,

--- a/common/types.go
+++ b/common/types.go
@@ -18,7 +18,6 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	boostTypes "github.com/flashbots/go-boost-utils/types"
-	"github.com/holiman/uint256"
 )
 
 var (
@@ -744,7 +743,7 @@ func BoostBidToBidTrace(bidTrace *boostTypes.BidTrace) *apiv1.BidTrace {
 		ProposerPubkey:       phase0.BLSPubKey(bidTrace.ProposerPubkey),
 		ProposerFeeRecipient: bellatrix.ExecutionAddress(bidTrace.ProposerFeeRecipient),
 		BlockHash:            phase0.Hash32(bidTrace.BlockHash),
-		Value:                uint256.NewInt(0).SetBytes(reverse(bidTrace.Value[:])),
+		Value:                U256StrToUint256(bidTrace.Value),
 		ParentHash:           phase0.Hash32(bidTrace.ParentHash),
 		GasLimit:             bidTrace.GasLimit,
 		GasUsed:              bidTrace.GasUsed,

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	boostTypes "github.com/flashbots/go-boost-utils/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoostBidToBidTrace(t *testing.T) {
+	bidTrace := boostTypes.BidTrace{
+		Slot:                 uint64(25),
+		ParentHash:           boostTypes.Hash{0x02, 0x03},
+		BuilderPubkey:        boostTypes.PublicKey{0x04, 0x05},
+		ProposerPubkey:       boostTypes.PublicKey{0x06, 0x07},
+		ProposerFeeRecipient: boostTypes.Address{0x08, 0x09},
+		GasLimit:             uint64(50),
+		GasUsed:              uint64(100),
+		Value:                boostTypes.U256Str{0x0a},
+	}
+	convertedBidTrace := BoostBidToBidTrace(&bidTrace)
+	require.Equal(t, bidTrace.Slot, convertedBidTrace.Slot)
+	require.Equal(t, phase0.Hash32(bidTrace.ParentHash), convertedBidTrace.ParentHash)
+	require.Equal(t, phase0.BLSPubKey(bidTrace.BuilderPubkey), convertedBidTrace.BuilderPubkey)
+	require.Equal(t, phase0.BLSPubKey(bidTrace.ProposerPubkey), convertedBidTrace.ProposerPubkey)
+	require.Equal(t, bellatrix.ExecutionAddress(bidTrace.ProposerFeeRecipient), convertedBidTrace.ProposerFeeRecipient)
+	require.Equal(t, bidTrace.GasLimit, convertedBidTrace.GasLimit)
+	require.Equal(t, bidTrace.GasUsed, convertedBidTrace.GasUsed)
+	require.Equal(t, bidTrace.Value.BigInt().String(), convertedBidTrace.Value.ToBig().String())
+}

--- a/common/utils.go
+++ b/common/utils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/flashbots/go-boost-utils/types"
+	"github.com/holiman/uint256"
 )
 
 var (
@@ -104,6 +105,12 @@ func GetMevBoostVersionFromUserAgent(ua string) string {
 		}
 	}
 	return "-"
+}
+
+func U256StrToUint256(s types.U256Str) *uint256.Int {
+	i := new(uint256.Int)
+	i.SetBytes(reverse(s[:]))
+	return i
 }
 
 func reverse(src []byte) []byte {

--- a/common/utils.go
+++ b/common/utils.go
@@ -105,3 +105,13 @@ func GetMevBoostVersionFromUserAgent(ua string) string {
 	}
 	return "-"
 }
+
+func reverse(src []byte) []byte {
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	for i := len(dst)/2 - 1; i >= 0; i-- {
+		opp := len(dst) - 1 - i
+		dst[i], dst[opp] = dst[opp], dst[i]
+	}
+	return dst
+}

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	boostTypes "github.com/flashbots/go-boost-utils/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,4 +41,26 @@ func TestGetMevBoostVersionFromUserAgent(t *testing.T) {
 			require.Equal(t, test.version, GetMevBoostVersionFromUserAgent(test.ua))
 		})
 	}
+}
+
+func TestBoostBidToBidTrace(t *testing.T) {
+	bidTrace := boostTypes.BidTrace{
+		Slot:                 uint64(25),
+		ParentHash:           boostTypes.Hash{0x02, 0x03},
+		BuilderPubkey:        boostTypes.PublicKey{0x04, 0x05},
+		ProposerPubkey:       boostTypes.PublicKey{0x06, 0x07},
+		ProposerFeeRecipient: boostTypes.Address{0x08, 0x09},
+		GasLimit:             uint64(50),
+		GasUsed:              uint64(100),
+		Value:                boostTypes.U256Str{0x0a},
+	}
+	convertedBidTrace := BoostBidToBidTrace(&bidTrace)
+	require.Equal(t, bidTrace.Slot, convertedBidTrace.Slot)
+	require.Equal(t, phase0.Hash32(bidTrace.ParentHash), convertedBidTrace.ParentHash)
+	require.Equal(t, phase0.BLSPubKey(bidTrace.BuilderPubkey), convertedBidTrace.BuilderPubkey)
+	require.Equal(t, phase0.BLSPubKey(bidTrace.ProposerPubkey), convertedBidTrace.ProposerPubkey)
+	require.Equal(t, bellatrix.ExecutionAddress(bidTrace.ProposerFeeRecipient), convertedBidTrace.ProposerFeeRecipient)
+	require.Equal(t, bidTrace.GasLimit, convertedBidTrace.GasLimit)
+	require.Equal(t, bidTrace.GasUsed, convertedBidTrace.GasUsed)
+	require.Equal(t, bidTrace.Value.BigInt().String(), convertedBidTrace.Value.ToBig().String())
 }


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When converting the boost bid value, there is a possibility of overflow. This PR converts between the types using the byte values.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
