### PR TITLE
builder demotion: fix nil pointer when error is reqErr

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -603,8 +603,15 @@ func (api *RelayAPI) processOptimisticBlock(opts blockSimOptions) {
 		opts.builder.status.IsOptimistic = false
 		api.log.WithError(simErr).Warn("block simulation failed in processOptimisticBlock, demoting builder")
 
+		var demotionErr error
+		if reqErr != nil {
+			demotionErr = reqErr
+		} else {
+			demotionErr = simErr
+		}
+
 		// Demote the builder.
-		api.demoteBuilder(builderPubkey, &opts.req.BuilderSubmitBlockRequest, simErr)
+		api.demoteBuilder(builderPubkey, &opts.req.BuilderSubmitBlockRequest, demotionErr)
 	}
 }
 


### PR DESCRIPTION
## 📝 Summary

When block simulation fails due to a request error (such as request timeout in prio-load-balancer) there's a nil pointer error in the `InsertBuilderDemotion` function. This change fixes that by also persisting request errors in the demotions table.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
