### PR TITLE
builder submission: +wasSimulated, separate request error from validation error

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -24,7 +24,7 @@ type IDatabaseService interface {
 	GetValidatorRegistration(pubkey string) (*ValidatorRegistrationEntry, error)
 	GetValidatorRegistrationsForPubkeys(pubkeys []string) ([]*ValidatorRegistrationEntry, error)
 
-	SaveBuilderBlockSubmission(payload *common.BuilderSubmitBlockRequest, simError error, receivedAt, eligibleAt time.Time, wasSimulated, saveExecPayload bool) (entry *BuilderBlockSubmissionEntry, err error)
+	SaveBuilderBlockSubmission(payload *common.BuilderSubmitBlockRequest, requestError, validationError error, receivedAt, eligibleAt time.Time, wasSimulated, saveExecPayload bool) (entry *BuilderBlockSubmissionEntry, err error)
 	GetBlockSubmissionEntry(slot uint64, proposerPubkey, blockHash string) (entry *BuilderBlockSubmissionEntry, err error)
 	GetBuilderSubmissions(filters GetBuilderSubmissionsFilters) ([]*BuilderBlockSubmissionEntry, error)
 	GetBuilderSubmissionsBySlots(slotFrom, slotTo uint64) (entries []*BuilderBlockSubmissionEntry, err error)
@@ -92,8 +92,8 @@ func (s *DatabaseService) prepareNamedQueries() (err error) {
 
 	// Insert block builder submission
 	query = `INSERT INTO ` + vars.TableBuilderBlockSubmission + `
-	(received_at, eligible_at, execution_payload_id, was_simulated, sim_success, sim_error, signature, slot, parent_hash, block_hash, builder_pubkey, proposer_pubkey, proposer_fee_recipient, gas_used, gas_limit, num_tx, value, epoch, block_number) VALUES
-	(:received_at, :eligible_at, :execution_payload_id, :was_simulated, :sim_success, :sim_error, :signature, :slot, :parent_hash, :block_hash, :builder_pubkey, :proposer_pubkey, :proposer_fee_recipient, :gas_used, :gas_limit, :num_tx, :value, :epoch, :block_number)
+	(received_at, eligible_at, execution_payload_id, was_simulated, sim_success, sim_error, sim_req_error, signature, slot, parent_hash, block_hash, builder_pubkey, proposer_pubkey, proposer_fee_recipient, gas_used, gas_limit, num_tx, value, epoch, block_number) VALUES
+	(:received_at, :eligible_at, :execution_payload_id, :was_simulated, :sim_success, :sim_error, :sim_req_error, :signature, :slot, :parent_hash, :block_hash, :builder_pubkey, :proposer_pubkey, :proposer_fee_recipient, :gas_used, :gas_limit, :num_tx, :value, :epoch, :block_number)
 	RETURNING id`
 	s.nstmtInsertBlockBuilderSubmission, err = s.DB.PrepareNamed(query)
 	return err
@@ -168,7 +168,7 @@ func (s *DatabaseService) GetLatestValidatorRegistrations(timestampOnly bool) ([
 	return registrations, err
 }
 
-func (s *DatabaseService) SaveBuilderBlockSubmission(payload *common.BuilderSubmitBlockRequest, simError error, receivedAt, eligibleAt time.Time, wasSimulated, saveExecPayload bool) (entry *BuilderBlockSubmissionEntry, err error) {
+func (s *DatabaseService) SaveBuilderBlockSubmission(payload *common.BuilderSubmitBlockRequest, requestError, validationError error, receivedAt, eligibleAt time.Time, wasSimulated, saveExecPayload bool) (entry *BuilderBlockSubmissionEntry, err error) {
 	// Save execution_payload: insert, or if already exists update to be able to return the id ('on conflict do nothing' doesn't return an id)
 	execPayloadEntry, err := PayloadToExecPayloadEntry(payload)
 	if err != nil {
@@ -184,8 +184,13 @@ func (s *DatabaseService) SaveBuilderBlockSubmission(payload *common.BuilderSubm
 
 	// Save block_submission
 	simErrStr := ""
-	if simError != nil {
-		simErrStr = simError.Error()
+	if validationError != nil {
+		simErrStr = validationError.Error()
+	}
+
+	requestErrStr := ""
+	if requestError != nil {
+		requestErrStr = requestError.Error()
 	}
 
 	blockSubmissionEntry := &BuilderBlockSubmissionEntry{
@@ -194,8 +199,9 @@ func (s *DatabaseService) SaveBuilderBlockSubmission(payload *common.BuilderSubm
 		ExecutionPayloadID: NewNullInt64(execPayloadEntry.ID),
 
 		WasSimulated: wasSimulated,
-		SimSuccess:   simError == nil,
+		SimSuccess:   wasSimulated && validationError == nil,
 		SimError:     simErrStr,
+		SimReqError:  requestErrStr,
 
 		Signature: payload.Signature().String(),
 

--- a/database/database.go
+++ b/database/database.go
@@ -24,7 +24,7 @@ type IDatabaseService interface {
 	GetValidatorRegistration(pubkey string) (*ValidatorRegistrationEntry, error)
 	GetValidatorRegistrationsForPubkeys(pubkeys []string) ([]*ValidatorRegistrationEntry, error)
 
-	SaveBuilderBlockSubmission(payload *common.BuilderSubmitBlockRequest, simError error, receivedAt, eligibleAt time.Time, saveExecPayload bool) (entry *BuilderBlockSubmissionEntry, err error)
+	SaveBuilderBlockSubmission(payload *common.BuilderSubmitBlockRequest, simError error, receivedAt, eligibleAt time.Time, wasSimulated, saveExecPayload bool) (entry *BuilderBlockSubmissionEntry, err error)
 	GetBlockSubmissionEntry(slot uint64, proposerPubkey, blockHash string) (entry *BuilderBlockSubmissionEntry, err error)
 	GetBuilderSubmissions(filters GetBuilderSubmissionsFilters) ([]*BuilderBlockSubmissionEntry, error)
 	GetBuilderSubmissionsBySlots(slotFrom, slotTo uint64) (entries []*BuilderBlockSubmissionEntry, err error)
@@ -92,8 +92,8 @@ func (s *DatabaseService) prepareNamedQueries() (err error) {
 
 	// Insert block builder submission
 	query = `INSERT INTO ` + vars.TableBuilderBlockSubmission + `
-	(received_at, eligible_at, execution_payload_id, sim_success, sim_error, signature, slot, parent_hash, block_hash, builder_pubkey, proposer_pubkey, proposer_fee_recipient, gas_used, gas_limit, num_tx, value, epoch, block_number) VALUES
-	(:received_at, :eligible_at, :execution_payload_id, :sim_success, :sim_error, :signature, :slot, :parent_hash, :block_hash, :builder_pubkey, :proposer_pubkey, :proposer_fee_recipient, :gas_used, :gas_limit, :num_tx, :value, :epoch, :block_number)
+	(received_at, eligible_at, execution_payload_id, was_simulated, sim_success, sim_error, signature, slot, parent_hash, block_hash, builder_pubkey, proposer_pubkey, proposer_fee_recipient, gas_used, gas_limit, num_tx, value, epoch, block_number) VALUES
+	(:received_at, :eligible_at, :execution_payload_id, :was_simulated, :sim_success, :sim_error, :signature, :slot, :parent_hash, :block_hash, :builder_pubkey, :proposer_pubkey, :proposer_fee_recipient, :gas_used, :gas_limit, :num_tx, :value, :epoch, :block_number)
 	RETURNING id`
 	s.nstmtInsertBlockBuilderSubmission, err = s.DB.PrepareNamed(query)
 	return err
@@ -168,7 +168,7 @@ func (s *DatabaseService) GetLatestValidatorRegistrations(timestampOnly bool) ([
 	return registrations, err
 }
 
-func (s *DatabaseService) SaveBuilderBlockSubmission(payload *common.BuilderSubmitBlockRequest, simError error, receivedAt, eligibleAt time.Time, saveExecPayload bool) (entry *BuilderBlockSubmissionEntry, err error) {
+func (s *DatabaseService) SaveBuilderBlockSubmission(payload *common.BuilderSubmitBlockRequest, simError error, receivedAt, eligibleAt time.Time, wasSimulated, saveExecPayload bool) (entry *BuilderBlockSubmissionEntry, err error) {
 	// Save execution_payload: insert, or if already exists update to be able to return the id ('on conflict do nothing' doesn't return an id)
 	execPayloadEntry, err := PayloadToExecPayloadEntry(payload)
 	if err != nil {
@@ -193,8 +193,9 @@ func (s *DatabaseService) SaveBuilderBlockSubmission(payload *common.BuilderSubm
 		EligibleAt:         NewNullTime(eligibleAt),
 		ExecutionPayloadID: NewNullInt64(execPayloadEntry.ID),
 
-		SimSuccess: simError == nil,
-		SimError:   simErrStr,
+		WasSimulated: wasSimulated,
+		SimSuccess:   simError == nil,
+		SimError:     simErrStr,
 
 		Signature: payload.Signature().String(),
 
@@ -349,7 +350,7 @@ func (s *DatabaseService) GetRecentDeliveredPayloads(queryArgs GetPayloadsFilter
 }
 
 func (s *DatabaseService) GetDeliveredPayloads(idFirst, idLast uint64) (entries []*DeliveredPayloadEntry, err error) {
-	query := `SELECT id, inserted_at, signed_at, slot, epoch, builder_pubkey, proposer_pubkey, proposer_fee_recipient, parent_hash, block_hash, block_number, num_tx, value, gas_used, gas_limit, publish_ms 
+	query := `SELECT id, inserted_at, signed_at, slot, epoch, builder_pubkey, proposer_pubkey, proposer_fee_recipient, parent_hash, block_hash, block_number, num_tx, value, gas_used, gas_limit, publish_ms
 	FROM ` + vars.TableDeliveredPayload + `
 	WHERE id >= $1 AND id <= $2
 	ORDER BY slot ASC`

--- a/database/migrations/007_builder_submission_was_simulated.go
+++ b/database/migrations/007_builder_submission_was_simulated.go
@@ -9,6 +9,7 @@ var Migration007BuilderSubmissionWasSimulated = &migrate.Migration{
 	Id: "007-builder-submission-was-simulated",
 	Up: []string{`
 		ALTER TABLE ` + vars.TableBuilderBlockSubmission + ` ADD was_simulated boolean NOT NULL DEFAULT true;
+		ALTER TABLE ` + vars.TableBuilderBlockSubmission + ` ADD sim_req_error text NOT NULL DEFAULT '';
 	`},
 	Down: []string{},
 

--- a/database/migrations/007_builder_submission_was_simulated.go
+++ b/database/migrations/007_builder_submission_was_simulated.go
@@ -1,0 +1,17 @@
+package migrations
+
+import (
+	"github.com/flashbots/mev-boost-relay/database/vars"
+	migrate "github.com/rubenv/sql-migrate"
+)
+
+var Migration007BuilderSubmissionWasSimulated = &migrate.Migration{
+	Id: "007-builder-submission-was-simulated",
+	Up: []string{`
+		ALTER TABLE ` + vars.TableBuilderBlockSubmission + ` ADD was_simulated boolean NOT NULL DEFAULT true;
+	`},
+	Down: []string{},
+
+	DisableTransactionUp:   true,
+	DisableTransactionDown: true,
+}

--- a/database/migrations/migration.go
+++ b/database/migrations/migration.go
@@ -13,5 +13,6 @@ var Migrations = migrate.MemoryMigrationSource{
 		Migration004BlockedValidator,
 		Migration005RemoveBlockedValidator,
 		Migration006CreateTooLateGetPayload,
+		Migration007BuilderSubmissionWasSimulated,
 	},
 }

--- a/database/mockdb.go
+++ b/database/mockdb.go
@@ -28,7 +28,7 @@ func (db MockDB) GetLatestValidatorRegistrations(timestampOnly bool) ([]*Validat
 	return nil, nil
 }
 
-func (db MockDB) SaveBuilderBlockSubmission(payload *common.BuilderSubmitBlockRequest, simError error, receivedAt, eligibleAt time.Time, wasSimulated, saveExecPayload bool) (entry *BuilderBlockSubmissionEntry, err error) {
+func (db MockDB) SaveBuilderBlockSubmission(payload *common.BuilderSubmitBlockRequest, requestError, validationError error, receivedAt, eligibleAt time.Time, wasSimulated, saveExecPayload bool) (entry *BuilderBlockSubmissionEntry, err error) {
 	return nil, nil
 }
 

--- a/database/mockdb.go
+++ b/database/mockdb.go
@@ -28,7 +28,7 @@ func (db MockDB) GetLatestValidatorRegistrations(timestampOnly bool) ([]*Validat
 	return nil, nil
 }
 
-func (db MockDB) SaveBuilderBlockSubmission(payload *common.BuilderSubmitBlockRequest, simError error, receivedAt, eligibleAt time.Time, saveExecPayload bool) (entry *BuilderBlockSubmissionEntry, err error) {
+func (db MockDB) SaveBuilderBlockSubmission(payload *common.BuilderSubmitBlockRequest, simError error, receivedAt, eligibleAt time.Time, wasSimulated, saveExecPayload bool) (entry *BuilderBlockSubmissionEntry, err error) {
 	return nil, nil
 }
 

--- a/database/types.go
+++ b/database/types.go
@@ -133,8 +133,9 @@ type BuilderBlockSubmissionEntry struct {
 	ExecutionPayloadID sql.NullInt64 `db:"execution_payload_id"`
 
 	// Sim Result
-	SimSuccess bool   `db:"sim_success"`
-	SimError   string `db:"sim_error"`
+	WasSimulated bool   `db:"was_simulated"`
+	SimSuccess   bool   `db:"sim_success"`
+	SimError     string `db:"sim_error"`
 
 	// BidTrace data
 	Signature string `db:"signature"`

--- a/database/types.go
+++ b/database/types.go
@@ -136,6 +136,7 @@ type BuilderBlockSubmissionEntry struct {
 	WasSimulated bool   `db:"was_simulated"`
 	SimSuccess   bool   `db:"sim_success"`
 	SimError     string `db:"sim_error"`
+	SimReqError  string `db:"sim_req_error"`
 
 	// BidTrace data
 	Signature string `db:"signature"`

--- a/services/api/blocksim_ratelimiter.go
+++ b/services/api/blocksim_ratelimiter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -16,7 +17,8 @@ import (
 )
 
 var (
-	ErrRequestClosed = errors.New("request context closed")
+	ErrRequestClosed    = errors.New("request context closed")
+	ErrSimulationFailed = errors.New("simulation failed")
 
 	maxConcurrentBlocks = int64(cli.GetEnvInt("BLOCKSIM_MAX_CONCURRENT", 4)) // 0 for no maximum
 	simRequestTimeout   = time.Duration(cli.GetEnvInt("BLOCKSIM_TIMEOUT_MS", 3000)) * time.Millisecond
@@ -104,5 +106,8 @@ func SendJSONRPCRequest(client *http.Client, req jsonrpc.JSONRPCRequest, url str
 		return nil, err, nil
 	}
 
-	return res, nil, res.Error
+	if res.Error != nil {
+		return res, nil, fmt.Errorf("%w: %s", ErrSimulationFailed, res.Error.Message)
+	}
+	return res, nil, nil
 }

--- a/services/api/blocksim_ratelimiter.go
+++ b/services/api/blocksim_ratelimiter.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -17,8 +16,7 @@ import (
 )
 
 var (
-	ErrRequestClosed    = errors.New("request context closed")
-	ErrSimulationFailed = errors.New("simulation failed")
+	ErrRequestClosed = errors.New("request context closed")
 
 	maxConcurrentBlocks = int64(cli.GetEnvInt("BLOCKSIM_MAX_CONCURRENT", 4)) // 0 for no maximum
 	simRequestTimeout   = time.Duration(cli.GetEnvInt("BLOCKSIM_TIMEOUT_MS", 3000)) * time.Millisecond
@@ -42,7 +40,7 @@ func NewBlockSimulationRateLimiter(blockSimURL string) *BlockSimulationRateLimit
 	}
 }
 
-func (b *BlockSimulationRateLimiter) send(context context.Context, payload *common.BuilderBlockValidationRequest, isHighPrio bool) error {
+func (b *BlockSimulationRateLimiter) Send(context context.Context, payload *common.BuilderBlockValidationRequest, isHighPrio bool) (requestErr, validationErr error) {
 	b.cv.L.Lock()
 	cnt := atomic.AddInt64(&b.counter, 1)
 	if maxConcurrentBlocks > 0 && cnt > maxConcurrentBlocks {
@@ -58,45 +56,34 @@ func (b *BlockSimulationRateLimiter) send(context context.Context, payload *comm
 	}()
 
 	if err := context.Err(); err != nil {
-		return ErrRequestClosed
+		return ErrRequestClosed, nil
 	}
 
 	var simReq *jsonrpc.JSONRPCRequest
-	var simResp *jsonrpc.JSONRPCResponse
-	var err error
-	if payload.Bellatrix != nil {
-		simReq = jsonrpc.NewJSONRPCRequest("1", "flashbots_validateBuilderSubmissionV1", payload)
-		simResp, err = SendJSONRPCRequest(&b.client, *simReq, b.blockSimURL, isHighPrio)
-	}
-
 	if payload.Capella != nil {
 		simReq = jsonrpc.NewJSONRPCRequest("1", "flashbots_validateBuilderSubmissionV2", payload)
-		simResp, err = SendJSONRPCRequest(&b.client, *simReq, b.blockSimURL, isHighPrio)
+	} else if payload.Bellatrix != nil {
+		simReq = jsonrpc.NewJSONRPCRequest("1", "flashbots_validateBuilderSubmissionV1", payload)
 	}
-
-	if err != nil {
-		return err
-	} else if simResp.Error != nil {
-		return fmt.Errorf("%w: %s", ErrSimulationFailed, simResp.Error.Message)
-	}
-	return nil
+	_, requestErr, validationErr = SendJSONRPCRequest(&b.client, *simReq, b.blockSimURL, isHighPrio)
+	return requestErr, validationErr
 }
 
-// currentCounter returns the number of waiting and active requests
-func (b *BlockSimulationRateLimiter) currentCounter() int64 {
+// CurrentCounter returns the number of waiting and active requests
+func (b *BlockSimulationRateLimiter) CurrentCounter() int64 {
 	return atomic.LoadInt64(&b.counter)
 }
 
 // SendJSONRPCRequest sends the request to URL and returns the general JsonRpcResponse, or an error (note: not the JSONRPCError)
-func SendJSONRPCRequest(client *http.Client, req jsonrpc.JSONRPCRequest, url string, isHighPrio bool) (res *jsonrpc.JSONRPCResponse, err error) {
+func SendJSONRPCRequest(client *http.Client, req jsonrpc.JSONRPCRequest, url string, isHighPrio bool) (res *jsonrpc.JSONRPCResponse, requestErr, validationErr error) {
 	buf, err := json.Marshal(req)
 	if err != nil {
-		return nil, err
+		return nil, err, nil
 	}
 
 	httpReq, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(buf))
 	if err != nil {
-		return nil, err
+		return nil, err, nil
 	}
 
 	// set request headers
@@ -108,14 +95,14 @@ func SendJSONRPCRequest(client *http.Client, req jsonrpc.JSONRPCRequest, url str
 	// execute request
 	resp, err := client.Do(httpReq)
 	if err != nil {
-		return nil, err
+		return nil, err, nil
 	}
 	defer resp.Body.Close()
 
 	res = new(jsonrpc.JSONRPCResponse)
 	if err := json.NewDecoder(resp.Body).Decode(res); err != nil {
-		return nil, err
+		return nil, err, nil
 	}
 
-	return res, nil
+	return res, nil, res.Error
 }

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1358,20 +1358,20 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	var simErr error
-	var eligibleAt time.Time
 	var wasSimulated bool
+	var requestErr, validationErr error
+	var eligibleAt time.Time
 
 	// Save the builder submission to the database whenever this function ends
 	defer func() {
 		savePayloadToDatabase := !api.ffDisablePayloadDBStorage
-		submissionEntry, err := api.db.SaveBuilderBlockSubmission(payload, simErr, receivedAt, eligibleAt, wasSimulated, savePayloadToDatabase)
+		submissionEntry, err := api.db.SaveBuilderBlockSubmission(payload, requestErr, validationErr, receivedAt, eligibleAt, wasSimulated, savePayloadToDatabase)
 		if err != nil {
 			log.WithError(err).WithField("payload", payload).Error("saving builder block submission to database failed")
 			return
 		}
 
-		err = api.db.UpsertBlockBuilderEntryAfterSubmission(submissionEntry, simErr != nil)
+		err = api.db.UpsertBlockBuilderEntryAfterSubmission(submissionEntry, validationErr != nil)
 		if err != nil {
 			log.WithError(err).Error("failed to upsert block-builder-entry")
 		}
@@ -1402,48 +1402,51 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		BuilderSubmitBlockRequest: *payload,
 		RegisteredGasLimit:        slotDuty.GasLimit,
 	}
-	simErr = api.blockSimRateLimiter.send(req.Context(), validationRequestPayload, builderIsHighPrio)
-	wasSimulated = true
+	requestErr, validationErr = api.blockSimRateLimiter.Send(req.Context(), validationRequestPayload, builderIsHighPrio)
+	validationDurationMs := time.Since(timeBeforeValidation).Milliseconds()
+	log = log.WithFields(logrus.Fields{
+		"timestampAfterValidation": time.Now().UTC().UnixMilli(),
+		"validationDurationMs":     validationDurationMs,
+	})
 
-	if simErr != nil {
-		log = log.WithField("simErr", simErr.Error())
-		log.WithError(simErr).WithFields(logrus.Fields{
-			"durationMs": time.Since(timeBeforeValidation).Milliseconds(),
-			"numWaiting": api.blockSimRateLimiter.currentCounter(),
-		}).Info("block validation failed")
-
-		if os.IsTimeout(simErr) {
+	if requestErr != nil {
+		// Request error -- log and return error
+		log.WithFields(logrus.Fields{
+			"requestErr": requestErr.Error(),
+			"durationMs": validationDurationMs,
+		}).Info("block validation failed - request error")
+		if os.IsTimeout(requestErr) {
 			api.RespondError(w, http.StatusGatewayTimeout, "validation request timeout")
+		} else {
+			api.RespondError(w, http.StatusBadRequest, requestErr.Error())
+		}
+		return
+	} else {
+		wasSimulated = true
+		if validationErr != nil {
+			log.WithFields(logrus.Fields{
+				"validationErr": validationErr.Error(),
+				"durationMs":    validationDurationMs,
+			}).Info("block validation failed - validation error")
+			api.RespondError(w, http.StatusBadRequest, validationErr.Error())
 			return
 		}
-
-		api.RespondError(w, http.StatusBadRequest, simErr.Error())
-		return
 	}
 
-	log = log.WithField("timestampAfterValidation", time.Now().UTC().UnixMilli())
-	log.WithFields(logrus.Fields{
-		"durationMs": time.Since(timeBeforeValidation).Milliseconds(),
-		"numWaiting": api.blockSimRateLimiter.currentCounter(),
-	}).Info("block validation successful")
+	// Log successful validation
+	log.WithField("durationMs", validationDurationMs).Info("block validation successful")
 
+	// If cancellations are enabled, then abort now if this submission is not the latest one
 	if isCancellationEnabled {
-		// Ensure this request is still the latest one. This logic intentionally
-		// ignores the value of the bids and makes the current active bid the one
-		// that arrived at the relay last. This allows for builders to reduce the
-		// value of their bid (effectively cancel a high bid) by ensuring a lower
-		// bid arrives later. Even if the higher bid takes longer to simulate,
-		// by checking the receivedAt timestamp, this logic ensures that the low bid
+		// Ensure this request is still the latest one. This logic intentionally ignores the value of the bids and makes the current active bid the one
+		// that arrived at the relay last. This allows for builders to reduce the value of their bid (effectively cancel a high bid) by ensuring a lower
+		// bid arrives later. Even if the higher bid takes longer to simulate, by checking the receivedAt timestamp, this logic ensures that the low bid
 		// is not overwritten by the high bid.
 		//
-		// NOTE: this can lead to a rather tricky race condition. If a builder
-		// submits two blocks to the relay concurrently, then the randomness of
-		// network latency will make it impossible to predict which arrives first.
-		// Thus a high bid could unintentionally be overwritten by a low bid that
-		// happened to arrive a few microseconds later. If builders are submitting
-		// blocks at a frequency where they cannot reliably predict which bid will
-		// arrive at the relay first, they should instead use multiple pubkeys to
-		// avoid uninitentionally overwriting their own bids.
+		// NOTE: this can lead to a rather tricky race condition. If a builder submits two blocks to the relay concurrently, then the randomness of network
+		// latency will make it impossible to predict which arrives first. Thus a high bid could unintentionally be overwritten by a low bid that happened
+		// to arrive a few microseconds later. If builders are submitting blocks at a frequency where they cannot reliably predict which bid will arrive at
+		// the relay first, they should instead use multiple pubkeys to avoid uninitentionally overwriting their own bids.
 		latestPayloadReceivedAt, err := api.redis.GetBuilderLatestPayloadReceivedAt(payload.Slot(), payload.BuilderPubkey().String(), payload.ParentHash(), payload.ProposerPubkey())
 		if err != nil {
 			log.WithError(err).Error("failed getting latest payload receivedAt from redis")

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1360,11 +1360,12 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 
 	var simErr error
 	var eligibleAt time.Time
+	var wasSimulated bool
 
 	// Save the builder submission to the database whenever this function ends
 	defer func() {
 		savePayloadToDatabase := !api.ffDisablePayloadDBStorage
-		submissionEntry, err := api.db.SaveBuilderBlockSubmission(payload, simErr, receivedAt, eligibleAt, savePayloadToDatabase)
+		submissionEntry, err := api.db.SaveBuilderBlockSubmission(payload, simErr, receivedAt, eligibleAt, wasSimulated, savePayloadToDatabase)
 		if err != nil {
 			log.WithError(err).WithField("payload", payload).Error("saving builder block submission to database failed")
 			return
@@ -1402,6 +1403,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		RegisteredGasLimit:        slotDuty.GasLimit,
 	}
 	simErr = api.blockSimRateLimiter.send(req.Context(), validationRequestPayload, builderIsHighPrio)
+	wasSimulated = true
 
 	if simErr != nil {
 		log = log.WithField("simErr", simErr.Error())


### PR DESCRIPTION
## 📝 Summary

- Separate `requestError` and `validationError`
- Add `wasSimulated` and `simRequestError` to builder submission database entry

Important note: previously, request errors would have been stored in the `sim_error ` db field, whereas after this change it's stored in the `sim_req_error` field

TODO:
* [ ] expose non-validated submissions through Data API? later PR

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
