### PR TITLE
Fetch latest builder value for cancellations check

### DIFF
--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -527,3 +527,18 @@ func (r *RedisCache) GetTopBidValue(slot uint64, parentHash, proposerPubkey stri
 	topBidValue.SetString(topBidValueStr, 10)
 	return topBidValue, nil
 }
+
+// GetBuilderLatestValue gets the latest bid value for a given slot+parent+proposer combination for a specific builder pubkey.
+func (r *RedisCache) GetBuilderLatestValue(slot uint64, parentHash, proposerPubkey, builderPubkey string) (topBidValue *big.Int, err error) {
+	keyLatestValue := r.keyBlockBuilderLatestBidsValue(slot, parentHash, proposerPubkey)
+	topBidValueStr, err := r.client.HGet(context.Background(), keyLatestValue, builderPubkey).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return big.NewInt(0), nil
+		}
+		return nil, err
+	}
+	topBidValue = new(big.Int)
+	topBidValue.SetString(topBidValueStr, 10)
+	return topBidValue, nil
+}

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -660,9 +660,9 @@ func (api *RelayAPI) RespondError(w http.ResponseWriter, code int, message strin
 	}
 }
 
-func (api *RelayAPI) RespondOK(w http.ResponseWriter, response any) {
+func (api *RelayAPI) RespondOK(w http.ResponseWriter, code int, response any) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(code)
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		api.log.WithField("response", response).WithError(err).Error("Couldn't write OK response")
 		http.Error(w, "", http.StatusInternalServerError)
@@ -995,7 +995,7 @@ func (api *RelayAPI) handleGetHeader(w http.ResponseWriter, req *http.Request) {
 		"value":     bid.Value().String(),
 		"blockHash": bid.BlockHash().String(),
 	}).Info("bid delivered")
-	api.RespondOK(w, bid)
+	api.RespondOK(w, http.StatusOK, bid)
 }
 
 func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) {
@@ -1229,7 +1229,7 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 	time.Sleep(time.Duration(getPayloadResponseDelayMs) * time.Millisecond)
 
 	// respond to the HTTP request
-	api.RespondOK(w, getPayloadResp)
+	api.RespondOK(w, http.StatusOK, getPayloadResp)
 	log = log.WithFields(logrus.Fields{
 		"numTx":       getPayloadResp.NumTx(),
 		"blockNumber": payload.BlockNumber(),
@@ -1512,7 +1512,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		// Without cancellations, discard lower or similar value submissions to previous top bid
 		if !isCancellationEnabled && payload.Value().Cmp(topBidValue) < 1 {
 			log.Info("rejecting submission because it is lower or equal to the top bid (redis)")
-			w.WriteHeader(http.StatusOK)
+			api.RespondOK(w, http.StatusAccepted, "ignoring submission because it is lower or equal to the top bid and cancellations are not enabled")
 			return
 		}
 	}
@@ -1673,7 +1673,7 @@ func (api *RelayAPI) handleInternalBuilderStatus(w http.ResponseWriter, req *htt
 			return
 		}
 
-		api.RespondOK(w, builderEntry)
+		api.RespondOK(w, http.StatusOK, builderEntry)
 		return
 	} else if req.Method == http.MethodPost || req.Method == http.MethodPut || req.Method == http.MethodPatch {
 		args := req.URL.Query()
@@ -1696,7 +1696,7 @@ func (api *RelayAPI) handleInternalBuilderStatus(w http.ResponseWriter, req *htt
 			api.log.WithError(err).Error("could not set block builder status in database")
 		}
 
-		api.RespondOK(w, struct{ newStatus string }{newStatus: string(newStatus)})
+		api.RespondOK(w, http.StatusOK, struct{ newStatus string }{newStatus: string(newStatus)})
 	}
 }
 
@@ -1794,7 +1794,7 @@ func (api *RelayAPI) handleDataProposerPayloadDelivered(w http.ResponseWriter, r
 		response[i] = database.DeliveredPayloadEntryToBidTraceV2JSON(payload)
 	}
 
-	api.RespondOK(w, response)
+	api.RespondOK(w, http.StatusOK, response)
 }
 
 func (api *RelayAPI) handleDataBuilderBidsReceived(w http.ResponseWriter, req *http.Request) {
@@ -1879,7 +1879,7 @@ func (api *RelayAPI) handleDataBuilderBidsReceived(w http.ResponseWriter, req *h
 		response[i] = database.BuilderSubmissionEntryToBidTraceV2WithTimestampJSON(payload)
 	}
 
-	api.RespondOK(w, response)
+	api.RespondOK(w, http.StatusOK, response)
 }
 
 func (api *RelayAPI) handleDataValidatorRegistration(w http.ResponseWriter, req *http.Request) {
@@ -1914,5 +1914,5 @@ func (api *RelayAPI) handleDataValidatorRegistration(w http.ResponseWriter, req 
 		return
 	}
 
-	api.RespondOK(w, signedRegistration)
+	api.RespondOK(w, http.StatusOK, signedRegistration)
 }

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -660,7 +660,7 @@ func (api *RelayAPI) RespondError(w http.ResponseWriter, code int, message strin
 	}
 }
 
