### PR TITLE
flexible user agent getHeader filtering by env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `MEMCACHED_MAX_IDLE_CONNS` - client max idle conns (default: 10)
 * `NUM_ACTIVE_VALIDATOR_PROCESSORS` - proposer API - number of goroutines to listen to the active validators channel
 * `NUM_VALIDATOR_REG_PROCESSORS` - proposer API - number of goroutines to listen to the validator registration channel
+* `NO_HEADER_USERAGENTS` - proposer API - comma separated list of user agents for which no bids should be returned
 
 #### Feature Flags
 

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -264,11 +264,13 @@ func (c *ProdBeaconInstance) PublishBlock(block *common.SignedBeaconBlock) (code
 }
 
 type GetGenesisResponse struct {
-	Data struct {
-		GenesisTime           uint64 `json:"genesis_time,string"`
-		GenesisValidatorsRoot string `json:"genesis_validators_root"`
-		GenesisForkVersion    string `json:"genesis_fork_version"`
-	}
+	Data GetGenesisResponseData `json:"data"`
+}
+
+type GetGenesisResponseData struct {
+	GenesisTime           uint64 `json:"genesis_time,string"`
+	GenesisValidatorsRoot string `json:"genesis_validators_root"`
+	GenesisForkVersion    string `json:"genesis_fork_version"`
 }
 
 // GetGenesis returns the genesis info - https://ethereum.github.io/beacon-APIs/#/Beacon/getGenesis

--- a/common/utils.go
+++ b/common/utils.go
@@ -122,3 +122,11 @@ func reverse(src []byte) []byte {
 	}
 	return dst
 }
+
+// GetEnvStrSlice returns a slice of strings from a comma-separated env var
+func GetEnvStrSlice(key string, defaultValue []string) []string {
+	if value, ok := os.LookupEnv(key); ok {
+		return strings.Split(value, ",")
+	}
+	return defaultValue
+}

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -77,4 +78,23 @@ func TestU256StrToUint256(t *testing.T) {
 			require.Equal(t, test.want, fmt.Sprintf("%d", got))
 		})
 	}
+}
+
+func TestGetEnvStrSlice(t *testing.T) {
+	testEnvVar := "TESTENV_TestGetEnvStrSlice"
+	os.Unsetenv(testEnvVar)
+	r := GetEnvStrSlice(testEnvVar, nil)
+	require.Len(t, r, 0)
+
+	t.Setenv(testEnvVar, "")
+	r = GetEnvStrSlice(testEnvVar, nil)
+	require.Len(t, r, 1)
+	require.Equal(t, "", r[0])
+
+	t.Setenv(testEnvVar, "str1,str2")
+	r = GetEnvStrSlice(testEnvVar, nil)
+	require.Len(t, r, 2)
+	require.Equal(t, "str1", r[0])
+	require.Equal(t, "str2", r[1])
+	os.Unsetenv(testEnvVar)
 }

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -171,22 +171,6 @@ func TestActiveValidators(t *testing.T) {
 	require.True(t, vals[pk1])
 }
 
