### PR TITLE
process cancellable bids below floor correctly

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -65,7 +65,7 @@ linters-settings:
     min-complexity: 85 # default: 30
 
   gocyclo:
-    min-complexity: 75 # default: 30
+    min-complexity: 70 # default: 30
 
   gomoddirectives:
     replace-allow-list:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -65,7 +65,7 @@ linters-settings:
     min-complexity: 85 # default: 30
 
   gocyclo:
-    min-complexity: 65 # default: 30
+    min-complexity: 75 # default: 30
 
   gomoddirectives:
     replace-allow-list:

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -683,13 +683,6 @@ func (r *RedisCache) DelBuilderBid(slot uint64, parentHash, proposerPubkey, buil
 		return err
 	}
 
-	// delete the bid
-	keyLatestBid := r.keyLatestBidByBuilder(slot, parentHash, proposerPubkey, builderPubkey)
-	err = r.client.Del(context.Background(), keyLatestBid).Err()
-	if err != nil {
-		return err
-	}
-
 	// update bids now to compute current top bid
 	state := SaveBidAndUpdateTopBidResponse{} //nolint:exhaustruct
 	_, err = r._UpdateTopBid(state, nil, slot, parentHash, proposerPubkey, nil)

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -625,7 +625,7 @@ func (r *RedisCache) _UpdateTopBid(state SaveBidAndUpdateTopBidResponse, builder
 		return state, err
 	}
 
