### PR TITLE
Allow multiple getPayload calls for a delivered payload

### DIFF
--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -28,8 +28,9 @@ var (
 	RedisStatsFieldLatestSlot      = "latest-slot"
 	RedisStatsFieldValidatorsTotal = "validators-total"
 
-	ErrFailedUpdatingTopBidNoBids = errors.New("failed to update top bid because no bids were found")
-	ErrSlotAlreadyDelivered       = errors.New("payload for slot was already delivered")
+	ErrFailedUpdatingTopBidNoBids            = errors.New("failed to update top bid because no bids were found")
+	ErrAnotherPayloadAlreadyDeliveredForSlot = errors.New("another payload block hash for slot was already delivered")
+	ErrPastSlotAlreadyDelivered              = errors.New("payload for past slot was already delivered")
 )
 
 type BlockBuilderStatus string
@@ -84,6 +85,7 @@ type RedisCache struct {
 	keyProposerDuties     string
 	keyBlockBuilderStatus string
 	keyLastSlotDelivered  string
+	keyLastHashDelivered  string
 }
 
 func NewRedisCache(prefix, redisURI, readonlyURI string) (*RedisCache, error) {
@@ -124,6 +126,7 @@ func NewRedisCache(prefix, redisURI, readonlyURI string) (*RedisCache, error) {
 		keyProposerDuties:     fmt.Sprintf("%s/%s:proposer-duties", redisPrefix, prefix),
 		keyBlockBuilderStatus: fmt.Sprintf("%s/%s:block-builder-status", redisPrefix, prefix),
 		keyLastSlotDelivered:  fmt.Sprintf("%s/%s:last-slot-delivered", redisPrefix, prefix),
+		keyLastHashDelivered:  fmt.Sprintf("%s/%s:last-hash-delivered", redisPrefix, prefix),
 	}, nil
 }
 
@@ -272,7 +275,7 @@ func (r *RedisCache) GetActiveValidators() (map[boostTypes.PubkeyHex]bool, error
 	return validators, nil
 }
 
