### PR TITLE
code cleanup: switch redis arg order

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -108,7 +108,7 @@ var apiCmd = &cobra.Command{
 
 		// Connect to Redis
 		log.Infof("Connecting to Redis at %s ...", redisURI)
-		redis, err := datastore.NewRedisCache(redisURI, networkInfo.Name, redisReadonlyURI)
+		redis, err := datastore.NewRedisCache(networkInfo.Name, redisURI, redisReadonlyURI)
 		if err != nil {
 			log.WithError(err).Fatalf("Failed to connect to Redis at %s", redisURI)
 		}

--- a/cmd/housekeeper.go
+++ b/cmd/housekeeper.go
@@ -56,7 +56,7 @@ var housekeeperCmd = &cobra.Command{
 		beaconClient := beaconclient.NewMultiBeaconClient(log, beaconInstances)
 
 		// Connect to Redis and setup the datastore
-		redis, err := datastore.NewRedisCache(redisURI, networkInfo.Name, "")
+		redis, err := datastore.NewRedisCache(networkInfo.Name, redisURI, "")
 		if err != nil {
 			log.WithError(err).Fatalf("Failed to connect to Redis at %s", redisURI)
 		}

--- a/cmd/website.go
+++ b/cmd/website.go
@@ -66,7 +66,7 @@ var websiteCmd = &cobra.Command{
 		log.Debug(networkInfo.String())
 
 		// Connect to Redis
-		redis, err := datastore.NewRedisCache(redisURI, networkInfo.Name, redisReadonlyURI)
+		redis, err := datastore.NewRedisCache(networkInfo.Name, redisURI, redisReadonlyURI)
 		if err != nil {
 			log.WithError(err).Fatalf("Failed to connect to Redis at %s", redisURI)
 		}

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -18,7 +18,7 @@ func setupTestDatastore(t *testing.T) *Datastore {
 	redisTestServer, err := miniredis.Run()
 	require.NoError(t, err)
 
-	redisDs, err := NewRedisCache(redisTestServer.Addr(), "", "")
+	redisDs, err := NewRedisCache("", redisTestServer.Addr(), "")
 	require.NoError(t, err)
 
 	// TODO: add support for testing datastore with memcached enabled

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -85,7 +85,7 @@ type RedisCache struct {
 	keyBlockBuilderStatus string
 }
 
-func NewRedisCache(redisURI, prefix, readonlyURI string) (*RedisCache, error) {
+func NewRedisCache(prefix, redisURI, readonlyURI string) (*RedisCache, error) {
 	client, err := connectRedis(redisURI)
 	if err != nil {
 		return nil, err

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -18,7 +18,7 @@ func setupTestRedis(t *testing.T) *RedisCache {
 	redisTestServer, err := miniredis.Run()
 	require.NoError(t, err)
 
-	redisService, err := NewRedisCache(redisTestServer.Addr(), "", "")
+	redisService, err := NewRedisCache("", redisTestServer.Addr(), "")
 	require.NoError(t, err)
 
 	return redisService
@@ -281,9 +281,9 @@ func TestRedisURIs(t *testing.T) {
 	require.NoError(t, err)
 
 	// test connection with and without protocol
-	_, err = NewRedisCache(redisTestServer.Addr(), "", "")
+	_, err = NewRedisCache("", redisTestServer.Addr(), "")
 	require.NoError(t, err)
-	_, err = NewRedisCache("redis://"+redisTestServer.Addr(), "", "")
+	_, err = NewRedisCache("", "redis://"+redisTestServer.Addr(), "")
 	require.NoError(t, err)
 
 	// test connection w/ credentials
@@ -291,14 +291,14 @@ func TestRedisURIs(t *testing.T) {
 	password := "pass"
 	redisTestServer.RequireUserAuth(username, password)
 	fullURL := "redis://" + username + ":" + password + "@" + redisTestServer.Addr()
-	_, err = NewRedisCache(fullURL, "", "")
+	_, err = NewRedisCache("", fullURL, "")
 	require.NoError(t, err)
 
 	// ensure malformed URL throws error
 	malformURL := "http://" + username + ":" + password + "@" + redisTestServer.Addr()
-	_, err = NewRedisCache(malformURL, "", "")
+	_, err = NewRedisCache("", malformURL, "")
 	require.Error(t, err)
 	malformURL = "redis://" + username + ":" + "wrongpass" + "@" + redisTestServer.Addr()
-	_, err = NewRedisCache(malformURL, "", "")
+	_, err = NewRedisCache("", malformURL, "")
 	require.Error(t, err)
 }

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -33,7 +33,7 @@ func newTestBackend(t require.TestingT, numBeaconNodes int) *testBackend {
 	redisClient, err := miniredis.Run()
 	require.NoError(t, err)
 
-	redisCache, err := datastore.NewRedisCache(redisClient.Addr(), "", "")
+	redisCache, err := datastore.NewRedisCache("", redisClient.Addr(), "")
 	require.NoError(t, err)
 
 	db := database.MockDB{}


### PR DESCRIPTION
## 📝 Summary

Following up on Chris' comment in https://github.com/flashbots/mev-boost-relay/pull/363. Switching the signature of the `NewRedisCache` function

```
old : func NewRedisCache(redisURI, prefix, readonlyURI string) (*RedisCache, error) {
new : func NewRedisCache(prefix, redisURI, readonlyURI string) (*RedisCache, error) {
```

## ⛱ Motivation and Context

code health

## 📚 References

N/A

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