-	state.WasTopBidUpdated = state.PrevTopBidValue.Cmp(state.TopBidValue) != 0
+	state.WasTopBidUpdated = state.PrevTopBidValue == nil || state.PrevTopBidValue.Cmp(state.TopBidValue) != 0
 
 	// 6. Finally, update the global top bid value
 	keyTopBidValue := r.keyTopBidValue(slot, parentHash, proposerPubkey)

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -496,13 +496,13 @@ type SaveBidAndUpdateTopBidResponse struct {
 }
 
 func (r *RedisCache) SaveBidAndUpdateTopBid(payload *common.BuilderSubmitBlockRequest, getPayloadResponse *common.GetPayloadResponse, getHeaderResponse *common.GetHeaderResponse, reqReceivedAt time.Time, isCancellationEnabled bool, floorValue *big.Int) (state SaveBidAndUpdateTopBidResponse, err error) {
-	// 1. Load latest bids for a given slot+parent+proposer
-	keyBidValues := r.keyBlockBuilderLatestBidsValue(payload.Slot(), payload.ParentHash(), payload.ProposerPubkey())
-	bidValueMap, err := r.client.HGetAll(context.Background(), keyBidValues).Result()
+	// Load latest bids for a given slot+parent+proposer
+	builderBids, err := NewBuilderBidsFromRedis(r, payload.Slot(), payload.ParentHash(), payload.ProposerPubkey())
 	if err != nil {
 		return state, err
 	}
 
+	// Load floor value (if not passed in already)
 	if floorValue == nil {
 		floorValue, err = r.GetFloorBidValue(payload.Slot(), payload.ParentHash(), payload.ProposerPubkey())
 		if err != nil {
@@ -510,18 +510,22 @@ func (r *RedisCache) SaveBidAndUpdateTopBid(payload *common.BuilderSubmitBlockRe
 		}
 	}
 
-	builderBids := NewBuilderBids(bidValueMap)
-	_, state.PrevTopBidValue = builderBids.getTopBid()
-	state.TopBidValue = state.PrevTopBidValue
+	// Get the reference top bid value
+	_, state.TopBidValue = builderBids.getTopBid()
+	if floorValue.Cmp(state.TopBidValue) == 1 {
+		state.TopBidValue = floorValue
+	}
+	state.PrevTopBidValue = state.TopBidValue
 
-	// 2. Do we even need to continue / save the new payload and update the top bid?
-	// - In cancellation mode: always continue to saving latest bid
-	// - In non-cancellation mode: only save if current bid is higher value than floor value
-	if !isCancellationEnabled && payload.Value().Cmp(floorValue) < 1 {
+	// Abort now if non-cancellation bid is lower than floor value
+	isBidAboveFloor := payload.Value().Cmp(floorValue) == 1
+	if !isCancellationEnabled && !isBidAboveFloor {
 		return state, nil
 	}
 
+	//
 	// Time to save things in Redis
+	//
 	// 1. Save the execution payload
 	err = r.SaveExecutionPayload(payload.Slot(), payload.ProposerPubkey(), payload.BlockHash(), getPayloadResponse)
 	if err != nil {
@@ -534,26 +538,82 @@ func (r *RedisCache) SaveBidAndUpdateTopBid(payload *common.BuilderSubmitBlockRe
 		return state, err
 	}
 	state.WasBidSaved = true
-
-	// 3. Update this builders latest bid in local cache
 	builderBids.bidValues[payload.BuilderPubkey().String()] = payload.Value()
-	topBidBuilder := ""
-	topBidBuilder, state.TopBidValue = builderBids.getTopBid()
-	keyBidSource := r.keyLatestBidByBuilder(payload.Slot(), payload.ParentHash(), payload.ProposerPubkey(), topBidBuilder)
 
-	// 4. Only proceed to update top bid in redis if it changed in local cache
+	// If top bid value hasn't change, abort now
+	_, state.TopBidValue = builderBids.getTopBid()
 	if state.TopBidValue.Cmp(state.PrevTopBidValue) == 0 {
 		return state, nil
 	}
 
+	//
+	// Update the top bid
+	//
+	state, err = r._UpdateTopBid(state, builderBids, payload.Slot(), payload.ParentHash(), payload.ProposerPubkey(), floorValue)
+	if err != nil {
+		return state, err
+	}
+	state.IsNewTopBid = payload.Value().Cmp(state.TopBidValue) == 0
+
+	//
+	// Check if should set a new bid floor
+	//
+	if !isCancellationEnabled && isBidAboveFloor {
+		keyBidSource := r.keyLatestBidByBuilder(payload.Slot(), payload.ParentHash(), payload.ProposerPubkey(), payload.BuilderPubkey().String())
+		keyFloorBid := r.keyFloorBid(payload.Slot(), payload.ParentHash(), payload.ProposerPubkey())
+		wasCopied, copyErr := r.client.Copy(context.Background(), keyBidSource, keyFloorBid, 0, true).Result()
+		if copyErr != nil {
+			return state, copyErr
+		} else if wasCopied == 0 {
+			return state, fmt.Errorf("could not copy %s to %s", keyBidSource, keyFloorBid) //nolint:goerr113
+		}
+		err = r.client.Expire(context.Background(), keyFloorBid, expiryBidCache).Err()
+		if err != nil {
+			return state, err
+		}
+
+		keyFloorBidValue := r.keyFloorBidValue(payload.Slot(), payload.ParentHash(), payload.ProposerPubkey())
+		err = r.client.Set(context.Background(), keyFloorBidValue, payload.Value().String(), expiryBidCache).Err()
+		if err != nil {
+			return state, err
+		}
+	}
+
+	return state, nil
+}
+
+func (r *RedisCache) _UpdateTopBid(state SaveBidAndUpdateTopBidResponse, builderBids *BuilderBids, slot uint64, parentHash, proposerPubkey string, floorValue *big.Int) (resp SaveBidAndUpdateTopBidResponse, err error) {
+	if builderBids == nil {
+		builderBids, err = NewBuilderBidsFromRedis(r, slot, parentHash, proposerPubkey)
+		if err != nil {
+			return state, err
+		}
+	}
+
+	if len(builderBids.bidValues) == 0 {
+		return state, nil
+	}
+
+	// Load floor value (if not passed in already)
+	if floorValue == nil {
+		floorValue, err = r.GetFloorBidValue(slot, parentHash, proposerPubkey)
+		if err != nil {
+			return state, err
+		}
+	}
+
+	topBidBuilder := ""
+	topBidBuilder, state.TopBidValue = builderBids.getTopBid()
+	keyBidSource := r.keyLatestBidByBuilder(slot, parentHash, proposerPubkey, topBidBuilder)
+
 	// If floor value is higher than this bid, use floor bid instead
 	if floorValue.Cmp(state.TopBidValue) == 1 {
 		state.TopBidValue = floorValue
-		keyBidSource = r.keyFloorBid(payload.Slot(), payload.ParentHash(), payload.ProposerPubkey())
+		keyBidSource = r.keyFloorBid(slot, parentHash, proposerPubkey)
 	}
 
-	// 5. Copy winning bid to top bid cache
-	keyTopBid := r.keyCacheGetHeaderResponse(payload.Slot(), payload.ParentHash(), payload.ProposerPubkey())
+	// Copy winning bid to top bid cache
+	keyTopBid := r.keyCacheGetHeaderResponse(slot, parentHash, proposerPubkey)
 	wasCopied, err := r.client.Copy(context.Background(), keyBidSource, keyTopBid, 0, true).Result()
 	if err != nil {
 		return state, err
@@ -566,32 +626,12 @@ func (r *RedisCache) SaveBidAndUpdateTopBid(payload *common.BuilderSubmitBlockRe
 	}
 
 	state.WasTopBidUpdated = state.PrevTopBidValue.Cmp(state.TopBidValue) != 0
-	state.IsNewTopBid = payload.Value().Cmp(state.TopBidValue) == 0
 
 	// 6. Finally, update the global top bid value
-	keyTopBidValue := r.keyTopBidValue(payload.Slot(), payload.ParentHash(), payload.ProposerPubkey())
+	keyTopBidValue := r.keyTopBidValue(slot, parentHash, proposerPubkey)
 	err = r.client.Set(context.Background(), keyTopBidValue, state.TopBidValue.String(), expiryBidCache).Err()
 	if err != nil {
 		return state, err
-	}
-
-	// 7. If non-cancelling, perhaps set a new bid floor
-	if !isCancellationEnabled && payload.Value().Cmp(floorValue) == 1 {
-		keyBidSource := r.keyLatestBidByBuilder(payload.Slot(), payload.ParentHash(), payload.ProposerPubkey(), payload.BuilderPubkey().String())
-		keyFloorBid := r.keyFloorBid(payload.Slot(), payload.ParentHash(), payload.ProposerPubkey())
-		wasCopied, copyErr := r.client.Copy(context.Background(), keyBidSource, keyFloorBid, 0, true).Result()
-		if copyErr != nil {
-			return state, copyErr
-		} else if wasCopied == 0 {
-			return state, fmt.Errorf("could not copy %s to %s", keyBidSource, keyTopBid) //nolint:goerr113
-		}
-		err = r.client.Expire(context.Background(), keyFloorBid, expiryBidCache).Err()
-		if err != nil {
-			return state, err
-		}
-
-		keyFloorBidValue := r.keyFloorBidValue(payload.Slot(), payload.ParentHash(), payload.ProposerPubkey())
-		err = r.client.Set(context.Background(), keyFloorBidValue, payload.Value().String(), expiryBidCache).Err()
 	}
 
 	return state, err
@@ -625,6 +665,35 @@ func (r *RedisCache) GetBuilderLatestValue(slot uint64, parentHash, proposerPubk
 	topBidValue = new(big.Int)
 	topBidValue.SetString(topBidValueStr, 10)
 	return topBidValue, nil
+}
+
+// DelBuilderBid removes a builders most recent bid
+func (r *RedisCache) DelBuilderBid(slot uint64, parentHash, proposerPubkey, builderPubkey string) (err error) {
+	// delete the value
+	keyLatestValue := r.keyBlockBuilderLatestBidsValue(slot, parentHash, proposerPubkey)
+	err = r.client.HDel(context.Background(), keyLatestValue, builderPubkey).Err()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return err
+	}
+
+	// delete the time
+	keyLatestBidsTime := r.keyBlockBuilderLatestBidsTime(slot, parentHash, proposerPubkey)
+	err = r.client.HDel(context.Background(), keyLatestBidsTime, builderPubkey).Err()
+	if err != nil {
+		return err
+	}
+
+	// delete the bid
+	keyLatestBid := r.keyLatestBidByBuilder(slot, parentHash, proposerPubkey, builderPubkey)
+	err = r.client.Del(context.Background(), keyLatestBid).Err()
+	if err != nil {
+		return err
+	}
+
+	// update bids now to compute current top bid
+	state := SaveBidAndUpdateTopBidResponse{} //nolint:exhaustruct
+	_, err = r._UpdateTopBid(state, nil, slot, parentHash, proposerPubkey, nil)
+	return err
 }
 
 // GetFloorBidValue returns the value of the highest non-cancellable bid

--- a/datastore/utils.go
+++ b/datastore/utils.go
@@ -1,12 +1,22 @@
 package datastore
 
 import (
+	"context"
 	"math/big"
 )
 
 // BuilderBids supports redis.SaveBidAndUpdateTopBid
 type BuilderBids struct {
 	bidValues map[string]*big.Int
+}
+
+func NewBuilderBidsFromRedis(r *RedisCache, slot uint64, parentHash, proposerPubkey string) (*BuilderBids, error) {
+	keyBidValues := r.keyBlockBuilderLatestBidsValue(slot, parentHash, proposerPubkey)
+	bidValueMap, err := r.client.HGetAll(context.Background(), keyBidValues).Result()
+	if err != nil {
+		return nil, err
+	}
+	return NewBuilderBids(bidValueMap), nil
 }
 
 func NewBuilderBids(bidValueMap map[string]string) *BuilderBids {

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1949,7 +1949,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	updateBidResult, err := api.redis.SaveBidAndUpdateTopBid(payload, getPayloadResponse, getHeaderResponse, receivedAt, isCancellationEnabled, floorBidValue)
 	if err != nil {
 		log.WithError(err).Error("could not save bid and update top bids")
-		api.RespondError(w, http.StatusInternalServerError, err.Error())
+		api.RespondError(w, http.StatusInternalServerError, "failed saving and updating bid")
 		return
 	}
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1803,7 +1803,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 			if isCancellationEnabled {
 				// if cancellations are enabled, we don't need to validate, but we may need to cancel this builders previous cancellable bid (if higher than floor)
 				simResultC <- &blockSimResult{false, false, nil, nil}
-				log.Info("submission with cancellation and below floor bid value - deleting previous bid")
+				log.Info("submission below floor bid value, with cancellation")
 				err := api.redis.DelBuilderBid(payload.Slot(), payload.ParentHash(), payload.ProposerPubkey(), payload.BuilderPubkey().String())
 				if err != nil {
 					log.WithError(err).Error("failed processing cancellable bid below floor")
@@ -1814,8 +1814,8 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 				return
 			} else {
 				simResultC <- &blockSimResult{false, false, nil, nil}
-				log.Info("ignoring submission without cancellation and below floor bid value")
-				api.RespondMsg(w, http.StatusAccepted, "ignoring submission without cancellation and below floor bid value")
+				log.Info("submission below floor bid value, without cancellation")
+				api.RespondMsg(w, http.StatusAccepted, "accepted bid below floor, skipped validation")
 				return
 			}
 		}


### PR DESCRIPTION
## 📝 Summary

As [suggested](https://github.com/flashbots/mev-boost-relay/pull/399#discussion_r1190196533) by @dvush -- cancellable bids below the floor don't need to be validated, and should just delete any previous bid by this builder.

Skips an additional 100-200 validations per slot:
![Screenshot 2023-05-25 at 12 22 11](https://github.com/flashbots/mev-boost-relay/assets/116939/3f39d157-7ae5-4bcc-8d7d-27bc8a615b9d)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