-func _buildGetHeaderResponse(value uint64) *common.GetHeaderResponse {
-	return &common.GetHeaderResponse{
-		Bellatrix: &types.GetHeaderResponse{
-			Version: "bellatrix",
-			Data: &types.SignedBuilderBid{
-				Message: &types.BuilderBid{
-					Header: &types.ExecutionPayloadHeader{},
-					Value:  types.IntToU256(value),
-					Pubkey: types.PublicKey{0x01},
-				},
-				Signature: types.Signature{0x01},
-			},
-		},
-	}
-}
-
 func TestBuilderBids(t *testing.T) {
 	cache := setupTestRedis(t)
 
@@ -200,9 +184,9 @@ func TestBuilderBids(t *testing.T) {
 	receivedAt := time.Now()
 
 	// 2 initial bids: 99 and 100 value
-	err := cache.SaveLatestBuilderBid(slot, builder1pk, parentHash, proposerPk, receivedAt, _buildGetHeaderResponse(100))
+	err := cache.SaveLatestBuilderBid(slot, builder1pk, parentHash, proposerPk, receivedAt, BuildDummyBellatrixGetHeaderResponse(100))
 	require.NoError(t, err)
-	err = cache.SaveLatestBuilderBid(slot, builder2pk, parentHash, proposerPk, receivedAt, _buildGetHeaderResponse(99))
+	err = cache.SaveLatestBuilderBid(slot, builder2pk, parentHash, proposerPk, receivedAt, BuildDummyBellatrixGetHeaderResponse(99))
 	require.NoError(t, err)
 	err = cache.UpdateTopBid(slot, parentHash, proposerPk)
 	require.NoError(t, err)
@@ -211,7 +195,7 @@ func TestBuilderBids(t *testing.T) {
 	require.Equal(t, "100", topBid.Value().String())
 
 	// new top bid by builder3: 101
-	err = cache.SaveLatestBuilderBid(slot, builder3pk, parentHash, proposerPk, receivedAt, _buildGetHeaderResponse(101))
+	err = cache.SaveLatestBuilderBid(slot, builder3pk, parentHash, proposerPk, receivedAt, BuildDummyBellatrixGetHeaderResponse(101))
 	require.NoError(t, err)
 	err = cache.UpdateTopBid(slot, parentHash, proposerPk)
 	require.NoError(t, err)
@@ -220,7 +204,7 @@ func TestBuilderBids(t *testing.T) {
 	require.Equal(t, "101", topBid.Value().String())
 
 	// builder3 cancels 101 bid, by sending 100 value
-	err = cache.SaveLatestBuilderBid(slot, builder3pk, parentHash, proposerPk, receivedAt, _buildGetHeaderResponse(99))
+	err = cache.SaveLatestBuilderBid(slot, builder3pk, parentHash, proposerPk, receivedAt, BuildDummyBellatrixGetHeaderResponse(99))
 	require.NoError(t, err)
 	err = cache.UpdateTopBid(slot, parentHash, proposerPk)
 	require.NoError(t, err)

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -184,9 +184,9 @@ func TestBuilderBids(t *testing.T) {
 	receivedAt := time.Now()
 
 	// 2 initial bids: 99 and 100 value
-	err := cache.SaveLatestBuilderBid(slot, builder1pk, parentHash, proposerPk, receivedAt, BuildDummyBellatrixGetHeaderResponse(100))
+	err := cache.SaveLatestBuilderBid(slot, builder1pk, parentHash, proposerPk, receivedAt, BuildEmptyBellatrixGetHeaderResponse(100))
 	require.NoError(t, err)
-	err = cache.SaveLatestBuilderBid(slot, builder2pk, parentHash, proposerPk, receivedAt, BuildDummyBellatrixGetHeaderResponse(99))
+	err = cache.SaveLatestBuilderBid(slot, builder2pk, parentHash, proposerPk, receivedAt, BuildEmptyBellatrixGetHeaderResponse(99))
 	require.NoError(t, err)
 	err = cache.UpdateTopBid(slot, parentHash, proposerPk)
 	require.NoError(t, err)
@@ -195,7 +195,7 @@ func TestBuilderBids(t *testing.T) {
 	require.Equal(t, "100", topBid.Value().String())
 
 	// new top bid by builder3: 101
-	err = cache.SaveLatestBuilderBid(slot, builder3pk, parentHash, proposerPk, receivedAt, BuildDummyBellatrixGetHeaderResponse(101))
+	err = cache.SaveLatestBuilderBid(slot, builder3pk, parentHash, proposerPk, receivedAt, BuildEmptyBellatrixGetHeaderResponse(101))
 	require.NoError(t, err)
 	err = cache.UpdateTopBid(slot, parentHash, proposerPk)
 	require.NoError(t, err)
@@ -204,7 +204,7 @@ func TestBuilderBids(t *testing.T) {
 	require.Equal(t, "101", topBid.Value().String())
 
 	// builder3 cancels 101 bid, by sending 100 value
-	err = cache.SaveLatestBuilderBid(slot, builder3pk, parentHash, proposerPk, receivedAt, BuildDummyBellatrixGetHeaderResponse(99))
+	err = cache.SaveLatestBuilderBid(slot, builder3pk, parentHash, proposerPk, receivedAt, BuildEmptyBellatrixGetHeaderResponse(99))
 	require.NoError(t, err)
 	err = cache.UpdateTopBid(slot, parentHash, proposerPk)
 	require.NoError(t, err)

--- a/datastore/utils.go
+++ b/datastore/utils.go
@@ -15,7 +15,7 @@ func MakeBlockBuilderStatus(isHighPrio, isBlacklisted bool) BlockBuilderStatus {
 	}
 }
 
-func BuildDummyBellatrixGetHeaderResponse(value uint64) *common.GetHeaderResponse {
+func BuildEmptyBellatrixGetHeaderResponse(value uint64) *common.GetHeaderResponse {
 	return &common.GetHeaderResponse{ //nolint:exhaustruct
 		Bellatrix: &types.GetHeaderResponse{
 			Version: "bellatrix",

--- a/datastore/utils.go
+++ b/datastore/utils.go
@@ -1,5 +1,10 @@
 package datastore
 
+import (
+	"github.com/flashbots/go-boost-utils/types"
+	"github.com/flashbots/mev-boost-relay/common"
+)
+
 func MakeBlockBuilderStatus(isHighPrio, isBlacklisted bool) BlockBuilderStatus {
 	if isBlacklisted {
 		return RedisBlockBuilderStatusBlacklisted
@@ -7,5 +12,21 @@ func MakeBlockBuilderStatus(isHighPrio, isBlacklisted bool) BlockBuilderStatus {
 		return RedisBlockBuilderStatusHighPrio
 	} else {
 		return RedisBlockBuilderStatusLowPrio
+	}
+}
+
+func BuildDummyBellatrixGetHeaderResponse(value uint64) *common.GetHeaderResponse {
+	return &common.GetHeaderResponse{ //nolint:exhaustruct
+		Bellatrix: &types.GetHeaderResponse{
+			Version: "bellatrix",
+			Data: &types.SignedBuilderBid{
+				Message: &types.BuilderBid{
+					Header: &types.ExecutionPayloadHeader{}, //nolint:exhaustruct
+					Value:  types.IntToU256(value),
+					Pubkey: types.PublicKey{0x01},
+				},
+				Signature: types.Signature{0x01},
+			},
+		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	github.com/tdewolff/minify v2.3.6+incompatible
 	go.uber.org/atomic v1.10.0
+	golang.org/x/exp v0.0.0-20230206171751-46f607a40771
 	golang.org/x/text v0.8.0
 )
 
@@ -59,7 +60,6 @@ require (
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
-	golang.org/x/exp v0.0.0-20230206171751-46f607a40771 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -159,7 +159,6 @@ type RelayAPI struct {
 	ffDisablePayloadDBStorage    bool // disable storing the execution payloads in the database
 	ffAllowMemcacheSavingFail    bool // don't fail when saving payloads to memcache doesn't succeed
 	ffLogInvalidSignaturePayload bool // log payload if getPayload signature validation fails
-	ffRejectPrysmGetHeader       bool
 
 	payloadAttributes     map[string]payloadAttributesHelper // key:parentBlockHash
 	payloadAttributesLock sync.RWMutex
@@ -254,8 +253,6 @@ func NewRelayAPI(opts RelayAPIOpts) (api *RelayAPI, err error) {
 		api.log.Warn("env: LOG_INVALID_GETPAYLOAD_SIGNATURE - getPayload payloads with invalid proposer signature will be logged")
 		api.ffLogInvalidSignaturePayload = true
 	}
-
-	api.ffRejectPrysmGetHeader = true
 
 	return api, nil
 }
@@ -818,11 +815,6 @@ func (api *RelayAPI) handleGetHeader(w http.ResponseWriter, req *http.Request) {
 	parentHashHex := vars["parent_hash"]
 	proposerPubkeyHex := vars["pubkey"]
 	ua := req.UserAgent()
-	if api.ffRejectPrysmGetHeader && ua == "mev-boost/v1.5.0 Go-http-client/1.1" {
-		api.log.Info("rejecting getHeader from prysm client")
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
 	headSlot := api.headSlot.Load()
 
 	slot, err := strconv.ParseUint(slotStr, 10, 64)

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -821,6 +821,7 @@ func (api *RelayAPI) handleGetHeader(w http.ResponseWriter, req *http.Request) {
 	if api.ffRejectPrysmGetHeader && ua == "mev-boost/v1.5.0 Go-http-client/1.1" {
 		api.log.Info("rejecting getHeader from prysm client")
 		w.WriteHeader(http.StatusNoContent)
+		return
 	}
 	headSlot := api.headSlot.Load()
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -35,7 +35,6 @@ import (
 	"github.com/flashbots/mev-boost-relay/datastore"
 	"github.com/go-redis/redis/v9"
 	"github.com/gorilla/mux"
-	"github.com/rs/zerolog/log"
 	"github.com/sirupsen/logrus"
 	uberatomic "go.uber.org/atomic"
 )
@@ -819,8 +818,8 @@ func (api *RelayAPI) handleGetHeader(w http.ResponseWriter, req *http.Request) {
 	parentHashHex := vars["parent_hash"]
 	proposerPubkeyHex := vars["pubkey"]
 	ua := req.UserAgent()
-	if ffRejectPrysmGetHeader && strings.Contains(ua, "Go-http-client") {
-		log.Info("rejecting prysm submission")
+	if ffRejectPrysmGetHeader && ua == "mev-boost/v1.5.0 Go-http-client/1.1" {
+		api.log.Info("rejecting getHeader from prysm client")
 		w.WriteHeader(http.StatusNoContent)
 	}
 	headSlot := api.headSlot.Load()

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -818,7 +818,7 @@ func (api *RelayAPI) handleGetHeader(w http.ResponseWriter, req *http.Request) {
 	parentHashHex := vars["parent_hash"]
 	proposerPubkeyHex := vars["pubkey"]
 	ua := req.UserAgent()
-	if ffRejectPrysmGetHeader && ua == "mev-boost/v1.5.0 Go-http-client/1.1" {
+	if api.ffRejectPrysmGetHeader && ua == "mev-boost/v1.5.0 Go-http-client/1.1" {
 		api.log.Info("rejecting getHeader from prysm client")
 		w.WriteHeader(http.StatusNoContent)
 	}

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -256,7 +256,7 @@ func TestGetHeader(t *testing.T) {
 	}
 
 	// Add a bid
-	err := backend.redis.SaveLatestBuilderBid(slot, proposerPubkey, parentHash, proposerPubkey, time.Now(), datastore.BuildDummyBellatrixGetHeaderResponse(99))
+	err := backend.redis.SaveLatestBuilderBid(slot, proposerPubkey, parentHash, proposerPubkey, time.Now(), datastore.BuildEmptyBellatrixGetHeaderResponse(99))
 	require.NoError(t, err)
 	err = backend.redis.UpdateTopBid(slot, parentHash, proposerPubkey)
 	require.NoError(t, err)

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -90,6 +91,25 @@ func (be *testBackend) request(method, path string, payload any) *httptest.Respo
 		require.NoError(be.t, err2)
 		req, err = http.NewRequest(method, path, bytes.NewReader(payloadBytes))
 	}
+
+	require.NoError(be.t, err)
+	rr := httptest.NewRecorder()
+	be.relay.getRouter().ServeHTTP(rr, req)
+	return rr
+}
+
+func (be *testBackend) requestWithUA(method, path, userAgent string, payload any) *httptest.ResponseRecorder {
+	var req *http.Request
+	var err error
+
+	if payload == nil {
+		req, err = http.NewRequest(method, path, bytes.NewReader(nil))
+	} else {
+		payloadBytes, err2 := json.Marshal(payload)
+		require.NoError(be.t, err2)
+		req, err = http.NewRequest(method, path, bytes.NewReader(payloadBytes))
+	}
+	req.Header.Set("User-Agent", userAgent)
 
 	require.NoError(be.t, err)
 	rr := httptest.NewRecorder()
@@ -218,6 +238,40 @@ func TestRegisterValidator(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, rr.Code)
 		require.Contains(t, rr.Body.String(), "timestamp too far in the future")
 	})
+}
+
+func TestGetHeader(t *testing.T) {
+	slot := uint64(2)
+	parentHash := "0x13e606c7b3d1faad7e83503ce3dedce4c6bb89b0c28ffb240d713c7b110b9747"
+	proposerPubkey := "0x6ae5932d1e248d987d51b58665b81848814202d7b23b343d20f2a167d12f07dcb01ca41c42fdd60b7fca9c4b90890792"
+	path := fmt.Sprintf("/eth/v1/builder/header/%d/%s/%s", slot, parentHash, proposerPubkey)
+
+	// Setup backend with headSlot and genesisTime
+	backend := newTestBackend(t, 1)
+	backend.relay.headSlot.Store(uint64(2))
+	backend.relay.genesisInfo = &beaconclient.GetGenesisResponse{
+		Data: beaconclient.GetGenesisResponseData{
+			GenesisTime: uint64(time.Now().UTC().Unix()),
+		},
+	}
+
+	// Add a bid
+	err := backend.redis.SaveLatestBuilderBid(slot, proposerPubkey, parentHash, proposerPubkey, time.Now(), datastore.BuildDummyBellatrixGetHeaderResponse(99))
+	require.NoError(t, err)
+	err = backend.redis.UpdateTopBid(slot, parentHash, proposerPubkey)
+	require.NoError(t, err)
+
+	// Check 1: regular request works and returns a bid
+	rr := backend.request(http.MethodGet, path, nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+	resp := common.GetHeaderResponse{}
+	err = json.Unmarshal(rr.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.Equal(t, "99", resp.Value().String())
+
+	// Check 2: Request returns 204 if sending a filtered user agent
+	rr = backend.requestWithUA(http.MethodGet, path, "mev-boost/v1.5.0 Go-http-client/1.1", nil)
+	require.Equal(t, http.StatusNoContent, rr.Code)
 }
 
 func TestBuilderApiGetValidators(t *testing.T) {

--- a/services/api/types.go
+++ b/services/api/types.go
@@ -35,7 +35,7 @@ var VersionBellatrix boostTypes.VersionString = "bellatrix"
 
 var ZeroU256 = boostTypes.IntToU256(0)
 
-func BuildGetHeaderResponse(payload *common.BuilderSubmitBlockRequest, sk *bls.SecretKey, pubkey *boostTypes.PublicKey, domain boostTypes.Domain) (*common.GetHeaderResponse, error) {
+func BuildDummyGetHeaderResponse(payload *common.BuilderSubmitBlockRequest, sk *bls.SecretKey, pubkey *boostTypes.PublicKey, domain boostTypes.Domain) (*common.GetHeaderResponse, error) {
 	if payload == nil {
 		return nil, ErrMissingRequest
 	}


### PR DESCRIPTION
## 📝 Summary

- Allows setting filtered user agents through env var `NO_HEADER_USERAGENTS`
- Test for getHeader user-agent filter

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
