### PR TITLE
Change from Niclas to write optimistic sim errors to submissions db

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -146,6 +146,13 @@ type blockBuilderCacheEntry struct {
 	collateral *big.Int
 }
 
+type blockSimResult struct {
+	wasSimulated         bool
+	optimisticSubmission bool
+	requestErr           error
+	validationErr        error
+}
+
 // RelayAPI represents a single Relay instance
 type RelayAPI struct {
 	opts RelayAPIOpts
@@ -582,7 +589,7 @@ func (api *RelayAPI) demoteBuilder(pubkey string, req *common.BuilderSubmitBlock
 
 // processOptimisticBlock is called on a new goroutine when a optimistic block
 // needs to be simulated.
-func (api *RelayAPI) processOptimisticBlock(opts blockSimOptions) {
+func (api *RelayAPI) processOptimisticBlock(opts blockSimOptions, simResultC chan *blockSimResult) {
 	api.optimisticBlocksInFlight.Add(1)
 	defer func() { api.optimisticBlocksInFlight.Sub(1) }()
 	api.optimisticBlocksWG.Add(1)
@@ -598,6 +605,7 @@ func (api *RelayAPI) processOptimisticBlock(opts blockSimOptions) {
 		"optBlocksInFlight": api.optimisticBlocksInFlight,
 	}).Infof("simulating optimistic block with hash: %v", opts.req.BuilderSubmitBlockRequest.BlockHash())
 	reqErr, simErr := api.simulateBlock(ctx, opts)
+	simResultC <- &blockSimResult{reqErr == nil, true, reqErr, simErr}
 	if reqErr != nil || simErr != nil {
 		// Mark builder as non-optimistic.
 		opts.builder.status.IsOptimistic = false
@@ -1739,20 +1747,28 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	var wasSimulated, optimisticSubmission bool
-	var requestErr, validationErr error
 	var eligibleAt time.Time
+	// Used to communicate simulation result to the deferred function
+	simResultC := make(chan *blockSimResult, 1)
 
 	// Save the builder submission to the database whenever this function ends
 	defer func() {
 		savePayloadToDatabase := !api.ffDisablePayloadDBStorage
-		submissionEntry, err := api.db.SaveBuilderBlockSubmission(payload, requestErr, validationErr, receivedAt, eligibleAt, wasSimulated, savePayloadToDatabase, pf, optimisticSubmission)
+		var simResult *blockSimResult
+		select {
+		case simResult = <-simResultC:
+		case <-time.After(10 * time.Second):
+			log.Warn("timed out waiting for simulation result")
+			simResult = &blockSimResult{false, false, nil, nil}
+		}
+
+		submissionEntry, err := api.db.SaveBuilderBlockSubmission(payload, simResult.requestErr, simResult.validationErr, receivedAt, eligibleAt, simResult.wasSimulated, savePayloadToDatabase, pf, simResult.optimisticSubmission)
 		if err != nil {
 			log.WithError(err).WithField("payload", payload).Error("saving builder block submission to database failed")
 			return
 		}
 
-		err = api.db.UpsertBlockBuilderEntryAfterSubmission(submissionEntry, validationErr != nil)
+		err = api.db.UpsertBlockBuilderEntryAfterSubmission(submissionEntry, simResult.validationErr != nil)
 		if err != nil {
 			log.WithError(err).Error("failed to upsert block-builder-entry")
 		}
@@ -1818,11 +1834,11 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	if builderEntry.status.IsOptimistic &&
 		builderEntry.collateral.Cmp(payload.Value()) >= 0 &&
 		payload.Slot() == api.optimisticSlot.Load() {
-		optimisticSubmission = true
-		go api.processOptimisticBlock(opts)
+		go api.processOptimisticBlock(opts, simResultC)
 	} else {
-		// Simulate block (synchronously)
-		requestErr, validationErr = api.simulateBlock(req.Context(), opts) // success/error logging happens inside
+		// Simulate block (synchronously).
+		requestErr, validationErr := api.simulateBlock(req.Context(), opts) // success/error logging happens inside
+		simResultC <- &blockSimResult{requestErr == nil, false, requestErr, validationErr}
 		validationDurationMs := time.Since(timeBeforeValidation).Milliseconds()
 		log = log.WithFields(logrus.Fields{
 			"timestampAfterValidation": time.Now().UTC().UnixMilli(),
@@ -1836,7 +1852,6 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 			}
 			return
 		} else {
-			wasSimulated = true
 			if validationErr != nil {
 				api.RespondError(w, http.StatusBadRequest, validationErr.Error())
 				return

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1787,6 +1787,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 
 		// Without cancellations, discard bids below floor value
 		if !isCancellationEnabled && !isBidAboveFloor {
+			simResultC <- &blockSimResult{false, false, nil, nil}
 			log.Info("ignoring submission without cancellation and below floor bid value")
 			api.RespondMsg(w, http.StatusAccepted, "ignoring submission without cancellation and below floor bid value")
 			return


### PR DESCRIPTION
## 📝 Summary

copied from @blombern's change on the ultra sound repo

Without this change, the DB write for the block submission could occur before the block validation finished in the optimistic path. With this change, a new channel is introduced to pass the simulation error data from the main handler into the deferred db write, and that write blocks until the simulation is complete.

## ⛱ Motivation and Context

From https://github.com/ultrasoundmoney/mev-boost-relay/pull/12/files. Part of our rebase is getting these last changes merged upstream. This change was under review concurrently as the optimistic relay change, so was left out.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x]  I have seen and agree to `CONTRIBUTING.md`
