### PR TITLE
redis cleanup for switch to storing proposers by index

### DIFF
--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -182,6 +182,11 @@ func (r *RedisCache) GetKnownValidators() (map[uint64]boostTypes.PubkeyHex, erro
 		return nil, err
 	}
 	for proposerIndexStr, pubkey := range entries {
+		if strings.HasPrefix(proposerIndexStr, "0x") {
+			// remove -- it's an artifact of the previous storage by pubkey
+			r.client.HDel(context.Background(), r.keyKnownValidators, proposerIndexStr)
+			continue
+		}
 		proposerIndex, err := strconv.ParseUint(proposerIndexStr, 10, 64)
 		if err == nil {
 			validators[proposerIndex] = boostTypes.PubkeyHex(pubkey)


### PR DESCRIPTION
## 📝 Summary

The switch from storing proposers in Redis by pubkey to storing by index (see https://github.com/flashbots/mev-boost-relay/commit/bccadc5de9816a05ddebc496252e6f2183b9004b) duplicated the amount of fields in the redis hash, because the old pubkeys are still left in there.

This PR deletes these if encountered.

You will notice the number of fields in the Redis hash halving:

```
hlen boost-relay/mainnet:known-validators
```

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
