### PR TITLE
check for any non-200 code

### DIFF
--- a/beaconclient/multi_beacon_client.go
+++ b/beaconclient/multi_beacon_client.go
@@ -3,6 +3,7 @@ package beaconclient
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -265,7 +266,7 @@ func (c *MultiBeaconClient) PublishBlock(block *common.SignedBeaconBlock) (code 
 	}
 
 	log.Error("failed to publish block on any CL node")
-	return lastErrPublishResp.code, lastErrPublishResp.err
+	return lastErrPublishResp.code, fmt.Errorf("last error: %w", lastErrPublishResp.err)
 }
 
 // GetGenesis returns the genesis info - https://ethereum.github.io/beacon-APIs/#/Beacon/getGenesis

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1139,7 +1139,7 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 	log = log.WithField("timestampBeforePublishing", timeBeforePublish)
 	signedBeaconBlock := common.SignedBlindedBeaconBlockToBeaconBlock(payload, getPayloadResp)
 	code, err := api.beaconClient.PublishBlock(signedBeaconBlock) // errors are logged inside
-	if err != nil || code != 200 {
+	if err != nil || code != http.StatusOK {
 		log.WithError(err).WithField("code", code).Error("failed to publish block")
 		api.RespondError(w, http.StatusBadRequest, "failed to publish block")
 		return

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1139,7 +1139,7 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 	log = log.WithField("timestampBeforePublishing", timeBeforePublish)
 	signedBeaconBlock := common.SignedBlindedBeaconBlockToBeaconBlock(payload, getPayloadResp)
 	code, err := api.beaconClient.PublishBlock(signedBeaconBlock) // errors are logged inside
-	if err != nil {
+	if err != nil || code != 200 {
 		log.WithError(err).WithField("code", code).Error("failed to publish block")
 		api.RespondError(w, http.StatusBadRequest, "failed to publish block")
 		return


### PR DESCRIPTION
## 📝 Summary

Two minor changes: 
1. when no beacon publication was successful, wrap the returned error so that it is non-nil. in the case of all 202s, the error was returning nil, when really 202 should be an error case.
2. redundantly check the error code is 200 alongside the err being non-nil

## ⛱ Motivation and Context

To avoid returning the full `SignedBeaconBlock` to the proposer in cases where 202s are returned from beacon nodes.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
