### PR TITLE
support multiple parents

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -506,7 +506,7 @@ func (api *RelayAPI) processPayloadAttributes(payloadAttributes beaconclient.Pay
 	var err error
 	if api.isCapella(payloadAttrSlot) {
 		withdrawalsRoot, err = ComputeWithdrawalsRoot(payloadAttributes.Data.PayloadAttributes.Withdrawals)
-		log = log.WithField("withdrawalsRoot", withdrawalsRoot)
+		log = log.WithField("withdrawalsRoot", withdrawalsRoot.String())
 		if err != nil {
 			log.WithError(err).Error("error computing withdrawals root")
 			return
@@ -1285,8 +1285,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	if withdrawals := payload.Withdrawals(); withdrawals != nil {
-		// get latest withdrawals and verify the roots match
+	if api.isCapella(payload.Slot()) { // Capella requires correct withdrawals
 		withdrawalsRoot, err := ComputeWithdrawalsRoot(payload.Withdrawals())
 		if err != nil {
 			log.WithError(err).Warn("could not compute withdrawals root from payload")

--- a/services/api/utils.go
+++ b/services/api/utils.go
@@ -15,6 +15,7 @@ var (
 	ErrParentHashMismatch = errors.New("parentHash mismatch")
 
 	ErrNoPayloads               = errors.New("no payloads")
+	ErrNoWithdrawals            = errors.New("no withdrawals")
 	ErrPayloadMismatchBellatrix = errors.New("bellatrix beacon-block but no bellatrix payload")
 	ErrPayloadMismatchCapella   = errors.New("capella beacon-block but no capella payload")
 	ErrHeaderHTRMismatch        = errors.New("beacon-block and payload header mismatch")
@@ -38,6 +39,9 @@ func checkBLSPublicKeyHex(pkHex string) error {
 }
 
 func ComputeWithdrawalsRoot(w []*capella.Withdrawal) (phase0.Root, error) {
+	if w == nil {
+		return phase0.Root{}, ErrNoWithdrawals
+	}
 	withdrawals := utilcapella.ExecutionPayloadWithdrawals{Withdrawals: w}
 	return withdrawals.HashTreeRoot()
 }


### PR DESCRIPTION
## 📝 Summary

Allow builder submissions for multiple parents (for any known through the received `payload_attributes` SSE events)!

- Remove polling of withdrawals and randao, as they don't allow for multiple parents
- See also https://github.com/flashbots/mev-boost-relay/issues/326
- This might also solve the problems we've been seeing with Prysm v4 leading to increased `incorrect prev_randao` error rates for block builder submissions.
- Note: there's a new log message if the first check for the parent of block builder submissions fails: `payload attributes not (yet) known`

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
