### PR TITLE
v0.22 fixes

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1811,23 +1811,23 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		go api.processOptimisticBlock(opts)
 	} else {
 		// Simulate block (synchronously)
-		reqErr, simErr := api.simulateBlock(req.Context(), opts) // success/error logging happens inside
+		requestErr, validationErr = api.simulateBlock(req.Context(), opts) // success/error logging happens inside
 		validationDurationMs := time.Since(timeBeforeValidation).Milliseconds()
 		log = log.WithFields(logrus.Fields{
 			"timestampAfterValidation": time.Now().UTC().UnixMilli(),
 			"validationDurationMs":     validationDurationMs,
 		})
-		if reqErr != nil { // Request error
-			if os.IsTimeout(reqErr) {
+		if requestErr != nil { // Request error
+			if os.IsTimeout(requestErr) {
 				api.RespondError(w, http.StatusGatewayTimeout, "validation request timeout")
 			} else {
-				api.RespondError(w, http.StatusBadRequest, reqErr.Error())
+				api.RespondError(w, http.StatusBadRequest, requestErr.Error())
 			}
 			return
 		} else {
 			wasSimulated = true
-			if simErr != nil {
-				api.RespondError(w, http.StatusBadRequest, simErr.Error())
+			if validationErr != nil {
+				api.RespondError(w, http.StatusBadRequest, validationErr.Error())
 				return
 			}
 		}

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -603,8 +603,15 @@ func (api *RelayAPI) processOptimisticBlock(opts blockSimOptions) {
 		opts.builder.status.IsOptimistic = false
 		api.log.WithError(simErr).Warn("block simulation failed in processOptimisticBlock, demoting builder")
 
+		var demotionErr error
+		if reqErr != nil {
+			demotionErr = reqErr
+		} else {
+			demotionErr = simErr
+		}
+
 		// Demote the builder.
-		api.demoteBuilder(builderPubkey, &opts.req.BuilderSubmitBlockRequest, simErr)
+		api.demoteBuilder(builderPubkey, &opts.req.BuilderSubmitBlockRequest, demotionErr)
 	}
 }
 


### PR DESCRIPTION
## 📝 Summary

update to v0.22 release

* [Fix: persist validation errors in database](https://github.com/flashbots/mev-boost-relay/pull/410/commits/a6225a04f004aea0cbec893f0c31dac50e28e5bb) -- didn't save validation error details to the database before (block submissions and builder stats)
* [Fix: builder demotion: fix nil pointer when error is reqErr](https://github.com/flashbots/mev-boost-relay/pull/410/commits/ded11619ee951dcf9c7724b9cf7f151caa44d681)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