-func (api *RelayAPI) RespondOK(w http.ResponseWriter, code int, response any) {
+func (api *RelayAPI) Respond(w http.ResponseWriter, code int, response any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -995,7 +995,7 @@ func (api *RelayAPI) handleGetHeader(w http.ResponseWriter, req *http.Request) {
 		"value":     bid.Value().String(),
 		"blockHash": bid.BlockHash().String(),
 	}).Info("bid delivered")
-	api.RespondOK(w, http.StatusOK, bid)
+	api.Respond(w, http.StatusOK, bid)
 }
 
 func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) {
@@ -1229,7 +1229,7 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 	time.Sleep(time.Duration(getPayloadResponseDelayMs) * time.Millisecond)
 
 	// respond to the HTTP request
-	api.RespondOK(w, http.StatusOK, getPayloadResp)
+	api.Respond(w, http.StatusOK, getPayloadResp)
 	log = log.WithFields(logrus.Fields{
 		"numTx":       getPayloadResp.NumTx(),
 		"blockNumber": payload.BlockNumber(),
@@ -1512,7 +1512,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		// Without cancellations, discard lower or similar value submissions to previous top bid
 		if !isCancellationEnabled && payload.Value().Cmp(topBidValue) < 1 {
 			log.Info("rejecting submission because it is lower or equal to the top bid (redis)")
-			api.RespondOK(w, http.StatusAccepted, "ignoring submission because it is lower or equal to the top bid and cancellations are not enabled")
+			api.Respond(w, http.StatusAccepted, "ignoring submission because it is lower or equal to the top bid and cancellations are not enabled")
 			return
 		}
 	}
@@ -1673,7 +1673,7 @@ func (api *RelayAPI) handleInternalBuilderStatus(w http.ResponseWriter, req *htt
 			return
 		}
 
-		api.RespondOK(w, http.StatusOK, builderEntry)
+		api.Respond(w, http.StatusOK, builderEntry)
 		return
 	} else if req.Method == http.MethodPost || req.Method == http.MethodPut || req.Method == http.MethodPatch {
 		args := req.URL.Query()
@@ -1696,7 +1696,7 @@ func (api *RelayAPI) handleInternalBuilderStatus(w http.ResponseWriter, req *htt
 			api.log.WithError(err).Error("could not set block builder status in database")
 		}
 
-		api.RespondOK(w, http.StatusOK, struct{ newStatus string }{newStatus: string(newStatus)})
+		api.Respond(w, http.StatusOK, struct{ newStatus string }{newStatus: string(newStatus)})
 	}
 }
 
@@ -1794,7 +1794,7 @@ func (api *RelayAPI) handleDataProposerPayloadDelivered(w http.ResponseWriter, r
 		response[i] = database.DeliveredPayloadEntryToBidTraceV2JSON(payload)
 	}
 
-	api.RespondOK(w, http.StatusOK, response)
+	api.Respond(w, http.StatusOK, response)
 }
 
 func (api *RelayAPI) handleDataBuilderBidsReceived(w http.ResponseWriter, req *http.Request) {
@@ -1879,7 +1879,7 @@ func (api *RelayAPI) handleDataBuilderBidsReceived(w http.ResponseWriter, req *h
 		response[i] = database.BuilderSubmissionEntryToBidTraceV2WithTimestampJSON(payload)
 	}
 
-	api.RespondOK(w, http.StatusOK, response)
+	api.Respond(w, http.StatusOK, response)
 }
 
 func (api *RelayAPI) handleDataValidatorRegistration(w http.ResponseWriter, req *http.Request) {
@@ -1914,5 +1914,5 @@ func (api *RelayAPI) handleDataValidatorRegistration(w http.ResponseWriter, req 
 		return
 	}
 
-	api.RespondOK(w, http.StatusOK, signedRegistration)
+	api.Respond(w, http.StatusOK, signedRegistration)
 }


### PR DESCRIPTION
## 📝 Summary

Instead of comparing to the max overall bid value to determine if a bid should be cancelled, look just at the latest bid from the builder. 

## ⛱ Motivation and Context

The previous iteration allowed for builders to submit artificially high bids and get other builder submissions rejected if they weren't using cancellations. The new logic is

```
> 1. if the bid is higher than the existing bid from that builder, update the builder’s bid
> 2. if the bid is lower than the existing bid from that builder
>    * if cancellations are enabled, update the builder’s bid
>    * if cancellations are not enabled, do not update the builder’s bid
```

So the check becomes local to the builder pubkey rather then global over all the bids. 

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x]  `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
