### PR TITLE
Update attestant types dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alicebob/miniredis/v2 v2.23.0
 	github.com/attestantio/go-builder-client v0.2.7
-	github.com/attestantio/go-eth2-client v0.15.2
+	github.com/attestantio/go-eth2-client v0.15.8-0.20230310152300-bc14358487b6
 	github.com/btcsuite/btcd/btcutil v1.1.2
 	github.com/buger/jsonparser v1.1.1
 	github.com/ethereum/go-ethereum v1.11.3
@@ -100,6 +100,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// replace github.com/attestantio/go-eth2-client with custom fork
-replace github.com/attestantio/go-eth2-client => github.com/avalonche/go-eth2-client v0.0.0-20230220205736-f9665d7ade90

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/attestantio/go-builder-client v0.2.7 h1:DVjqHj5vsM4LaHnRERgCq283aLG3lKR6kd920U1jrCY=
 github.com/attestantio/go-builder-client v0.2.7/go.mod h1:lZt7TKYeVfOfJPVtWdOguwysQeFqeQMDjCru87RBdic=
-github.com/avalonche/go-eth2-client v0.0.0-20230220205736-f9665d7ade90 h1:TB+ORxQHVuNSnxmVOfKx8rqh/T3jkUYgoGQPBSF/Pug=
-github.com/avalonche/go-eth2-client v0.0.0-20230220205736-f9665d7ade90/go.mod h1:/Oh6YTuHmHhgLN/ZnQRKHGc7HdIzGlDkI2vjNZvOsvA=
+github.com/attestantio/go-eth2-client v0.15.8-0.20230310152300-bc14358487b6 h1:wwRpxrmhd9zgygmk/ggdpu4Fb/cvf5vlU82Yx1FKU8I=
+github.com/attestantio/go-eth2-client v0.15.8-0.20230310152300-bc14358487b6/go.mod h1:PLRKnILnr63V3yl2VagBqnhVRFBWc0V+JhQSsXQaSwQ=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/services/api/types.go
+++ b/services/api/types.go
@@ -8,9 +8,10 @@ import (
 	"github.com/attestantio/go-builder-client/api/capella"
 	"github.com/attestantio/go-builder-client/spec"
 	consensusspec "github.com/attestantio/go-eth2-client/spec"
-	consensusbellatrix "github.com/attestantio/go-eth2-client/spec/bellatrix"
 	consensuscapella "github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	utilbellatrix "github.com/attestantio/go-eth2-client/util/bellatrix"
+	utilcapella "github.com/attestantio/go-eth2-client/util/capella"
 	"github.com/flashbots/go-boost-utils/bls"
 	boostTypes "github.com/flashbots/go-boost-utils/types"
 	"github.com/flashbots/mev-boost-relay/common"
@@ -150,13 +151,13 @@ func CapellaPayloadToPayloadHeader(p *consensuscapella.ExecutionPayload) (*conse
 		return nil, ErrEmptyPayload
 	}
 
-	transactions := consensusbellatrix.Transactions{Transactions: p.Transactions}
+	transactions := utilbellatrix.ExecutionPayloadTransactions{Transactions: p.Transactions}
 	transactionsRoot, err := transactions.HashTreeRoot()
 	if err != nil {
 		return nil, err
 	}
 
-	withdrawals := consensuscapella.Withdrawals{Withdrawals: p.Withdrawals}
+	withdrawals := utilcapella.ExecutionPayloadWithdrawals{Withdrawals: p.Withdrawals}
 	withdrawalsRoot, err := withdrawals.HashTreeRoot()
 	if err != nil {
 		return nil, err

--- a/services/api/utils.go
+++ b/services/api/utils.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	utilcapella "github.com/attestantio/go-eth2-client/util/capella"
 	"github.com/flashbots/go-boost-utils/types"
 	"github.com/flashbots/mev-boost-relay/common"
 )
@@ -32,6 +33,6 @@ func checkBLSPublicKeyHex(pkHex string) error {
 }
 
 func ComputeWithdrawalsRoot(w []*capella.Withdrawal) (phase0.Root, error) {
-	withdrawals := capella.Withdrawals{Withdrawals: w}
+	withdrawals := utilcapella.ExecutionPayloadWithdrawals{Withdrawals: w}
 	return withdrawals.HashTreeRoot()
 }


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

## ⛱ Motivation and Context

updating the attestant types since https://github.com/attestantio/go-eth2-client/pull/47 is merged and we can directly use the util functions to calculate the ssd hash instead of referencing the custom fork.

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
