### PR TITLE
add redis readonly URI

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -46,6 +46,7 @@ func init() {
 	apiCmd.Flags().StringVar(&apiListenAddr, "listen-addr", apiDefaultListenAddr, "listen address for webserver")
 	apiCmd.Flags().StringSliceVar(&beaconNodeURIs, "beacon-uris", defaultBeaconURIs, "beacon endpoints")
 	apiCmd.Flags().StringVar(&redisURI, "redis-uri", defaultRedisURI, "redis uri")
+	apiCmd.Flags().StringVar(&redisReadonlyURI, "redis-readonly-uri", defaultRedisReadonlyURI, "redis readonly uri")
 	apiCmd.Flags().StringVar(&postgresDSN, "db", defaultPostgresDSN, "PostgreSQL DSN")
 	apiCmd.Flags().StringSliceVar(&memcachedURIs, "memcached-uris", defaultMemcachedURIs,
 		"Enable memcached, typically used as secondary backup to Redis for redundancy")
@@ -96,7 +97,7 @@ var apiCmd = &cobra.Command{
 
 		// Connect to Redis
 		log.Infof("Connecting to Redis at %s ...", redisURI)
-		redis, err := datastore.NewRedisCache(redisURI, networkInfo.Name)
+		redis, err := datastore.NewRedisCache(redisURI, networkInfo.Name, redisReadonlyURI)
 		if err != nil {
 			log.WithError(err).Fatalf("Failed to connect to Redis at %s", redisURI)
 		}

--- a/cmd/housekeeper.go
+++ b/cmd/housekeeper.go
@@ -56,7 +56,7 @@ var housekeeperCmd = &cobra.Command{
 		beaconClient := beaconclient.NewMultiBeaconClient(log, beaconInstances)
 
 		// Connect to Redis and setup the datastore
-		redis, err := datastore.NewRedisCache(redisURI, networkInfo.Name)
+		redis, err := datastore.NewRedisCache(redisURI, networkInfo.Name, "")
 		if err != nil {
 			log.WithError(err).Fatalf("Failed to connect to Redis at %s", redisURI)
 		}

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -7,18 +7,20 @@ import (
 )
 
 var (
-	defaultNetwork       = common.GetEnv("NETWORK", "")
-	defaultBeaconURIs    = common.GetSliceEnv("BEACON_URIS", []string{"http://localhost:3500"})
-	defaultRedisURI      = common.GetEnv("REDIS_URI", "localhost:6379")
-	defaultPostgresDSN   = common.GetEnv("POSTGRES_DSN", "")
-	defaultMemcachedURIs = common.GetSliceEnv("MEMCACHED_URIS", nil)
-	defaultLogJSON       = os.Getenv("LOG_JSON") != ""
-	defaultLogLevel      = common.GetEnv("LOG_LEVEL", "info")
+	defaultNetwork          = common.GetEnv("NETWORK", "")
+	defaultBeaconURIs       = common.GetSliceEnv("BEACON_URIS", []string{"http://localhost:3500"})
+	defaultRedisURI         = common.GetEnv("REDIS_URI", "localhost:6379")
+	defaultRedisReadonlyURI = common.GetEnv("REDIS_READONLY_URI", "")
+	defaultPostgresDSN      = common.GetEnv("POSTGRES_DSN", "")
+	defaultMemcachedURIs    = common.GetSliceEnv("MEMCACHED_URIS", nil)
+	defaultLogJSON          = os.Getenv("LOG_JSON") != ""
+	defaultLogLevel         = common.GetEnv("LOG_LEVEL", "info")
 
-	beaconNodeURIs []string
-	redisURI       string
-	postgresDSN    string
-	memcachedURIs  []string
+	beaconNodeURIs   []string
+	redisURI         string
+	redisReadonlyURI string
+	postgresDSN      string
+	memcachedURIs    []string
 
 	logJSON  bool
 	logLevel string

--- a/cmd/website.go
+++ b/cmd/website.go
@@ -66,7 +66,7 @@ var websiteCmd = &cobra.Command{
 		log.Debug(networkInfo.String())
 
 		// Connect to Redis
-		redis, err := datastore.NewRedisCache(redisURI, networkInfo.Name)
+		redis, err := datastore.NewRedisCache(redisURI, networkInfo.Name, redisReadonlyURI)
 		if err != nil {
 			log.WithError(err).Fatalf("Failed to connect to Redis at %s", redisURI)
 		}

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -18,7 +18,7 @@ func setupTestDatastore(t *testing.T) *Datastore {
 	redisTestServer, err := miniredis.Run()
 	require.NoError(t, err)
 
-	redisDs, err := NewRedisCache(redisTestServer.Addr(), "")
+	redisDs, err := NewRedisCache(redisTestServer.Addr(), "", "")
 	require.NoError(t, err)
 
 	// TODO: add support for testing datastore with memcached enabled

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -18,7 +18,7 @@ func setupTestRedis(t *testing.T) *RedisCache {
 	redisTestServer, err := miniredis.Run()
 	require.NoError(t, err)
 
-	redisService, err := NewRedisCache(redisTestServer.Addr(), "")
+	redisService, err := NewRedisCache(redisTestServer.Addr(), "", "")
 	require.NoError(t, err)
 
 	return redisService
@@ -281,9 +281,9 @@ func TestRedisURIs(t *testing.T) {
 	require.NoError(t, err)
 
 	// test connection with and without protocol
-	_, err = NewRedisCache(redisTestServer.Addr(), "")
+	_, err = NewRedisCache(redisTestServer.Addr(), "", "")
 	require.NoError(t, err)
-	_, err = NewRedisCache("redis://"+redisTestServer.Addr(), "")
+	_, err = NewRedisCache("redis://"+redisTestServer.Addr(), "", "")
 	require.NoError(t, err)
 
 	// test connection w/ credentials
@@ -291,14 +291,14 @@ func TestRedisURIs(t *testing.T) {
 	password := "pass"
 	redisTestServer.RequireUserAuth(username, password)
 	fullURL := "redis://" + username + ":" + password + "@" + redisTestServer.Addr()
-	_, err = NewRedisCache(fullURL, "")
+	_, err = NewRedisCache(fullURL, "", "")
 	require.NoError(t, err)
 
 	// ensure malformed URL throws error
 	malformURL := "http://" + username + ":" + password + "@" + redisTestServer.Addr()
-	_, err = NewRedisCache(malformURL, "")
+	_, err = NewRedisCache(malformURL, "", "")
 	require.Error(t, err)
 	malformURL = "redis://" + username + ":" + "wrongpass" + "@" + redisTestServer.Addr()
-	_, err = NewRedisCache(malformURL, "")
+	_, err = NewRedisCache(malformURL, "", "")
 	require.Error(t, err)
 }

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -33,7 +33,7 @@ func newTestBackend(t require.TestingT, numBeaconNodes int) *testBackend {
 	redisClient, err := miniredis.Run()
 	require.NoError(t, err)
 
-	redisCache, err := datastore.NewRedisCache(redisClient.Addr(), "")
+	redisCache, err := datastore.NewRedisCache(redisClient.Addr(), "", "")
 	require.NoError(t, err)
 
 	db := database.MockDB{}


### PR DESCRIPTION
## 📝 Summary

Allow redis readonly URI to be configured for `HGetAll` of known validators and active validators. 

## ⛱ Motivation and Context

These two redis Gets are data intensive and slow. Our readonly replica of the redis instance has a different IP address than the write endpoint. This PR allows us to opt in to use the readonly endpoint for these two queries by specifying the `REDIS_READONLY_URI` environment variable. 

The default of `""` will revert to using the same client for all the queries. 

## 📚 References

NA

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
