### PR TITLE
Remove blocked_validator functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 ```
 
 
-### Environment variables
+## Environment variables
+
+#### General
 
 * `ACTIVE_VALIDATOR_HOURS` - number of hours to track active proposers in redis (default: 3)
 * `API_TIMEOUT_READ_MS` - http read timeout in milliseconds (default: 1500)
@@ -160,7 +162,7 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `RUN_INTEGRATION_TESTS` - when set to "1" enables integration tests, currently used for testing Memcached using comma separated list of endpoints specified by `MEMCACHED_URIS`
 * `TEST_DB_DSN` - specifies connection string using Data Source Name (DSN) for Postgres (default: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable)
 
-### Updating the website
+## Updating the website
 
 * Edit the HTML in `services/website/website.html`
 * Edit template values in `testdata/website-htmldata.json`
@@ -172,11 +174,10 @@ The website is using:
 * [PureCSS](https://purecss.io/)
 * [HeroIcons](https://heroicons.com/)
 
----
 
 # Technical Notes
 
-See [ARCHITECTURE.md](ARCHITECTURE.md) for more technical details!
+See [ARCHITECTURE.md](ARCHITECTURE.md) and [Running MEV-Boost-Relay at scale](https://flashbots.notion.site/Draft-Running-a-relay-4040ccd5186c425d9a860cbb29bbfe09) for more technical details!
 
 ### Storing execution payloads and redundant data availability
 
@@ -192,20 +193,6 @@ To enable memcached, you just need to supply the memcached URIs either via envir
 
 You can disable storing the execution payloads in the database with this environment variable:
 `DISABLE_PAYLOAD_DATABASE_STORAGE=1`.
-
-
-### blocked_validators
-
-DISABLED
-
-blocked_validators table is empty by default, relay operators can add proposer pubkeys to the list.
-
-blocked_validators is used to prevent known attackers from exploiting the system. It is an optional list for relays
-to protect against known attackers: there is no reason to add any proposer that is not a known attacker.
-
-Blocked_validators is disabled and not running for any relays.
-
-
 
 ### Builder submission validation nodes
 

--- a/database/database.go
+++ b/database/database.go
@@ -3,9 +3,7 @@ package database
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -45,10 +43,6 @@ type IDatabaseService interface {
 	SetBlockBuilderStatus(pubkey string, isHighPrio, isBlacklisted bool) error
 	UpsertBlockBuilderEntryAfterSubmission(lastSubmission *BuilderBlockSubmissionEntry, isError bool) error
 	IncBlockBuilderStatsAfterGetPayload(builderPubkey string) error
-
-	InsertBlockedValidator(entry BlockedValidatorEntry) error
-	GetBlockedValidator(pubkey string) (*BlockedValidatorEntry, error)
-	IsValidatorBlocked(pubkey string) (bool, error)
 }
 
 type DatabaseService struct {
@@ -494,29 +488,4 @@ func (s *DatabaseService) DeleteExecutionPayloads(idFirst, idLast uint64) error 
 	query := `DELETE FROM ` + vars.TableExecutionPayload + ` WHERE id >= $1 AND id <= $2`
 	_, err := s.DB.Exec(query, idFirst, idLast)
 	return err
-}
-
-func (s *DatabaseService) InsertBlockedValidator(entry BlockedValidatorEntry) error {
-	query := `INSERT INTO ` + vars.TableBlockedValidator + `
-		(pubkey, is_blocked, notes) VALUES (:pubkey, :is_blocked, :notes)`
-	_, err := s.DB.NamedExec(query, entry)
-	return err
-}
-
-func (s *DatabaseService) GetBlockedValidator(pubkey string) (*BlockedValidatorEntry, error) {
-	query := `SELECT id, inserted_at, pubkey, is_blocked, notes FROM ` + vars.TableBlockedValidator + ` WHERE pubkey=$1;`
-	entry := &BlockedValidatorEntry{}
-	err := s.DB.Get(entry, query, pubkey)
-	return entry, err
-}
-
-func (s *DatabaseService) IsValidatorBlocked(pubkey string) (bool, error) {
-	entry, err := s.GetBlockedValidator(pubkey)
-	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return entry.Blocked, nil
 }

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -137,29 +137,3 @@ func TestMigrations(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(migrations.Migrations.Migrations), rowCount)
 }
-
-func TestBlockedValidator(t *testing.T) {
-	db := resetDatabase(t)
-
-	testValidator := BlockedValidatorEntry{
-		Pubkey:  "0x8996515293fcd87ca09b5c6ffe5c17f043c6a1a3639cc9494a82ec8eb50a9b55c34b47675e573be40d9be308b1ca2908",
-		Blocked: true,
-		Notes:   "evil actor",
-	}
-	err := db.InsertBlockedValidator(testValidator)
-	require.NoError(t, err)
-
-	out, err := db.GetBlockedValidator(testValidator.Pubkey)
-	require.NoError(t, err)
-	require.Equal(t, testValidator.Pubkey, out.Pubkey)
-	require.Equal(t, testValidator.Blocked, out.Blocked)
-	require.Equal(t, testValidator.Notes, out.Notes)
-
-	blocked, err := db.IsValidatorBlocked(testValidator.Pubkey)
-	require.NoError(t, err)
-	require.True(t, blocked)
-
-	blocked, err = db.IsValidatorBlocked("0x0")
-	require.NoError(t, err)
-	require.False(t, blocked)
-}

--- a/database/migrations/005_remove_blocked_validator.go
+++ b/database/migrations/005_remove_blocked_validator.go
@@ -1,0 +1,17 @@
+package migrations
+
+import (
+	"github.com/flashbots/mev-boost-relay/database/vars"
+	migrate "github.com/rubenv/sql-migrate"
+)
+
+var Migration005RemoveBlockedValidator = &migrate.Migration{
+	Id: "005-remove-blocked-validator",
+	Up: []string{`
+		DROP TABLE IF EXISTS ` + vars.TableBlockedValidator + `;
+	`},
+	Down: []string{},
+
+	DisableTransactionUp:   true,
+	DisableTransactionDown: true,
+}

--- a/database/migrations/migration.go
+++ b/database/migrations/migration.go
@@ -11,5 +11,6 @@ var Migrations = migrate.MemoryMigrationSource{
 		Migration002RemoveIsBestAddReceivedAt,
 		Migration003AddEligibleAtSignedAt,
 		Migration004BlockedValidator,
+		Migration005RemoveBlockedValidator,
 	},
 }

--- a/database/mockdb.go
+++ b/database/mockdb.go
@@ -99,15 +99,3 @@ func (db MockDB) IncBlockBuilderStatsAfterGetHeader(slot uint64, blockhash strin
 func (db MockDB) IncBlockBuilderStatsAfterGetPayload(builderPubkey string) error {
 	return nil
 }
-
-func (db MockDB) InsertBlockedValidator(entry BlockedValidatorEntry) error {
-	return nil
-}
-
-func (db MockDB) GetBlockedValidator(pubkey string) (*BlockedValidatorEntry, error) {
-	return nil, nil
-}
-
-func (db MockDB) IsValidatorBlocked(pubkey string) (bool, error) {
-	return false, nil
-}

--- a/database/types.go
+++ b/database/types.go
@@ -60,15 +60,6 @@ type ValidatorRegistrationEntry struct {
 	Signature    string `db:"signature"`
 }
 
-type BlockedValidatorEntry struct {
-	ID         int64     `db:"id"`
-	InsertedAt time.Time `db:"inserted_at"`
-
-	Pubkey  string `db:"pubkey"`
-	Blocked bool   `db:"is_blocked"`
-	Notes   string `db:"notes"`
-}
-
 func (reg ValidatorRegistrationEntry) ToSignedValidatorRegistration() (*types.SignedValidatorRegistration, error) {
 	pubkey, err := types.HexToPubkey(reg.Pubkey)
 	if err != nil {

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1031,18 +1031,6 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	// Check if validator is blocked.
-	// TODO: periodic get all blocked validators and store in memory (in bg goroutine)
-	// blocked, err := api.db.IsValidatorBlocked(pk.String())
-	// if err != nil {
-	// 	log.WithError(err).Error("unable to get validator blocked status")
-	// } else if blocked {
-	// 	log.Warn("validator is blocked")
-	// 	api.RespondError(w, http.StatusBadRequest, "validator is blocked")
-	// 	return
-	// }
-	// log = log.WithField("timestampAfterBlockCheck", time.Now().UTC().UnixMilli())
-
 	// Check whether getPayload has already been called
 	slotLastPayloadDelivered, err := api.redis.GetStatsUint64(datastore.RedisStatsFieldSlotLastPayloadDelivered)
 	if err != nil && !errors.Is(err, redis.Nil) {


### PR DESCRIPTION
## 📝 Summary

The ability to block validators was a temporary measure implemented in firefighting mode to prevent additional attacks by known malicious actors. See also https://collective.flashbots.net/t/post-mortem-april-3rd-2023-mev-boost-relay-incident-and-related-timing-issue/1540 for more details.

Thanks for good points from the community, and we agree with you entirely and remove the code in this PR.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