-func (r *RedisCache) CheckAndSetLastSlotDelivered(slot uint64) (err error) {
+func (r *RedisCache) CheckAndSetLastSlotAndHashDelivered(slot uint64, hash string) (err error) {
 	// More details about Redis optimistic locking:
 	// - https://redis.uptrace.dev/guide/go-redis-pipelines.html#transactions
 	// - https://github.com/redis/go-redis/blob/6ecbcf6c90919350c42181ce34c1cbdfbd5d1463/race_test.go#L183
@@ -282,12 +285,24 @@ func (r *RedisCache) CheckAndSetLastSlotDelivered(slot uint64) (err error) {
 			return err
 		}
 
-		if slot <= lastSlotDelivered {
-			return ErrSlotAlreadyDelivered
+		if slot < lastSlotDelivered {
+			return ErrPastSlotAlreadyDelivered
+		}
+
+		if slot == lastSlotDelivered {
+			lastHashDelivered, err := tx.Get(context.Background(), r.keyLastHashDelivered).Result()
+			if err != nil && !errors.Is(err, redis.Nil) {
+				return err
+			}
+			if hash != lastHashDelivered {
+				return ErrAnotherPayloadAlreadyDeliveredForSlot
+			}
+			return nil
 		}
 
 		_, err = tx.TxPipelined(context.Background(), func(pipe redis.Pipeliner) error {
 			pipe.Set(context.Background(), r.keyLastSlotDelivered, slot, 0)
+			pipe.Set(context.Background(), r.keyLastHashDelivered, hash, 0)
 			return nil
 		})
 
@@ -299,6 +314,10 @@ func (r *RedisCache) CheckAndSetLastSlotDelivered(slot uint64) (err error) {
 
 func (r *RedisCache) GetLastSlotDelivered() (slot uint64, err error) {
 	return r.client.Get(context.Background(), r.keyLastSlotDelivered).Uint64()
+}
+
+func (r *RedisCache) GetLastHashDelivered() (hash string, err error) {
+	return r.client.Get(context.Background(), r.keyLastHashDelivered).Result()
 }
 
 func (r *RedisCache) SetStats(field string, value any) (err error) {

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -285,10 +285,12 @@ func (r *RedisCache) CheckAndSetLastSlotAndHashDelivered(slot uint64, hash strin
 			return err
 		}
 
+		// slot in the past, reject request
 		if slot < lastSlotDelivered {
 			return ErrPastSlotAlreadyDelivered
 		}
 
+		// current slot, reject request if hash is different
 		if slot == lastSlotDelivered {
 			lastHashDelivered, err := tx.Get(context.Background(), r.keyLastHashDelivered).Result()
 			if err != nil && !errors.Is(err, redis.Nil) {
@@ -309,7 +311,7 @@ func (r *RedisCache) CheckAndSetLastSlotAndHashDelivered(slot uint64, hash strin
 		return err
 	}
 
-	return r.client.Watch(context.Background(), txf, r.keyLastSlotDelivered)
+	return r.client.Watch(context.Background(), txf, r.keyLastSlotDelivered, r.keyLastHashDelivered)
 }
 
 func (r *RedisCache) GetLastSlotDelivered() (slot uint64, err error) {

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -387,9 +387,10 @@ func TestRedisURIs(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestCheckAndSetLastSlotDelivered(t *testing.T) {
+func TestCheckAndSetLastSlotAndHashDelivered(t *testing.T) {
 	cache := setupTestRedis(t)
 	newSlot := uint64(123)
+	newHash := "0x0000000000000000000000000000000000000000000000000000000000000000"
 
 	// should return redis.Nil if wasn't set
 	slot, err := cache.GetLastSlotDelivered()
@@ -397,7 +398,7 @@ func TestCheckAndSetLastSlotDelivered(t *testing.T) {
 	require.Equal(t, uint64(0), slot)
 
 	// should be able to set once
-	err = cache.CheckAndSetLastSlotDelivered(newSlot)
+	err = cache.CheckAndSetLastSlotAndHashDelivered(newSlot, newHash)
 	require.NoError(t, err)
 
 	// should get slot
@@ -405,20 +406,31 @@ func TestCheckAndSetLastSlotDelivered(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, newSlot, slot)
 
-	// should fail on second time
-	err = cache.CheckAndSetLastSlotDelivered(newSlot)
-	require.ErrorIs(t, err, ErrSlotAlreadyDelivered)
+	// should get hash
+	hash, err := cache.GetLastHashDelivered()
+	require.NoError(t, err)
+	require.Equal(t, newHash, hash)
+
+	// should fail on a different payload (mismatch block hash)
+	differentHash := "0x0000000000000000000000000000000000000000000000000000000000000001"
+	err = cache.CheckAndSetLastSlotAndHashDelivered(newSlot, differentHash)
+	require.ErrorIs(t, err, ErrAnotherPayloadAlreadyDeliveredForSlot)
+
+	// should not return error for same hash
+	err = cache.CheckAndSetLastSlotAndHashDelivered(newSlot, newHash)
+	require.NoError(t, err)
 
 	// should also fail on earlier slots
-	err = cache.CheckAndSetLastSlotDelivered(newSlot - 1)
-	require.ErrorIs(t, err, ErrSlotAlreadyDelivered)
+	err = cache.CheckAndSetLastSlotAndHashDelivered(newSlot-1, newHash)
+	require.ErrorIs(t, err, ErrPastSlotAlreadyDelivered)
 }
 
-// Test_CheckAndSetLastSlotDeliveredForTesting ensures the optimistic locking works
-// i.e. running CheckAndSetLastSlotDelivered leading to err == redis.TxFailedErr
-func Test_CheckAndSetLastSlotDeliveredForTesting(t *testing.T) {
+// Test_CheckAndSetLastSlotAndHashDeliveredForTesting ensures the optimistic locking works
+// i.e. running CheckAndSetLastSlotAndHashDelivered leading to err == redis.TxFailedErr
+func Test_CheckAndSetLastSlotAndHashDeliveredForTesting(t *testing.T) {
 	cache := setupTestRedis(t)
 	newSlot := uint64(123)
+	hash := "0x0000000000000000000000000000000000000000000000000000000000000000"
 	n := 3
 
 	errC := make(chan error, n)
@@ -429,7 +441,7 @@ func Test_CheckAndSetLastSlotDeliveredForTesting(t *testing.T) {
 	for i := 0; i < n; i++ {
 		syncWG.Add(1)
 		go func() {
-			errC <- _CheckAndSetLastSlotDeliveredForTesting(cache, waitC, &syncWG, newSlot)
+			errC <- _CheckAndSetLastSlotAndHashDeliveredForTesting(cache, waitC, &syncWG, newSlot, hash)
 		}()
 	}
 
@@ -447,13 +459,14 @@ func Test_CheckAndSetLastSlotDeliveredForTesting(t *testing.T) {
 		require.ErrorIs(t, err, redis.TxFailedErr)
 	}
 
-	// Any later call should return ErrSlotAlreadyDelivered
-	err = _CheckAndSetLastSlotDeliveredForTesting(cache, waitC, &syncWG, newSlot)
+	// Any later call with a different hash should return ErrPayloadAlreadyDeliveredForSlot
+	differentHash := "0x0000000000000000000000000000000000000000000000000000000000000001"
+	err = _CheckAndSetLastSlotAndHashDeliveredForTesting(cache, waitC, &syncWG, newSlot, differentHash)
 	waitC <- true
-	require.ErrorIs(t, err, ErrSlotAlreadyDelivered)
+	require.ErrorIs(t, err, ErrAnotherPayloadAlreadyDeliveredForSlot)
 }
 
-func _CheckAndSetLastSlotDeliveredForTesting(r *RedisCache, waitC chan bool, wg *sync.WaitGroup, slot uint64) (err error) {
+func _CheckAndSetLastSlotAndHashDeliveredForTesting(r *RedisCache, waitC chan bool, wg *sync.WaitGroup, slot uint64, hash string) (err error) {
 	// copied from redis.go, with added channel and waitgroup to test the race condition in a controlled way
 	txf := func(tx *redis.Tx) error {
 		lastSlotDelivered, err := tx.Get(context.Background(), r.keyLastSlotDelivered).Uint64()
@@ -461,8 +474,19 @@ func _CheckAndSetLastSlotDeliveredForTesting(r *RedisCache, waitC chan bool, wg 
 			return err
 		}
 
-		if slot <= lastSlotDelivered {
-			return ErrSlotAlreadyDelivered
+		if slot < lastSlotDelivered {
+			return ErrPastSlotAlreadyDelivered
+		}
+
+		if slot == lastSlotDelivered {
+			lastHashDelivered, err := tx.Get(context.Background(), r.keyLastHashDelivered).Result()
+			if err != nil && !errors.Is(err, redis.Nil) {
+				return err
+			}
+			if hash != lastHashDelivered {
+				return ErrAnotherPayloadAlreadyDeliveredForSlot
+			}
+			return nil
 		}
 
 		wg.Done()
@@ -470,6 +494,7 @@ func _CheckAndSetLastSlotDeliveredForTesting(r *RedisCache, waitC chan bool, wg 
 
 		_, err = tx.TxPipelined(context.Background(), func(pipe redis.Pipeliner) error {
 			pipe.Set(context.Background(), r.keyLastSlotDelivered, slot, 0)
+			pipe.Set(context.Background(), r.keyLastHashDelivered, hash, 0)
 			return nil
 		})
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1155,21 +1155,25 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 	log = log.WithField("timestampAfterLoadResponse", time.Now().UTC().UnixMilli())
 
 	// Check whether getPayload has already been called -- TODO: do we need to allow multiple submissions of one blinded block?
-	err = api.redis.CheckAndSetLastSlotDelivered(payload.Slot())
+	err = api.redis.CheckAndSetLastSlotAndHashDelivered(payload.Slot(), payload.BlockHash())
 	log = log.WithField("timestampAfterAlreadyDeliveredCheck", time.Now().UTC().UnixMilli())
 	if err != nil {
-		if errors.Is(err, datastore.ErrSlotAlreadyDelivered) {
-			// BAD VALIDATOR, 2x GETPAYLOAD
-			log.Warn("validator called getPayload twice")
-			api.RespondError(w, http.StatusBadRequest, "payload for this slot was already delivered")
+		if errors.Is(err, datastore.ErrAnotherPayloadAlreadyDeliveredForSlot) {
+			// BAD VALIDATOR, 2x GETPAYLOAD FOR DIFFERENT PAYLOADS
+			log.Warn("validator called getPayload twice for different payload hashes")
+			api.RespondError(w, http.StatusBadRequest, "another payload for this slot was already delivered")
 			return
+		} else if errors.Is(err, datastore.ErrPastSlotAlreadyDelivered) {
+			// BAD VALIDATOR, 2x GETPAYLOAD FOR PAST SLOT
+			log.Warn("validator called getPayload for past slot")
+			api.RespondError(w, http.StatusBadRequest, "payload for this slot was already delivered")
 		} else if errors.Is(err, redis.TxFailedErr) {
 			// BAD VALIDATOR, 2x GETPAYLOAD + RACE
 			log.Warn("validator called getPayload twice (race)")
 			api.RespondError(w, http.StatusBadRequest, "payload for this slot was already delivered (race)")
 			return
 		}
-		log.WithError(err).Error("redis.CheckAndSetLastSlotDelivered failed")
+		log.WithError(err).Error("redis.CheckAndSetLastSlotAndHashDelivered failed")
 	}
 
 	// Handle early/late requests


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Allow multiple get payload calls if the block hashes match for the slot.

## ⛱ Motivation and Context
Supporting https://github.com/flashbots/mev-boost-relay/issues/397 to allow repeated getPayload requests for an already delivered payload. Improves redundancy for get payload requests

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
