### PR TITLE
Post-merge optimistic relaying minor tweaks.

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -63,9 +63,9 @@ func init() {
 	apiCmd.Flags().StringVar(&network, "network", defaultNetwork, "Which network to use")
 
 	apiCmd.Flags().BoolVar(&apiPprofEnabled, "pprof", apiDefaultPprofEnabled, "enable pprof API")
-	apiCmd.Flags().BoolVar(&apiInternalAPI, "internal-api", apiDefaultInternalAPIEnabled, "enable internal API (/internal/...)")
 	apiCmd.Flags().BoolVar(&apiBuilderAPI, "builder-api", apiDefaultBuilderAPIEnabled, "enable builder API (/builder/...)")
 	apiCmd.Flags().BoolVar(&apiDataAPI, "data-api", apiDefaultDataAPIEnabled, "enable data API (/data/...)")
+	apiCmd.Flags().BoolVar(&apiInternalAPI, "internal-api", apiDefaultInternalAPIEnabled, "enable internal API (/internal/...)")
 	apiCmd.Flags().BoolVar(&apiProposerAPI, "proposer-api", apiDefaultProposerAPIEnabled, "enable proposer API (/proposer/...)")
 }
 
@@ -151,9 +151,9 @@ var apiCmd = &cobra.Command{
 			EthNetDetails: *networkInfo,
 			BlockSimURL:   apiBlockSimURL,
 
-			InternalAPI:     apiInternalAPI,
 			BlockBuilderAPI: apiBuilderAPI,
 			DataAPI:         apiDataAPI,
+			InternalAPI:     apiInternalAPI,
 			ProposerAPI:     apiProposerAPI,
 			PprofAPI:        apiPprofEnabled,
 		}

--- a/database/database.go
+++ b/database/database.go
@@ -503,7 +503,7 @@ func (s *DatabaseService) SetBlockBuilderIDStatusIsOptimistic(pubkey string, isO
 		return fmt.Errorf("unable to read block builder: %v, %w", pubkey, err)
 	}
 	if builder.BuilderID == "" {
-		return fmt.Errorf("unable update optimistic status of a builder with no builder id: %v", pubkey)
+		return fmt.Errorf("unable update optimistic status of a builder with no builder id: %v", pubkey) //nolint:goerr113
 	}
 	query := `UPDATE ` + vars.TableBlockBuilder + ` SET is_optimistic=$1 WHERE builder_id=$2;`
 	_, err = s.DB.Exec(query, isOptimistic, builder.BuilderID)

