### PR TITLE
registerValidator with fast JSON decoding only

### DIFF
--- a/common/test_utils.go
+++ b/common/test_utils.go
@@ -41,12 +41,11 @@ func _HexToSignature(s string) (ret types.Signature) {
 var ValidPayloadRegisterValidator = types.SignedValidatorRegistration{
 	Message: &types.RegisterValidatorRequestMessage{
 		FeeRecipient: _HexToAddress("0xdb65fEd33dc262Fe09D9a2Ba8F80b329BA25f941"),
-		Timestamp:    1234356,
-		GasLimit:     278234191203,
+		Timestamp:    1606824043,
+		GasLimit:     30000000,
 		Pubkey: _HexToPubkey(
-			"0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249"),
+			"0x84e975405f8691ad7118527ee9ee4ed2e4e8bae973f6e29aa9ca9ee4aea83605ae3536d22acc9aa1af0545064eacf82e"),
 	},
-	// Signed by 0x4e343a647c5a5c44d76c2c58b63f02cdf3a9a0ec40f102ebc26363b4b1b95033
 	Signature: _HexToSignature(
-		"0x8209b5391cd69f392b1f02dbc03bab61f574bb6bb54bf87b59e2a85bdc0756f7db6a71ce1b41b727a1f46ccc77b213bf0df1426177b5b29926b39956114421eaa36ec4602969f6f6370a44de44a6bce6dae2136e5fb594cce2a476354264d1ea"),
+		"0xaf12df007a0c78abb5575067e5f8b089cfcc6227e4a91db7dd8cf517fe86fb944ead859f0781277d9b78c672e4a18c5d06368b603374673cf2007966cece9540f3a1b3f6f9e1bf421d779c4e8010368e6aac134649c7a009210780d401a778a5"),
 }

--- a/internal/investigations/validator-registration-signature-check/main.go
+++ b/internal/investigations/validator-registration-signature-check/main.go
@@ -1,0 +1,53 @@
+package main
+
+//
+// Script to create a signed validator registration
+//
+
+import (
+	"fmt"
+
+	"github.com/flashbots/go-boost-utils/bls"
+	boostTypes "github.com/flashbots/go-boost-utils/types"
+	"github.com/flashbots/mev-boost-relay/common"
+)
+
+var (
+	gasLimit     = 30000000
+	feeRecipient = "0xdb65fEd33dc262Fe09D9a2Ba8F80b329BA25f941"
+	timestamp    = 1606824043
+)
+
+func Perr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	mainnetDetails, err := common.NewEthNetworkDetails(common.EthNetworkMainnet)
+	Perr(err)
+
+	sk, pubkey, err := bls.GenerateNewKeypair()
+	Perr(err)
+
+	pk, err := boostTypes.BlsPublicKeyToPublicKey(pubkey)
+	Perr(err)
+
+	// Fill in validator registration details
+	validatorRegistration := boostTypes.RegisterValidatorRequestMessage{ //nolint:exhaustruct
+		GasLimit:  uint64(gasLimit),
+		Timestamp: uint64(timestamp),
+	}
+
+	validatorRegistration.Pubkey, err = boostTypes.HexToPubkey(pk.String())
+	Perr(err)
+	validatorRegistration.FeeRecipient, err = boostTypes.HexToAddress(feeRecipient)
+	Perr(err)
+
+	sig, err := boostTypes.SignMessage(&validatorRegistration, mainnetDetails.DomainBuilder, sk)
+	Perr(err)
+	fmt.Println("privkey:", sk.String())
+	fmt.Println("pubkey: ", pk.String())
+	fmt.Println("sig:    ", sig.String())
+}

