### PR TITLE
Fork version check

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -46,6 +46,7 @@ var (
 	ErrServerAlreadyStarted       = errors.New("server was already started")
 	ErrBuilderAPIWithoutSecretKey = errors.New("cannot start builder API without secret key")
 	ErrMismatchedForkVersions     = errors.New("can not find matching fork versions as retrieved from beacon node")
+	ErrMissingForkVersions        = errors.New("invalid bellatrix/capella fork version from beacon node")
 )
 
 var (
@@ -326,6 +327,10 @@ func (api *RelayAPI) StartServer() (err error) {
 		case api.opts.EthNetDetails.CapellaForkVersionHex:
 			api.capellaEpoch = fork.Epoch
 		}
+	}
+
+	if api.bellatrixEpoch == 0 || api.capellaEpoch == 0 {
+		return ErrMissingForkVersions
 	}
 
 	currentSlot := bestSyncStatus.HeadSlot


### PR DESCRIPTION
## 📝 Summary

* double-check fork version received from beacon node
* add `FORCE_BELLATRIX` env var to override

See also #311 

Current mainnet forkSchedule delivered from Prysm:

```
{
    "data": [
        {
            "previous_version": "0x00000000",
            "current_version": "0x00000000",
            "epoch": "0"
        },
        {
            "previous_version": "0x00000000",
            "current_version": "0x01000000",
            "epoch": "74240"
        },
        {
            "previous_version": "0x01000000",
            "current_version": "0x02000000",
            "epoch": "144896"
        }
    ]
}
```

Zhejiang testnet:
```
{
    "data": [
        {
            "previous_version": "0x00000069",
            "current_version": "0x00000069",
            "epoch": "0"
        },
        {
            "previous_version": "0x00000069",
            "current_version": "0x00000070",
            "epoch": "0"
        },
        {
            "previous_version": "0x00000070",
            "current_version": "0x00000071",
            "epoch": "0"
        },
        {
            "previous_version": "0x00000071",
            "current_version": "0x00000072",
            "epoch": "1350"
        }
    ]
}
```

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
