### PR TITLE
SSE Payload Attributes subscription

### DIFF
--- a/beaconclient/mock_beacon_instance.go
+++ b/beaconclient/mock_beacon_instance.go
@@ -84,7 +84,7 @@ func (c *MockBeaconInstance) CurrentSlot() (uint64, error) {
 
 func (c *MockBeaconInstance) SubscribeToHeadEvents(slotC chan HeadEventData) {}
 
-func (c *MockBeaconInstance) SubscribeToPayloadAttributesEvents(slotC chan PayloadAttributesData) {}
+func (c *MockBeaconInstance) SubscribeToPayloadAttributesEvents(slotC chan PayloadAttributesEvent) {}
 
 func (c *MockBeaconInstance) GetProposerDuties(epoch uint64) (*ProposerDutiesResponse, error) {
 	c.addDelay()

--- a/beaconclient/mock_beacon_instance.go
+++ b/beaconclient/mock_beacon_instance.go
@@ -84,6 +84,8 @@ func (c *MockBeaconInstance) CurrentSlot() (uint64, error) {
 
 func (c *MockBeaconInstance) SubscribeToHeadEvents(slotC chan HeadEventData) {}
 
+func (c *MockBeaconInstance) SubscribeToPayloadAttributesEvents(slotC chan PayloadAttributesData) {}
+
 func (c *MockBeaconInstance) GetProposerDuties(epoch uint64) (*ProposerDutiesResponse, error) {
 	c.addDelay()
 	return c.MockProposerDuties, c.MockProposerDutiesErr

--- a/beaconclient/multi_beacon_client.go
+++ b/beaconclient/multi_beacon_client.go
@@ -23,6 +23,7 @@ var (
 type IMultiBeaconClient interface {
 	BestSyncStatus() (*SyncStatusPayloadData, error)
 	SubscribeToHeadEvents(slotC chan HeadEventData)
+	// SubscribeToPayloadAttributesEvents subscribes to payload attributes events to validate fields such as prevrandao and withdrawals
 	SubscribeToPayloadAttributesEvents(payloadAttrC chan PayloadAttributesData)
 
 	// FetchValidators returns all active and pending validators from the beacon node

--- a/beaconclient/multi_beacon_client.go
+++ b/beaconclient/multi_beacon_client.go
@@ -23,7 +23,7 @@ var (
 type IMultiBeaconClient interface {
 	BestSyncStatus() (*SyncStatusPayloadData, error)
 	SubscribeToHeadEvents(slotC chan HeadEventData)
-	SubscribeToPayloadAttributesEvents(slotC chan PayloadAttributesData)
+	SubscribeToPayloadAttributesEvents(payloadAttrC chan PayloadAttributesData)
 
 	// FetchValidators returns all active and pending validators from the beacon node
 	FetchValidators(headSlot uint64) (map[types.PubkeyHex]ValidatorResponseEntry, error)

--- a/beaconclient/multi_beacon_client.go
+++ b/beaconclient/multi_beacon_client.go
@@ -23,6 +23,7 @@ var (
 type IMultiBeaconClient interface {
 	BestSyncStatus() (*SyncStatusPayloadData, error)
 	SubscribeToHeadEvents(slotC chan HeadEventData)
+	SubscribeToPayloadAttributes(slotC chan SyncStatusPayloadData)
 
 	// FetchValidators returns all active and pending validators from the beacon node
 	FetchValidators(headSlot uint64) (map[types.PubkeyHex]ValidatorResponseEntry, error)

--- a/beaconclient/multi_beacon_client.go
+++ b/beaconclient/multi_beacon_client.go
@@ -24,7 +24,7 @@ type IMultiBeaconClient interface {
 	BestSyncStatus() (*SyncStatusPayloadData, error)
 	SubscribeToHeadEvents(slotC chan HeadEventData)
 	// SubscribeToPayloadAttributesEvents subscribes to payload attributes events to validate fields such as prevrandao and withdrawals
-	SubscribeToPayloadAttributesEvents(payloadAttrC chan PayloadAttributesData)
+	SubscribeToPayloadAttributesEvents(payloadAttrC chan PayloadAttributesEvent)
 
 	// FetchValidators returns all active and pending validators from the beacon node
 	FetchValidators(headSlot uint64) (map[types.PubkeyHex]ValidatorResponseEntry, error)
@@ -43,7 +43,7 @@ type IBeaconInstance interface {
 	SyncStatus() (*SyncStatusPayloadData, error)
 	CurrentSlot() (uint64, error)
 	SubscribeToHeadEvents(slotC chan HeadEventData)
-	SubscribeToPayloadAttributesEvents(slotC chan PayloadAttributesData)
+	SubscribeToPayloadAttributesEvents(slotC chan PayloadAttributesEvent)
 	FetchValidators(headSlot uint64) (map[types.PubkeyHex]ValidatorResponseEntry, error)
 	GetProposerDuties(epoch uint64) (*ProposerDutiesResponse, error)
 	GetURI() string
@@ -142,7 +142,7 @@ func (c *MultiBeaconClient) SubscribeToHeadEvents(slotC chan HeadEventData) {
 	}
 }
 
-func (c *MultiBeaconClient) SubscribeToPayloadAttributesEvents(slotC chan PayloadAttributesData) {
+func (c *MultiBeaconClient) SubscribeToPayloadAttributesEvents(slotC chan PayloadAttributesEvent) {
 	for _, instance := range c.beaconInstances {
 		go instance.SubscribeToPayloadAttributesEvents(slotC)
 	}

--- a/beaconclient/multi_beacon_client.go
+++ b/beaconclient/multi_beacon_client.go
@@ -23,7 +23,7 @@ var (
 type IMultiBeaconClient interface {
 	BestSyncStatus() (*SyncStatusPayloadData, error)
 	SubscribeToHeadEvents(slotC chan HeadEventData)
-	SubscribeToPayloadAttributes(slotC chan SyncStatusPayloadData)
+	SubscribeToPayloadAttributesEvents(slotC chan PayloadAttributesData)
 
 	// FetchValidators returns all active and pending validators from the beacon node
 	FetchValidators(headSlot uint64) (map[types.PubkeyHex]ValidatorResponseEntry, error)
@@ -42,6 +42,7 @@ type IBeaconInstance interface {
 	SyncStatus() (*SyncStatusPayloadData, error)
 	CurrentSlot() (uint64, error)
 	SubscribeToHeadEvents(slotC chan HeadEventData)
+	SubscribeToPayloadAttributesEvents(slotC chan PayloadAttributesData)
 	FetchValidators(headSlot uint64) (map[types.PubkeyHex]ValidatorResponseEntry, error)
 	GetProposerDuties(epoch uint64) (*ProposerDutiesResponse, error)
 	GetURI() string
@@ -137,6 +138,12 @@ func (c *MultiBeaconClient) BestSyncStatus() (*SyncStatusPayloadData, error) {
 func (c *MultiBeaconClient) SubscribeToHeadEvents(slotC chan HeadEventData) {
 	for _, instance := range c.beaconInstances {
 		go instance.SubscribeToHeadEvents(slotC)
+	}
+}
+
+func (c *MultiBeaconClient) SubscribeToPayloadAttributesEvents(slotC chan PayloadAttributesData) {
+	for _, instance := range c.beaconInstances {
+		go instance.SubscribeToPayloadAttributesEvents(slotC)
 	}
 }
 

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -60,8 +60,9 @@ func (c *ProdBeaconInstance) SubscribeToHeadEvents(slotC chan HeadEventData) {
 	log := c.log.WithField("url", eventsURL)
 	log.Info("subscribing to head events")
 
+	client := sse.NewClient(eventsURL)
+
 	for {
-		client := sse.NewClient(eventsURL)
 		err := client.SubscribeRaw(func(msg *sse.Event) {
 			var data HeadEventData
 			err := json.Unmarshal(msg.Data, &data)
@@ -84,8 +85,9 @@ func (c *ProdBeaconInstance) SubscribeToPayloadAttributesEvents(payloadAttribute
 	log := c.log.WithField("url", eventsURL)
 	log.Info("subscribing to payload_attributes events")
 
+	client := sse.NewClient(eventsURL)
+
 	for {
-		client := sse.NewClient(eventsURL)
 		err := client.SubscribeRaw(func(msg *sse.Event) {
 			var data PayloadAttributesData
 			err := json.Unmarshal(msg.Data, &data)

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -34,6 +34,29 @@ type HeadEventData struct {
 	State string `json:"state"`
 }
 
+// PayloadAttributeData represents the data of a payload_attributes event
+// {"version": "capella", "data": {"proposer_index": "123", "proposal_slot": "10", "parent_block_number": "9", "parent_block_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "parent_block_hash": "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "payload_attributes": {"timestamp": "123456", "prev_randao": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "suggested_fee_recipient": "0x0000000000000000000000000000000000000000", "withdrawals": [{"index": "5", "validator_index": "10", "address": "0x0000000000000000000000000000000000000000", "amount": "15640"}]}}}
+type PayloadAttributeData struct {
+	Version string `json:"version"`
+	Data    struct {
+		ProposalSlot        string `json:"proposal_slot"`
+		ParentBlockHash     string `json:"parent_block_hash"`
+		PayloadAttributes   PayloadAttributes `json:"payload_attributes"`
+	} `json:"data"`
+}
+
+type PayloadAttributes struct {
+	Timestamp           uint64 `json:"timestamp"`
+	PrevRandao          string `json:"prev_randao"`
+	SuggestedFeeRecipient string `json:"suggested_fee_recipient"`
+	Withdrawals         []struct {
+		Index         string `json:"index"`
+		ValidatorIndex string `json:"validator_index"`
+		Address       string `json:"address"`
+		Amount        string `json:"amount"`
+	} `json:"withdrawals"`
+}
+
 func (c *ProdBeaconInstance) SubscribeToHeadEvents(slotC chan HeadEventData) {
 	eventsURL := fmt.Sprintf("%s/eth/v1/events?topics=head", c.beaconURI)
 	log := c.log.WithField("url", eventsURL)

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -39,15 +39,20 @@ type HeadEventData struct {
 type PayloadAttributesData struct {
 	Version string `json:"version"`
 	Data    struct {
+		ProposerIndex     uint64            `json:"proposer_index,string"`
 		ProposalSlot      uint64            `json:"proposal_slot,string"`
+		ParentBlockNumber uint64            `json:"parent_block_number,string"`
+		ParentBlockRoot   string            `json:"parent_block_root"`
 		ParentBlockHash   string            `json:"parent_block_hash"`
 		PayloadAttributes PayloadAttributes `json:"payload_attributes"`
 	} `json:"data"`
 }
 
 type PayloadAttributes struct {
-	PrevRandao  string                `json:"prev_randao"`
-	Withdrawals []*capella.Withdrawal `json:"withdrawals"`
+	Timestamp             uint64                `json:"timestamp,string"`
+	PrevRandao            string                `json:"prev_randao"`
+	SuggestedFeeRecipient string                `json:"suggested_fee_recipient"`
+	Withdrawals           []*capella.Withdrawal `json:"withdrawals"`
 }
 
 func (c *ProdBeaconInstance) SubscribeToHeadEvents(slotC chan HeadEventData) {

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -34,18 +34,20 @@ type HeadEventData struct {
 	State string `json:"state"`
 }
 
-// PayloadAttributesData represents the data of a payload_attributes event
+// PayloadAttributesEvent represents the data of a payload_attributes event
 // {"version": "capella", "data": {"proposer_index": "123", "proposal_slot": "10", "parent_block_number": "9", "parent_block_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "parent_block_hash": "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "payload_attributes": {"timestamp": "123456", "prev_randao": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "suggested_fee_recipient": "0x0000000000000000000000000000000000000000", "withdrawals": [{"index": "5", "validator_index": "10", "address": "0x0000000000000000000000000000000000000000", "amount": "15640"}]}}}
-type PayloadAttributesData struct {
-	Version string `json:"version"`
-	Data    struct {
-		ProposerIndex     uint64            `json:"proposer_index,string"`
-		ProposalSlot      uint64            `json:"proposal_slot,string"`
-		ParentBlockNumber uint64            `json:"parent_block_number,string"`
-		ParentBlockRoot   string            `json:"parent_block_root"`
-		ParentBlockHash   string            `json:"parent_block_hash"`
-		PayloadAttributes PayloadAttributes `json:"payload_attributes"`
-	} `json:"data"`
+type PayloadAttributesEvent struct {
+	Version string                     `json:"version"`
+	Data    PayloadAttributesEventData `json:"data"`
+}
+
+type PayloadAttributesEventData struct {
+	ProposerIndex     uint64            `json:"proposer_index,string"`
+	ProposalSlot      uint64            `json:"proposal_slot,string"`
+	ParentBlockNumber uint64            `json:"parent_block_number,string"`
+	ParentBlockRoot   string            `json:"parent_block_root"`
+	ParentBlockHash   string            `json:"parent_block_hash"`
+	PayloadAttributes PayloadAttributes `json:"payload_attributes"`
 }
 
 type PayloadAttributes struct {
@@ -80,7 +82,7 @@ func (c *ProdBeaconInstance) SubscribeToHeadEvents(slotC chan HeadEventData) {
 	}
 }
 
-func (c *ProdBeaconInstance) SubscribeToPayloadAttributesEvents(payloadAttributesC chan PayloadAttributesData) {
+func (c *ProdBeaconInstance) SubscribeToPayloadAttributesEvents(payloadAttributesC chan PayloadAttributesEvent) {
 	eventsURL := fmt.Sprintf("%s/eth/v1/events?topics=payload_attributes", c.beaconURI)
 	log := c.log.WithField("url", eventsURL)
 	log.Info("subscribing to payload_attributes events")
@@ -89,7 +91,7 @@ func (c *ProdBeaconInstance) SubscribeToPayloadAttributesEvents(payloadAttribute
 
 	for {
 		err := client.SubscribeRaw(func(msg *sse.Event) {
-			var data PayloadAttributesData
+			var data PayloadAttributesEvent
 			err := json.Unmarshal(msg.Data, &data)
 			if err != nil {
 				log.WithError(err).Error("could not unmarshal payload_attributes event")

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -34,27 +34,19 @@ type HeadEventData struct {
 	State string `json:"state"`
 }
 
-// PayloadAttributeData represents the data of a payload_attributes event
+// PayloadAttributesData represents the data of a payload_attributes event
 // {"version": "capella", "data": {"proposer_index": "123", "proposal_slot": "10", "parent_block_number": "9", "parent_block_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "parent_block_hash": "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf", "payload_attributes": {"timestamp": "123456", "prev_randao": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "suggested_fee_recipient": "0x0000000000000000000000000000000000000000", "withdrawals": [{"index": "5", "validator_index": "10", "address": "0x0000000000000000000000000000000000000000", "amount": "15640"}]}}}
-type PayloadAttributeData struct {
+type PayloadAttributesData struct {
 	Version string `json:"version"`
 	Data    struct {
-		ProposalSlot        string `json:"proposal_slot"`
-		ParentBlockHash     string `json:"parent_block_hash"`
-		PayloadAttributes   PayloadAttributes `json:"payload_attributes"`
+		ProposalSlot      uint64            `json:"proposal_slot,string"`
+		PayloadAttributes PayloadAttributes `json:"payload_attributes"`
 	} `json:"data"`
 }
 
 type PayloadAttributes struct {
-	Timestamp           uint64 `json:"timestamp"`
-	PrevRandao          string `json:"prev_randao"`
-	SuggestedFeeRecipient string `json:"suggested_fee_recipient"`
-	Withdrawals         []struct {
-		Index         string `json:"index"`
-		ValidatorIndex string `json:"validator_index"`
-		Address       string `json:"address"`
-		Amount        string `json:"amount"`
-	} `json:"withdrawals"`
+	PrevRandao  string                `json:"prev_randao"`
+	Withdrawals []*capella.Withdrawal `json:"withdrawals"`
 }
 
 func (c *ProdBeaconInstance) SubscribeToHeadEvents(slotC chan HeadEventData) {
@@ -75,6 +67,30 @@ func (c *ProdBeaconInstance) SubscribeToHeadEvents(slotC chan HeadEventData) {
 		})
 		if err != nil {
 			log.WithError(err).Error("failed to subscribe to head events")
+			time.Sleep(1 * time.Second)
+		}
+		c.log.Warn("beaconclient SubscribeRaw ended, reconnecting")
+	}
+}
+
+func (c *ProdBeaconInstance) SubscribeToPayloadAttributesEvents(payloadAttributesC chan PayloadAttributesData) {
+	eventsURL := fmt.Sprintf("%s/eth/v1/events?topics=payload_attributes", c.beaconURI)
+	log := c.log.WithField("url", eventsURL)
+	log.Info("subscribing to payload_attributes events")
+
+	for {
+		client := sse.NewClient(eventsURL)
+		err := client.SubscribeRaw(func(msg *sse.Event) {
+			var data PayloadAttributesData
+			err := json.Unmarshal(msg.Data, &data)
+			if err != nil {
+				log.WithError(err).Error("could not unmarshal payload_attributes event")
+			} else {
+				payloadAttributesC <- data
+			}
+		})
+		if err != nil {
+			log.WithError(err).Error("failed to subscribe to payload_attributes events")
 			time.Sleep(1 * time.Second)
 		}
 		c.log.Warn("beaconclient SubscribeRaw ended, reconnecting")

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -40,6 +40,7 @@ type PayloadAttributesData struct {
 	Version string `json:"version"`
 	Data    struct {
 		ProposalSlot      uint64            `json:"proposal_slot,string"`
+		ParentBlockHash   string            `json:"parent_block_hash"`
 		PayloadAttributes PayloadAttributes `json:"payload_attributes"`
 	} `json:"data"`
 }

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -476,7 +476,9 @@ func (api *RelayAPI) startValidatorRegistrationDBProcessor() {
 
 func (api *RelayAPI) processPayloadAttributes(payloadAttributes beaconclient.PayloadAttributesData) {
 	// only for builder-api and if using see subscriptions instead of querying for payload attributes
-	if api.opts.BlockBuilderAPI && api.ffDisableQueryPayloadAttributes {
+	if !api.opts.BlockBuilderAPI || !api.ffDisableQueryPayloadAttributes {
+		return
+	}
 		apiHeadSlot := api.headSlot.Load()
 		proposalSlot := payloadAttributes.Data.ProposalSlot
 		if proposalSlot <= apiHeadSlot {

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -476,9 +476,7 @@ func (api *RelayAPI) startValidatorRegistrationDBProcessor() {
 
 func (api *RelayAPI) processPayloadAttributes(payloadAttributes beaconclient.PayloadAttributesData) {
 	// only for builder-api and if using see subscriptions instead of querying for payload attributes
-	if !api.opts.BlockBuilderAPI || !api.ffDisableQueryPayloadAttributes {
-		return
-	}
+	if api.opts.BlockBuilderAPI && api.ffDisableQueryPayloadAttributes {
 		apiHeadSlot := api.headSlot.Load()
 		proposalSlot := payloadAttributes.Data.ProposalSlot
 		if proposalSlot <= apiHeadSlot {


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Adds SSE payload attributes subscription on the relay.

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
As part of https://github.com/ethereum/beacon-APIs/pull/305 SSE endpoint providing payload attributes allows the relay to retrieve `prev_randao` and `withdrawals` with a custom BN fork to retrieve this information. 

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
