### PR TITLE
Use transaction with optimistic lock to eliminate race

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1071,9 +1071,8 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 			log.Warn("validator called getPayload twice (race)")
 			api.RespondError(w, http.StatusBadRequest, "payload for this slot was already delivered (race)")
 			return
-		} else {
-			log.WithError(err).Error("redis.CheckAndSetLastSlotDelivered failed")
 		}
+		log.WithError(err).Error("redis.CheckAndSetLastSlotDelivered failed")
 	}
 
 	// Handle early/late requests


### PR DESCRIPTION
## 📝 Summary

Eliminate a possible race between multiple getPayload requests (until the Redis-write completes) by using an optimistically locked transaction.

See also:

- https://redis.uptrace.dev/guide/go-redis-pipelines.html#transactions
- https://github.com/redis/go-redis/blob/6ecbcf6c90919350c42181ce34c1cbdfbd5d1463/race_test.go#L183
- https://en.wikipedia.org/wiki/Optimistic_concurrency_control

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
