### PR TITLE
Publish block before returning to proposer

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 #### Feature Flags
 
 * `DISABLE_PAYLOAD_DATABASE_STORAGE` - builder API - disable storing execution payloads in the database (i.e. when using memcached as data availability redundancy)
-* `DISABLE_BLOCK_PUBLISHING` - disable publishing blocks to the beacon node at the end of getPayload
 * `DISABLE_LOWPRIO_BUILDERS` - reject block submissions by low-prio builders
 * `FORCE_GET_HEADER_204` - force 204 as getHeader response
 * `DISABLE_SSE_PAYLOAD_ATTRIBUTES` - instead of using SSE events, poll withdrawals and randao (requires custom Prysm fork)

--- a/beaconclient/multi_beacon_client.go
+++ b/beaconclient/multi_beacon_client.go
@@ -246,20 +246,20 @@ func (c *MultiBeaconClient) PublishBlock(block *common.SignedBeaconBlock) (code 
 	for i := 0; i < len(clients); i++ {
 		res := <-resChans
 		if res.err != nil {
-			log.WithField("beaconIndex", res.index).WithField("statusCode", res.code).WithError(res.err).Error("failed to publish block")
+			log.WithField("beacon", clients[res.index].GetURI()).WithField("statusCode", res.code).WithError(res.err).Error("failed to publish block")
 			lastErrPublishResp = res
 			continue
 		} else if res.code == 202 {
 			// Should the block fail full validation, a separate success response code (202) is used to indicate that the block was successfully broadcast but failed integration.
 			// https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/publishBlock
-			log.WithField("beaconIndex", res.index).WithField("statusCode", res.code).WithError(res.err).Error("block failed validation but was still broadcast")
+			log.WithField("beacon", clients[res.index].GetURI()).WithField("statusCode", res.code).WithError(res.err).Error("block failed validation but was still broadcast")
 			lastErrPublishResp = res
 			continue
 		}
 
 		c.bestBeaconIndex.Store(int64(res.index))
 
-		log.WithField("beaconIndex", res.index).WithField("statusCode", res.code).Info("published block")
+		log.WithField("beacon", clients[res.index].GetURI()).WithField("statusCode", res.code).Info("published block")
 		return res.code, nil
 	}
 

--- a/beaconclient/multi_beacon_client.go
+++ b/beaconclient/multi_beacon_client.go
@@ -232,14 +232,14 @@ func (c *MultiBeaconClient) PublishBlock(block *common.SignedBeaconBlock) (code 
 	for i, client := range clients {
 		log := log.WithField("uri", client.GetURI())
 		log.Debug("publishing block")
-		go func(i int) {
+		go func(index int, client IBeaconInstance) {
 			code, err := client.PublishBlock(block)
 			resChans <- publishResp{
-				index: i,
+				index: index,
 				code:  code,
 				err:   err,
 			}
-		}(i)
+		}(i, client)
 	}
 
 	var lastErrPublishResp publishResp

--- a/beaconclient/multi_beacon_client.go
+++ b/beaconclient/multi_beacon_client.go
@@ -246,24 +246,24 @@ func (c *MultiBeaconClient) PublishBlock(block *common.SignedBeaconBlock) (code 
 	for i := 0; i < len(clients); i++ {
 		res := <-resChans
 		if res.err != nil {
-			log.WithField("statusCode", res.code).WithError(res.err).Error("failed to publish block")
+			log.WithField("beaconIndex", res.index).WithField("statusCode", res.code).WithError(res.err).Error("failed to publish block")
 			lastErrPublishResp = res
 			continue
 		} else if res.code == 202 {
 			// Should the block fail full validation, a separate success response code (202) is used to indicate that the block was successfully broadcast but failed integration.
 			// https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/publishBlock
-			log.WithField("statusCode", res.code).WithError(res.err).Error("block failed validation but was still broadcast")
+			log.WithField("beaconIndex", res.index).WithField("statusCode", res.code).WithError(res.err).Error("block failed validation but was still broadcast")
 			lastErrPublishResp = res
 			continue
 		}
 
 		c.bestBeaconIndex.Store(int64(res.index))
 
-		log.WithField("statusCode", res.code).Info("published block")
+		log.WithField("beaconIndex", res.index).WithField("statusCode", res.code).Info("published block")
 		return res.code, nil
 	}
 
-	log.WithField("statusCode", lastErrPublishResp.code).WithError(lastErrPublishResp.err).Error("failed to publish block on any CL node")
+	log.Error("failed to publish block on any CL node")
 	return lastErrPublishResp.code, lastErrPublishResp.err
 }
 

--- a/beaconclient/multi_beacon_client.go
+++ b/beaconclient/multi_beacon_client.go
@@ -211,6 +211,12 @@ func (c *MultiBeaconClient) beaconInstancesByLastResponse() []IBeaconInstance {
 	return instances
 }
 
+type publishResp struct {
+	index int
+	code  int
+	err   error
+}
+
 // PublishBlock publishes the signed beacon block via https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/publishBlock
 func (c *MultiBeaconClient) PublishBlock(block *common.SignedBeaconBlock) (code int, err error) {
 	log := c.log.WithFields(logrus.Fields{
@@ -219,29 +225,46 @@ func (c *MultiBeaconClient) PublishBlock(block *common.SignedBeaconBlock) (code 
 	})
 
 	clients := c.beaconInstancesByLastResponse()
+
+	// The chan will be cleaner up automatically once the function exists even if it was still being written to
+	resChans := make(chan publishResp, len(clients))
+
 	for i, client := range clients {
 		log := log.WithField("uri", client.GetURI())
 		log.Debug("publishing block")
+		go func(i int) {
+			code, err := client.PublishBlock(block)
+			resChans <- publishResp{
+				index: i,
+				code:  code,
+				err:   err,
+			}
+		}(i)
+	}
 
-		if code, err = client.PublishBlock(block); err != nil {
-			log.WithField("statusCode", code).WithError(err).Error("failed to publish block")
+	var lastErrPublishResp publishResp
+	for i := 0; i < len(clients); i++ {
+		res := <-resChans
+		if res.err != nil {
+			log.WithField("statusCode", res.code).WithError(res.err).Error("failed to publish block")
+			lastErrPublishResp = res
 			continue
-		} else if code == 202 {
+		} else if res.code == 202 {
 			// Should the block fail full validation, a separate success response code (202) is used to indicate that the block was successfully broadcast but failed integration.
 			// https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/publishBlock
-			log.WithField("statusCode", code).WithError(err).Error("block failed validation but was still broadcast")
-			err = ErrBeaconBlock202
+			log.WithField("statusCode", res.code).WithError(res.err).Error("block failed validation but was still broadcast")
+			lastErrPublishResp = res
 			continue
 		}
 
-		c.bestBeaconIndex.Store(int64(i))
+		c.bestBeaconIndex.Store(int64(res.index))
 
-		log.WithField("statusCode", code).Info("published block")
-		return code, nil
+		log.WithField("statusCode", res.code).Info("published block")
+		return res.code, nil
 	}
 
-	log.WithField("statusCode", code).WithError(err).Error("failed to publish block on any CL node")
-	return code, err
+	log.WithField("statusCode", lastErrPublishResp.code).WithError(lastErrPublishResp.err).Error("failed to publish block on any CL node")
+	return lastErrPublishResp.code, lastErrPublishResp.err
 }
 
 // GetGenesis returns the genesis info - https://ethereum.github.io/beacon-APIs/#/Beacon/getGenesis

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -72,6 +72,7 @@ var (
 	numActiveValidatorProcessors = cli.GetEnvInt("NUM_ACTIVE_VALIDATOR_PROCESSORS", 10)
 	numValidatorRegProcessors    = cli.GetEnvInt("NUM_VALIDATOR_REG_PROCESSORS", 10)
 	timeoutGetPayloadRetryMs     = cli.GetEnvInt("GETPAYLOAD_RETRY_TIMEOUT_MS", 100)
+	timeoutGetPayloadResponseMs  = cli.GetEnvInt("GETPAYLOAD_RESPONSE_TIMEOUT_MS", 1000)
 
 	apiReadTimeoutMs       = cli.GetEnvInt("API_TIMEOUT_READ_MS", 1500)
 	apiReadHeaderTimeoutMs = cli.GetEnvInt("API_TIMEOUT_READHEADER_MS", 600)
@@ -983,6 +984,9 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 		api.RespondError(w, http.StatusBadRequest, "failed to publish block")
 		return
 	}
+
+	// give the beacon network some time to propagate the block
+	time.Sleep(time.Duration(timeoutGetPayloadResponseMs) * time.Millisecond)
 
 	api.RespondOK(w, getPayloadResp)
 	log = log.WithFields(logrus.Fields{


### PR DESCRIPTION
## 📝 Summary

This change publishes the code to the beacon network before returning to the proposer.

Important note: relays should run multiple beacon nodes! if publishing through the local beacon nodes fails, the payload won't get returned to the proposer and lead to a missed slot.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
