### PR TITLE
memcached timeout + max-idle-conns

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `GETPAYLOAD_RETRY_TIMEOUT_MS` - getPayload retry getting a payload if first try failed (default: 100)
 * `MEMCACHED_URIS` - optional comma separated list of memcached endpoints, typically used as secondary storage alongside Redis
 * `MEMCACHED_EXPIRY_SECONDS` - item expiry timeout when using memcache (default: 45)
+* `MEMCACHED_CLIENT_TIMEOUT_MS` - client timeout in milliseconds (default: 250)
+* `MEMCACHED_MAX_IDLE_CONNS` - client max idle conns (default: 10)
 * `NUM_ACTIVE_VALIDATOR_PROCESSORS` - proposer API - number of goroutines to listen to the active validators channel
 * `NUM_VALIDATOR_REG_PROCESSORS` - proposer API - number of goroutines to listen to the validator registration channel
 

--- a/datastore/memcached.go
+++ b/datastore/memcached.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/flashbots/go-utils/cli"
@@ -12,6 +13,8 @@ import (
 
 var (
 	defaultMemcachedExpirySeconds = int32(cli.GetEnvInt("MEMCACHED_EXPIRY_SECONDS", 45))
+	defaultMemcachedTimeoutMs     = cli.GetEnvInt("MEMCACHED_CLIENT_TIMEOUT_MS", 250)
+	defaultMemcachedMaxIdleConns  = cli.GetEnvInt("MEMCACHED_MAX_IDLE_CONNS", 10)
 
 	ErrInvalidProposerPublicKey = errors.New("invalid proposer public key specified")
 	ErrInvalidBlockHash         = errors.New("invalid block hash specified")
@@ -89,6 +92,9 @@ func NewMemcached(prefix string, servers ...string) (*Memcached, error) {
 	if err := client.Ping(); err != nil {
 		return nil, err
 	}
+
+	client.MaxIdleConns = defaultMemcachedMaxIdleConns
+	client.Timeout = time.Duration(defaultMemcachedTimeoutMs) * time.Millisecond
 
 	return &Memcached{client: client, keyPrefix: prefix}, nil
 }


### PR DESCRIPTION
## 📝 Summary

Memcached config options: `MEMCACHED_CLIENT_TIMEOUT_MS` and `MEMCACHED_MAX_IDLE_CONNS`

Replaces #337

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
