### PR TITLE
support for custom eth networks

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -81,6 +81,7 @@ var apiCmd = &cobra.Command{
 			log.WithError(err).Fatalf("error getting network details")
 		}
 		log.Infof("Using network: %s", networkInfo.Name)
+		log.Debug(networkInfo.String())
 
 		// Connect to beacon clients and ensure it's synced
 		if len(beaconNodeURIs) == 0 {

--- a/cmd/housekeeper.go
+++ b/cmd/housekeeper.go
@@ -42,6 +42,7 @@ var housekeeperCmd = &cobra.Command{
 			log.WithError(err).Fatalf("error getting network details")
 		}
 		log.Infof("Using network: %s", networkInfo.Name)
+		log.Debug(networkInfo.String())
 
 		// Connect to beacon clients and ensure it's synced
 		if len(beaconNodeURIs) == 0 {

--- a/cmd/website.go
+++ b/cmd/website.go
@@ -63,6 +63,7 @@ var websiteCmd = &cobra.Command{
 		}
 
 		log.Infof("Using network: %s", networkInfo.Name)
+		log.Debug(networkInfo.String())
 
 		// Connect to Redis
 		redis, err := datastore.NewRedisCache(redisURI, networkInfo.Name)

--- a/common/types.go
+++ b/common/types.go
@@ -60,18 +60,6 @@ func NewBuilderEntry(builderURL string) (entry *BuilderEntry, err error) {
 	}, nil
 }
 
-type EthNetworkDetails struct {
-	Name                     string
-	GenesisForkVersionHex    string
-	GenesisValidatorsRootHex string
-	BellatrixForkVersionHex  string
-	CapellaForkVersionHex    string
-
-	DomainBuilder                 boostTypes.Domain
-	DomainBeaconProposerBellatrix boostTypes.Domain
-	DomainBeaconProposerCapella   boostTypes.Domain
-}
-
 var (
 	EthNetworkRopsten  = "ropsten"
 	EthNetworkSepolia  = "sepolia"
@@ -91,6 +79,18 @@ var (
 	BellatrixForkVersionZhejiang  = "0x00000071"
 	CapellaForkVersionZhejiang    = "0x00000072"
 )
+
+type EthNetworkDetails struct {
+	Name                     string
+	GenesisForkVersionHex    string
+	GenesisValidatorsRootHex string
+	BellatrixForkVersionHex  string
+	CapellaForkVersionHex    string
+
+	DomainBuilder                 boostTypes.Domain
+	DomainBeaconProposerBellatrix boostTypes.Domain
+	DomainBeaconProposerCapella   boostTypes.Domain
+}
 
 func NewEthNetworkDetails(networkName string) (ret *EthNetworkDetails, err error) {
 	var genesisForkVersion string
@@ -161,6 +161,11 @@ func NewEthNetworkDetails(networkName string) (ret *EthNetworkDetails, err error
 		DomainBeaconProposerBellatrix: domainBeaconProposerBellatrix,
 		DomainBeaconProposerCapella:   domainBeaconProposerCapella,
 	}, nil
+}
+
+func (e *EthNetworkDetails) String() string {
+	return fmt.Sprintf("EthNetworkDetails{Name: %s, GenesisForkVersionHex: %s, GenesisValidatorsRootHex: %s, BellatrixForkVersionHex: %s, CapellaForkVersionHex: %s, DomainBuilder: %x, DomainBeaconProposerBellatrix: %x, DomainBeaconProposerCapella: %x}",
+		e.Name, e.GenesisForkVersionHex, e.GenesisValidatorsRootHex, e.BellatrixForkVersionHex, e.CapellaForkVersionHex, e.DomainBuilder, e.DomainBeaconProposerBellatrix, e.DomainBeaconProposerCapella)
 }
 
 type BidTraceV2 struct {

--- a/common/types.go
+++ b/common/types.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/attestantio/go-builder-client/api"
@@ -77,6 +78,7 @@ var (
 	EthNetworkGoerli   = "goerli"
 	EthNetworkMainnet  = "mainnet"
 	EthNetworkZhejiang = "zhejiang"
+	EthNetworkCustom   = "custom"
 
 	CapellaForkVersionRopsten = "0x03001020"
 	CapellaForkVersionSepolia = "0x90000072"
@@ -125,6 +127,11 @@ func NewEthNetworkDetails(networkName string) (ret *EthNetworkDetails, err error
 		genesisValidatorsRoot = GenesisValidatorsRootZhejiang
 		bellatrixForkVersion = BellatrixForkVersionZhejiang
 		capellaForkVersion = CapellaForkVersionZhejiang
+	case EthNetworkCustom:
+		genesisForkVersion = os.Getenv("GENESIS_FORK_VERSION")
+		genesisValidatorsRoot = os.Getenv("GENESIS_VALIDATORS_ROOT")
+		bellatrixForkVersion = os.Getenv("BELLATRIX_FORK_VERSION")
+		capellaForkVersion = os.Getenv("CAPELLA_FORK_VERSION")
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrUnknownNetwork, networkName)
 	}


### PR DESCRIPTION
## 📝 Summary

Allow to specify custom network parameters instead of only the predefined ones. This simplifies participating in custom testnets and mainnet shadow forks.

To do so, use `--network custom` and set the details through these environment variables:

* `GENESIS_FORK_VERSION`
* `GENESIS_VALIDATORS_ROOT`
* `BELLATRIX_FORK_VERSION`
* `CAPELLA_FORK_VERSION`

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