--- a/database/database.go
+++ b/database/database.go
@@ -41,7 +41,8 @@ type IDatabaseService interface {
 
 	GetBlockBuilders() ([]*BlockBuilderEntry, error)
 	GetBlockBuilderByPubkey(pubkey string) (*BlockBuilderEntry, error)
-	SetBlockBuilderStatus(pubkey string, status common.BuilderStatus, allKeys bool) error
+	SetBlockBuilderStatus(pubkey string, status common.BuilderStatus) error
+	SetBlockBuilderIDStatusIsOptimistic(pubkey string, isOptimistic bool) error
 	SetBlockBuilderCollateral(pubkey, builderID, collateral string) error
 	UpsertBlockBuilderEntryAfterSubmission(lastSubmission *BuilderBlockSubmissionEntry, isError bool) error
 	IncBlockBuilderStatsAfterGetPayload(builderPubkey string) error
@@ -490,21 +491,22 @@ func (s *DatabaseService) GetBlockBuilderByPubkey(pubkey string) (*BlockBuilderE
 	return entry, err
 }
 
-func (s *DatabaseService) SetBlockBuilderStatus(pubkey string, status common.BuilderStatus, allKeys bool) error {
+func (s *DatabaseService) SetBlockBuilderStatus(pubkey string, status common.BuilderStatus) error {
+	query := `UPDATE ` + vars.TableBlockBuilder + ` SET is_high_prio=$1, is_blacklisted=$2, is_optimistic=$3 WHERE builder_pubkey=$4;`
+	_, err := s.DB.Exec(query, status.IsHighPrio, status.IsBlacklisted, status.IsOptimistic, pubkey)
+	return err
+}
+
+func (s *DatabaseService) SetBlockBuilderIDStatusIsOptimistic(pubkey string, isOptimistic bool) error {
 	builder, err := s.GetBlockBuilderByPubkey(pubkey)
 	if err != nil {
 		return fmt.Errorf("unable to read block builder: %v, %w", pubkey, err)
 	}
-	var query string
-	queryPrefix := `UPDATE ` + vars.TableBlockBuilder
-	// If there is a builder ID and allKeys is true, then update statuses of all pubkeys.
-	if builder.BuilderID != "" && allKeys {
-		query = queryPrefix + fmt.Sprintf(" SET is_optimistic=$1 WHERE builder_id='%v';", builder.BuilderID)
-		_, err = s.DB.Exec(query, status.IsOptimistic)
-	} else { // Otherwise, just update the single pubkey.
-		query = queryPrefix + fmt.Sprintf(" SET is_high_prio=$1, is_blacklisted=$2, is_optimistic=$3 WHERE builder_pubkey='%v';", pubkey)
-		_, err = s.DB.Exec(query, status.IsHighPrio, status.IsBlacklisted, status.IsOptimistic)
+	if builder.BuilderID == "" {
+		return fmt.Errorf("unable update optimistic status of a builder with no builder id: %v", pubkey)
 	}
+	query := `UPDATE ` + vars.TableBlockBuilder + ` SET is_optimistic=$1 WHERE builder_id=$2;`
+	_, err = s.DB.Exec(query, isOptimistic, builder.BuilderID)
 	return err
 }
 

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -243,9 +243,8 @@ func TestSetBlockBuilderStatus(t *testing.T) {
 	for _, v := range []string{pubkey1, pubkey2, pubkey3} {
 		builder, err := db.GetBlockBuilderByPubkey(v)
 		require.NoError(t, err)
-		require.True(t, builder.IsHighPrio)
+		// Just is optimistic should change.
 		require.True(t, builder.IsOptimistic)
-		require.False(t, builder.IsBlacklisted)
 	}
 	// Builder 4 should be unchanged.
 	builder, err := db.GetBlockBuilderByPubkey(pubkey4)

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -218,6 +218,10 @@ func TestSetBlockBuilderStatus(t *testing.T) {
 	err = db.SetBlockBuilderCollateral(pubkey2, builderID, collateralStr)
 	require.NoError(t, err)
 
+	// Builder 3 has a different builder id.
+	err = db.SetBlockBuilderCollateral(pubkey3, "builder0x3", collateralStr)
+	require.NoError(t, err)
+
 	// Before status change.
 	for _, v := range []string{pubkey1, pubkey2, pubkey3, pubkey4} {
 		builder, err := db.GetBlockBuilderByPubkey(v)
@@ -227,16 +231,10 @@ func TestSetBlockBuilderStatus(t *testing.T) {
 		require.False(t, builder.IsBlacklisted)
 	}
 
-	// Update status of builder 1 and 3.
-	err = db.SetBlockBuilderStatus(pubkey1, common.BuilderStatus{
-		IsHighPrio:   true,
-		IsOptimistic: true,
-	}, true)
+	// Update isOptimistic of builder 1 and 3.
+	err = db.SetBlockBuilderIDStatusIsOptimistic(pubkey1, true)
 	require.NoError(t, err)
-	err = db.SetBlockBuilderStatus(pubkey3, common.BuilderStatus{
-		IsHighPrio:   true,
-		IsOptimistic: true,
-	}, true)
+	err = db.SetBlockBuilderIDStatusIsOptimistic(pubkey3, true)
 	require.NoError(t, err)
 
 	// After status change, builders 1, 2, 3 should be modified.
@@ -257,7 +255,7 @@ func TestSetBlockBuilderStatus(t *testing.T) {
 	err = db.SetBlockBuilderStatus(pubkey1, common.BuilderStatus{
 		IsHighPrio:   true,
 		IsOptimistic: false,
-	}, false)
+	})
 	require.NoError(t, err)
 	// Builder 1 should be non-optimistic.
 	builder, err = db.GetBlockBuilderByPubkey(pubkey1)

--- a/database/mockdb.go
+++ b/database/mockdb.go
@@ -102,26 +102,29 @@ func (db MockDB) GetBlockBuilderByPubkey(pubkey string) (*BlockBuilderEntry, err
 	return builder, nil
 }
 
-func (db MockDB) SetBlockBuilderStatus(pubkey string, status common.BuilderStatus, allKeys bool) error {
+func (db MockDB) SetBlockBuilderStatus(pubkey string, status common.BuilderStatus) error {
 	builder, ok := db.Builders[pubkey]
 	if !ok {
 		return fmt.Errorf("builder with pubkey %v not in Builders map", pubkey) //nolint:goerr113
 	}
-	// All keys updated.
-	if builder.BuilderID != "" && allKeys {
-		for _, v := range db.Builders {
-			if v.BuilderID == builder.BuilderID {
-				v.IsHighPrio = status.IsHighPrio
-				v.IsBlacklisted = status.IsBlacklisted
-				v.IsOptimistic = status.IsOptimistic
-			}
-		}
-		return nil
-	}
+
 	// Single key.
 	builder.IsHighPrio = status.IsHighPrio
 	builder.IsBlacklisted = status.IsBlacklisted
 	builder.IsOptimistic = status.IsOptimistic
+	return nil
+}
+
+func (db MockDB) SetBlockBuilderIDStatusIsOptimistic(pubkey string, isOptimistic bool) error {
+	builder, ok := db.Builders[pubkey]
+	if !ok {
+		return fmt.Errorf("builder with pubkey %v not in Builders map", pubkey) //nolint:goerr113
+	}
+	for _, v := range db.Builders {
+		if v.BuilderID == builder.BuilderID {
+			v.IsOptimistic = isOptimistic
+		}
+	}
 	return nil
 }
 

--- a/services/api/optimistic_test.go
+++ b/services/api/optimistic_test.go
@@ -421,7 +421,7 @@ func TestBuilderApiSubmitNewBlockOptimistic(t *testing.T) {
 func TestInternalBuilderStatus(t *testing.T) {
 	pubkey, _, backend := startTestBackend(t)
 	// Set all to false initially.
-	err := backend.relay.db.SetBlockBuilderStatus(pubkey.String(), common.BuilderStatus{}, false)
+	err := backend.relay.db.SetBlockBuilderStatus(pubkey.String(), common.BuilderStatus{})
 	require.NoError(t, err)
 	path := "/internal/v1/builder/" + pubkey.String()
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -566,7 +566,7 @@ func (api *RelayAPI) demoteBuilder(pubkey string, req *common.BuilderSubmitBlock
 		IsOptimistic:  false,
 	}
 	api.log.Infof("demoted builder, new status: %v", newStatus)
-	if err := api.db.SetBlockBuilderStatus(pubkey, newStatus, true); err != nil {
+	if err := api.db.SetBlockBuilderIDStatusIsOptimistic(pubkey, false); err != nil {
 		api.log.Error(fmt.Errorf("error setting builder: %v status: %w", pubkey, err))
 	}
 	// Write to demotions table.
@@ -1988,7 +1988,7 @@ func (api *RelayAPI) handleInternalBuilderStatus(w http.ResponseWriter, req *htt
 			"isBlacklisted": st.IsBlacklisted,
 			"isOptimistic":  st.IsOptimistic,
 		}).Info("updating builder status")
-		err := api.db.SetBlockBuilderStatus(builderPubkey, st, false)
+		err := api.db.SetBlockBuilderStatus(builderPubkey, st)
 		if err != nil {
 			err := fmt.Errorf("error setting builder: %v status: %w", builderPubkey, err)
 			api.log.Error(err)


### PR DESCRIPTION
## 📝 Summary

A few minor things: 

1. Ordering APIs to be alphabetical.
2. Fix for `SetBlockBuilderStatus` to only update is_optimistic when modifying multiple pubkey status'

## ⛱ Motivation and Context

We run these on our prod optimistic branch. they are minor cleanups that didn't make it into the main OR PR.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
