### PR TITLE
getPayload proposerIndex check + feeRecipient log

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"net/url"
 	"os"
-	"strings"
 
 	"github.com/attestantio/go-builder-client/api"
 	"github.com/attestantio/go-builder-client/api/capella"
@@ -18,49 +16,13 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	consensuscapella "github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	boostTypes "github.com/flashbots/go-boost-utils/types"
 )
 
 var (
 	ErrUnknownNetwork = errors.New("unknown network")
 	ErrEmptyPayload   = errors.New("empty payload")
-)
 
-// BuilderEntry represents a builder that is allowed to send blocks
-// Address will be schema://hostname:port
-type BuilderEntry struct {
-	Address string
-	Pubkey  hexutil.Bytes
-	URL     *url.URL
-}
-
-// NewBuilderEntry creates a new instance based on an input string
-// builderURL can be IP@PORT, PUBKEY@IP:PORT, https://IP, etc.
-func NewBuilderEntry(builderURL string) (entry *BuilderEntry, err error) {
-	if !strings.HasPrefix(builderURL, "http") {
-		builderURL = "http://" + builderURL
-	}
-
-	parsedURL, err := url.Parse(builderURL)
-	if err != nil {
-		return nil, err
-	}
-
-	var pubkey hexutil.Bytes
-	err = pubkey.UnmarshalText([]byte(entry.URL.User.Username()))
-	if err != nil {
-		return nil, err
-	}
-
-	return &BuilderEntry{
-		URL:     parsedURL,
-		Address: parsedURL.Scheme + "://" + parsedURL.Host,
-		Pubkey:  pubkey,
-	}, nil
-}
-
-var (
 	EthNetworkRopsten  = "ropsten"
 	EthNetworkSepolia  = "sepolia"
 	EthNetworkGoerli   = "goerli"
@@ -166,6 +128,12 @@ func NewEthNetworkDetails(networkName string) (ret *EthNetworkDetails, err error
 func (e *EthNetworkDetails) String() string {
 	return fmt.Sprintf("EthNetworkDetails{Name: %s, GenesisForkVersionHex: %s, GenesisValidatorsRootHex: %s, BellatrixForkVersionHex: %s, CapellaForkVersionHex: %s, DomainBuilder: %x, DomainBeaconProposerBellatrix: %x, DomainBeaconProposerCapella: %x}",
 		e.Name, e.GenesisForkVersionHex, e.GenesisValidatorsRootHex, e.BellatrixForkVersionHex, e.CapellaForkVersionHex, e.DomainBuilder, e.DomainBeaconProposerBellatrix, e.DomainBeaconProposerCapella)
+}
+
+type BuilderGetValidatorsResponseEntry struct {
+	Slot           uint64                                  `json:"slot,string"`
+	ValidatorIndex uint64                                  `json:"validator_index,string"`
+	Entry          *boostTypes.SignedValidatorRegistration `json:"entry"`
 }
 
 type BidTraceV2 struct {

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -320,12 +320,12 @@ func (r *RedisCache) GetStatsUint64(field string) (value uint64, err error) {
 	return value, err
 }
 
-func (r *RedisCache) SetProposerDuties(proposerDuties []boostTypes.BuilderGetValidatorsResponseEntry) (err error) {
+func (r *RedisCache) SetProposerDuties(proposerDuties []common.BuilderGetValidatorsResponseEntry) (err error) {
 	return r.SetObj(r.keyProposerDuties, proposerDuties, 0)
 }
 
-func (r *RedisCache) GetProposerDuties() (proposerDuties []boostTypes.BuilderGetValidatorsResponseEntry, err error) {
-	proposerDuties = make([]boostTypes.BuilderGetValidatorsResponseEntry, 0)
+func (r *RedisCache) GetProposerDuties() (proposerDuties []common.BuilderGetValidatorsResponseEntry, err error) {
+	proposerDuties = make([]common.BuilderGetValidatorsResponseEntry, 0)
 	err = r.GetObj(r.keyProposerDuties, &proposerDuties)
 	if errors.Is(err, redis.Nil) {
 		return proposerDuties, nil

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -140,7 +140,7 @@ func TestRedisValidatorRegistrations(t *testing.T) {
 
 func TestRedisProposerDuties(t *testing.T) {
 	cache := setupTestRedis(t)
-	duties := []types.BuilderGetValidatorsResponseEntry{
+	duties := []common.BuilderGetValidatorsResponseEntry{
 		{
 			Slot: 1,
 			Entry: &types.SignedValidatorRegistration{

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -278,18 +278,21 @@ func TestBuilderApiGetValidators(t *testing.T) {
 	path := "/relay/v1/builder/validators"
 
 	backend := newTestBackend(t, 1)
-	backend.relay.proposerDutiesResponse = []types.BuilderGetValidatorsResponseEntry{
+	duties := []common.BuilderGetValidatorsResponseEntry{
 		{
 			Slot:  1,
 			Entry: &common.ValidPayloadRegisterValidator,
 		},
 	}
+	responseBytes, err := json.Marshal(duties)
+	require.NoError(t, err)
+	backend.relay.proposerDutiesResponse = &responseBytes
 
 	rr := backend.request(http.MethodGet, path, nil)
 	require.Equal(t, http.StatusOK, rr.Code)
 
-	resp := []types.BuilderGetValidatorsResponseEntry{}
-	err := json.Unmarshal(rr.Body.Bytes(), &resp)
+	resp := []common.BuilderGetValidatorsResponseEntry{}
+	err = json.Unmarshal(rr.Body.Bytes(), &resp)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(resp))
 	require.Equal(t, uint64(1), resp[0].Slot)

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -282,13 +282,14 @@ func (hk *Housekeeper) updateProposerDuties(headSlot uint64) {
 	}
 
 	// Prepare proposer duties
-	proposerDuties := []types.BuilderGetValidatorsResponseEntry{}
+	proposerDuties := []common.BuilderGetValidatorsResponseEntry{}
 	for _, duty := range entries {
 		reg := signedValidatorRegistrations[duty.Pubkey]
 		if reg != nil {
-			proposerDuties = append(proposerDuties, types.BuilderGetValidatorsResponseEntry{
-				Slot:  duty.Slot,
-				Entry: reg,
+			proposerDuties = append(proposerDuties, common.BuilderGetValidatorsResponseEntry{
+				Slot:           duty.Slot,
+				ValidatorIndex: duty.ValidatorIndex,
+				Entry:          reg,
 			})
 		}
 	}


### PR DESCRIPTION
## 📝 Summary


- Check proposer-index on `getPayload`
- Include proposer-index in `builderGetValidators` API call. (see as example: https://boost-relay-goerli.flashbots.net/relay/v1/builder/validators)
- Log `slotDuty.feeRecipient` in getPayload

See also:
- https://github.com/flashbots/relay-specs/pull/13
- https://github.com/flashbots/go-boost-utils/pull/72

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
