### PR TITLE
batch upload known validators to Redis

### DIFF
--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -216,8 +216,17 @@ func (r *RedisCache) GetKnownValidators() (map[uint64]boostTypes.PubkeyHex, erro
 	return validators, nil
 }
 
+func (r *RedisCache) SetMultiKnownValidator(indexPkMap map[uint64]boostTypes.PubkeyHex) error {
+	values := []string{}
+	for proposerIndex, publickeyHex := range indexPkMap {
+		values = append(values, strconv.FormatUint(proposerIndex, 10), PubkeyHexToLowerStr(publickeyHex))
+	}
+
+	return r.client.HMSet(context.Background(), r.keyKnownValidators, values).Err()
+}
+
 func (r *RedisCache) SetKnownValidator(pubkeyHex boostTypes.PubkeyHex, proposerIndex uint64) error {
-	return r.client.HSet(context.Background(), r.keyKnownValidators, proposerIndex, PubkeyHexToLowerStr(pubkeyHex)).Err()
+	return r.SetMultiKnownValidator(map[uint64]boostTypes.PubkeyHex{proposerIndex: pubkeyHex})
 }
 
 func (r *RedisCache) GetValidatorRegistrationTimestamp(proposerPubkey boostTypes.PubkeyHex) (uint64, error) {

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -222,7 +222,7 @@ func (r *RedisCache) SetMultiKnownValidator(indexPkMap map[uint64]boostTypes.Pub
 		values = append(values, strconv.FormatUint(proposerIndex, 10), PubkeyHexToLowerStr(publickeyHex))
 	}
 
-	return r.client.HMSet(context.Background(), r.keyKnownValidators, values).Err()
+	return r.client.HSet(context.Background(), r.keyKnownValidators, values).Err()
 }
 
 func (r *RedisCache) SetKnownValidator(pubkeyHex boostTypes.PubkeyHex, proposerIndex uint64) error {

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -222,7 +222,7 @@ func (r *RedisCache) SetMultiKnownValidator(indexPkMap map[uint64]boostTypes.Pub
 		values = append(values, strconv.FormatUint(proposerIndex, 10), PubkeyHexToLowerStr(publickeyHex))
 	}
 
-	return r.client.HSet(context.Background(), r.keyKnownValidators, values).Err()
+	return r.client.HMSet(context.Background(), r.keyKnownValidators, values).Err()
 }
 
 func (r *RedisCache) SetKnownValidator(pubkeyHex boostTypes.PubkeyHex, proposerIndex uint64) error {

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -100,6 +100,24 @@ func TestRedisKnownValidators(t *testing.T) {
 		require.Contains(t, knownVals, index2)
 		require.Equal(t, key2, knownVals[index2])
 	})
+
+	t.Run("Can save multi and get known validators", func(t *testing.T) {
+		key1 := types.NewPubkeyHex("0x1a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249")
+		index1 := uint64(1)
+		key2 := types.NewPubkeyHex("0x2a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249")
+		index2 := uint64(2)
+
+		indexPkMap := map[uint64]types.PubkeyHex{index1: key1, index2: key2}
+		require.NoError(t, cache.SetMultiKnownValidator(indexPkMap))
+
+		knownVals, err := cache.GetKnownValidators()
+		require.NoError(t, err)
+		require.Equal(t, 2, len(knownVals))
+		require.Contains(t, knownVals, index1)
+		require.Equal(t, key1, knownVals[index1])
+		require.Contains(t, knownVals, index2)
+		require.Equal(t, key2, knownVals[index2])
+	})
 }
 
 func TestRedisValidatorRegistrations(t *testing.T) {

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -133,7 +133,7 @@ func (hk *Housekeeper) processNewSlot(headSlot uint64) {
 	}).Infof("updated headSlot to %d", headSlot)
 }
 
-func (hk *Housekeeper) flushKnownValidators(indexPkMap map[uint64]types.PubkeyHex) {
+func (hk *Housekeeper) saveKnownValidators(indexPkMap map[uint64]types.PubkeyHex) {
 	err := hk.redis.SetMultiKnownValidator(indexPkMap)
 	if err != nil {
 		hk.log.WithError(err).Error("failed to set known validators in Redis")
@@ -237,7 +237,7 @@ func (hk *Housekeeper) updateKnownValidators() {
 		indexPkMap[validator.Index] = types.PubkeyHex(validator.Validator.Pubkey)
 
 		if i%bufferSize == 0 {
-			hk.flushKnownValidators(indexPkMap)
+			hk.saveKnownValidators(indexPkMap)
 			indexPkMap = make(map[uint64]types.PubkeyHex)
 			newValidators += bufferSize
 			if printCounter {
@@ -246,7 +246,7 @@ func (hk *Housekeeper) updateKnownValidators() {
 		}
 	}
 
-	hk.flushKnownValidators(indexPkMap)
+	hk.saveKnownValidators(indexPkMap)
 	newValidators += len(indexPkMap)
 	if printCounter {
 		hk.log.Debugf("writing to redis: %d / %d", i, numValidators)


### PR DESCRIPTION
## 📝 Summary

batch upload known validators to Redis

Use HMSET instead of HSET to upload known validators to Redis

## ⛱ Motivation and Context

Following @metachris  request on #373.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
