### PR TITLE
fix SetMultiKnownValidator

### DIFF
--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -254,6 +254,10 @@ func (r *RedisCache) SetMultiKnownValidator(indexPkMap map[uint64]boostTypes.Pub
 		values = append(values, strconv.FormatUint(proposerIndex, 10), PubkeyHexToLowerStr(publickeyHex))
 	}
 
+	if len(values) == 0 {
+		return nil
+	}
+
 	return r.client.HMSet(context.Background(), r.keyKnownValidators, values).Err()
 }
 


### PR DESCRIPTION
Minor fix for 

- #373 

observed error: "`ERR wrong number of arguments for 'hmset' command`" because there might be 0 new validators, and then HMSET fails

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
