### PR TITLE
chore(website): update builder link

### DIFF
--- a/services/website/website.html
+++ b/services/website/website.html
@@ -212,7 +212,7 @@
                         <li><a href="http://boost.flashbots.net">boost.flashbots.net</a></li>
                         <li><a href="https://github.com/flashbots/mev-boost">flashbots/mev-boost</a></li>
                         <li><a href="https://github.com/flashbots/mev-boost-relay">flashbots/mev-boost-relay</a></li>
-                        <li><a href="https://github.com/flashbots/boost-geth-builder">flashbots/boost-geth-builder</a>
+                        <li><a href="https://github.com/flashbots/builder">flashbots/builder</a>
                         <li><a href="https://flashbots.notion.site/Relay-API-Spec-5fb0819366954962bc02e81cb33840f5">Relay API docs</a></li>
                     </ul>
 


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

[flashbots/boost-geth-builder](https://github.com/flashbots/boost-geth-builder) has been archived and is no longer maintained. Update the website link to the current [flashbots/builder](https://github.com/flashbots/boost-geth-builder)

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Up to date website reference

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

n/a

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
