### PR TITLE
enable readonly redis for website + minor cleanup

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -107,7 +107,11 @@ var apiCmd = &cobra.Command{
 		beaconClient := beaconclient.NewMultiBeaconClient(log, beaconInstances)
 
 		// Connect to Redis
-		log.Infof("Connecting to Redis at %s ...", redisURI)
+		if redisReadonlyURI == "" {
+			log.Infof("Connecting to Redis at %s ...", redisURI)
+		} else {
+			log.Infof("Connecting to Redis at %s / readonly: %s ...", redisURI, redisReadonlyURI)
+		}
 		redis, err := datastore.NewRedisCache(networkInfo.Name, redisURI, redisReadonlyURI)
 		if err != nil {
 			log.WithError(err).Fatalf("Failed to connect to Redis at %s", redisURI)

--- a/cmd/website.go
+++ b/cmd/website.go
@@ -35,6 +35,7 @@ func init() {
 
 	websiteCmd.Flags().StringVar(&websiteListenAddr, "listen-addr", websiteDefaultListenAddr, "listen address for webserver")
 	websiteCmd.Flags().StringVar(&redisURI, "redis-uri", defaultRedisURI, "redis uri")
+	websiteCmd.Flags().StringVar(&redisReadonlyURI, "redis-readonly-uri", defaultRedisReadonlyURI, "redis readonly uri")
 	websiteCmd.Flags().StringVar(&postgresDSN, "db", defaultPostgresDSN, "PostgreSQL DSN")
 	websiteCmd.Flags().StringVar(&websitePubkeyOverride, "pubkey-override", os.Getenv("PUBKEY_OVERRIDE"), "override for public key")
 
@@ -66,6 +67,11 @@ var websiteCmd = &cobra.Command{
 		log.Debug(networkInfo.String())
 
 		// Connect to Redis
+		if redisReadonlyURI == "" {
+			log.Infof("Connecting to Redis at %s ...", redisURI)
+		} else {
+			log.Infof("Connecting to Redis at %s / readonly: %s ...", redisURI, redisReadonlyURI)
+		}
 		redis, err := datastore.NewRedisCache(networkInfo.Name, redisURI, redisReadonlyURI)
 		if err != nil {
 			log.WithError(err).Fatalf("Failed to connect to Redis at %s", redisURI)

--- a/services/website/website.html
+++ b/services/website/website.html
@@ -209,11 +209,10 @@
                 <div class="pure-u-1 pure-u-md-1-3 links">
                     <h2>Links</h2>
                     <ul>
-                        <li><a href="http://boost.flashbots.net">boost.flashbots.net</a></li>
                         <li><a href="https://github.com/flashbots/mev-boost">flashbots/mev-boost</a></li>
                         <li><a href="https://github.com/flashbots/mev-boost-relay">flashbots/mev-boost-relay</a></li>
                         <li><a href="https://github.com/flashbots/builder">flashbots/builder</a>
-                        <li><a href="https://flashbots.notion.site/Relay-API-Spec-5fb0819366954962bc02e81cb33840f5">Relay API docs</a></li>
+                        <li><a href="https://github.com/flashbots/relay-specs">Relay API documentation</a></li>
                     </ul>
 
                 </div>


### PR DESCRIPTION
## 📝 Summary

readonly redis was enabled for 

 - [`GetKnownValidators`](https://github.com/flashbots/mev-boost-relay/blob/a2ec56f4d8a3ab7bb2115a211b15ff3f98ee101e/datastore/redis.go#L231) - used by api-proposer
- [`GetActiveValidators`](https://github.com/flashbots/mev-boost-relay/blob/a2ec56f4d8a3ab7bb2115a211b15ff3f98ee101e/datastore/redis.go#L302) - used by website

but the website didn't yet make use of it!

Related:
- #433

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