--- a/internal/investigations/validator-registration-signature-check/main_test.go
+++ b/internal/investigations/validator-registration-signature-check/main_test.go
@@ -8,30 +8,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSignature(t *testing.T) {
+// TestValidatorRegistrationSignature can be used to validate the signature of an arbitrary validator registration
+func TestValidatorRegistrationSignature(t *testing.T) {
 	t.Skip()
+
+	// Fill in validator registration details
 	pubkey := ""
 	gasLimit := 30000000
 	feeRecipient := ""
 	timestamp := 0
 	signature := ""
 
-	_pk, err := boostTypes.HexToPubkey(pubkey)
-	require.NoError(t, err)
-	_sig, err := boostTypes.HexToSignature(signature)
-	require.NoError(t, err)
-	_feeRecipient, err := boostTypes.HexToAddress(feeRecipient)
-	require.NoError(t, err)
-
+	// Constructing the object
 	payload := boostTypes.SignedValidatorRegistration{
 		Message: &boostTypes.RegisterValidatorRequestMessage{
-			FeeRecipient: _feeRecipient,
-			GasLimit:     uint64(gasLimit),
-			Timestamp:    uint64(timestamp),
-			Pubkey:       _pk,
+			GasLimit:  uint64(gasLimit),
+			Timestamp: uint64(timestamp),
 		},
-		Signature: _sig,
 	}
+
+	var err error
+	payload.Message.Pubkey, err = boostTypes.HexToPubkey(pubkey)
+	require.NoError(t, err)
+	payload.Signature, err = boostTypes.HexToSignature(signature)
+	require.NoError(t, err)
+	payload.Message.FeeRecipient, err = boostTypes.HexToAddress(feeRecipient)
+	require.NoError(t, err)
 
 	mainnetDetails, err := common.NewEthNetworkDetails(common.EthNetworkMainnet)
 	require.NoError(t, err)

--- a/internal/investigations/validator-registration-signature-check/main_test.go
+++ b/internal/investigations/validator-registration-signature-check/main_test.go
@@ -10,14 +10,12 @@ import (
 
 // TestValidatorRegistrationSignature can be used to validate the signature of an arbitrary validator registration
 func TestValidatorRegistrationSignature(t *testing.T) {
-	t.Skip()
-
 	// Fill in validator registration details
-	pubkey := ""
+	pubkey := "0x84e975405f8691ad7118527ee9ee4ed2e4e8bae973f6e29aa9ca9ee4aea83605ae3536d22acc9aa1af0545064eacf82e"
 	gasLimit := 30000000
-	feeRecipient := ""
-	timestamp := 0
-	signature := ""
+	feeRecipient := "0xdb65fed33dc262fe09d9a2ba8f80b329ba25f941"
+	timestamp := 1606824043
+	signature := "0xaf12df007a0c78abb5575067e5f8b089cfcc6227e4a91db7dd8cf517fe86fb944ead859f0781277d9b78c672e4a18c5d06368b603374673cf2007966cece9540f3a1b3f6f9e1bf421d779c4e8010368e6aac134649c7a009210780d401a778a5"
 
 	// Constructing the object
 	payload := boostTypes.SignedValidatorRegistration{

--- a/internal/investigations/validator-registration-signature-check/main_test.go
+++ b/internal/investigations/validator-registration-signature-check/main_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestSignature(t *testing.T) {
+	t.Skip()
 	pubkey := ""
 	gasLimit := 30000000
 	feeRecipient := ""

--- a/internal/investigations/validator-registration-signature-check/main_test.go
+++ b/internal/investigations/validator-registration-signature-check/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+
+	boostTypes "github.com/flashbots/go-boost-utils/types"
+	"github.com/flashbots/mev-boost-relay/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignature(t *testing.T) {
+	pubkey := ""
+	gasLimit := 30000000
+	feeRecipient := ""
+	timestamp := 0
+	signature := ""
+
+	_pk, err := boostTypes.HexToPubkey(pubkey)
+	require.NoError(t, err)
+	_sig, err := boostTypes.HexToSignature(signature)
+	require.NoError(t, err)
+	_feeRecipient, err := boostTypes.HexToAddress(feeRecipient)
+	require.NoError(t, err)
+
+	payload := boostTypes.SignedValidatorRegistration{
+		Message: &boostTypes.RegisterValidatorRequestMessage{
+			FeeRecipient: _feeRecipient,
+			GasLimit:     uint64(gasLimit),
+			Timestamp:    uint64(timestamp),
+			Pubkey:       _pk,
+		},
+		Signature: _sig,
+	}
+
+	mainnetDetails, err := common.NewEthNetworkDetails(common.EthNetworkMainnet)
+	require.NoError(t, err)
+
+	ok, err := boostTypes.VerifySignature(payload.Message, mainnetDetails.DomainBuilder, payload.Message.Pubkey[:], payload.Signature[:])
+	require.NoError(t, err)
+	require.True(t, ok)
+}

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -693,7 +693,7 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 	})
 
 	start := time.Now().UTC()
-	registrationTimeUpperBound := start.Add(10 * time.Second)
+	registrationTimestampUpperBound := start.Unix() + 10 // 10 seconds from now
 
 	numRegTotal := 0
 	numRegProcessed := 0
@@ -827,10 +827,7 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 		if registrationTimestamp < int64(api.genesisInfo.Data.GenesisTime) {
 			handleError(regLog, http.StatusBadRequest, "timestamp too early")
 			return
-		}
-
-		registrationTime := time.Unix(registrationTimestamp, 0)
-		if registrationTime.After(registrationTimeUpperBound) {
+		} else if registrationTimestamp > registrationTimestampUpperBound {
 			handleError(regLog, http.StatusBadRequest, "timestamp too far in the future")
 			return
 		}

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -678,6 +678,7 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 		"method":    "registerValidator",
 		"ua":        ua,
 		"mevBoostV": common.GetMevBoostVersionFromUserAgent(ua),
+		"headSlot":  api.headSlot.Load(),
 	})
 
 	start := time.Now().UTC()
@@ -834,6 +835,12 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 			respondError(http.StatusBadRequest, fmt.Sprintf("error verifying registerValidator signature: %s", err.Error()))
 			return
 		} else if !ok {
+			regLog.WithFields(logrus.Fields{
+				"signature":    signedValidatorRegistration.Signature.String(),
+				"feeRecipient": signedValidatorRegistration.Message.FeeRecipient.String(),
+				"gasLimit":     signedValidatorRegistration.Message.GasLimit,
+				"timestamp":    signedValidatorRegistration.Message.Timestamp,
+			}).Info("invalid validator signature")
 			respondError(http.StatusBadRequest, fmt.Sprintf("failed to verify validator signature for %s", signedValidatorRegistration.Message.Pubkey.String()))
 			return
 		}


### PR DESCRIPTION
## 📝 Summary

Processing validator registrations with [buger/jsonparser](https://github.com/buger/jsonparser) only.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
