### PR TITLE
Redis pipelining for block submissions

### DIFF
--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -214,6 +214,7 @@ func (r *RedisCache) SetObj(key string, value any, expiration time.Duration) (er
 	return r.client.Set(context.Background(), key, marshalledValue, expiration).Err()
 }
 
+// SetObjPipelined saves an object in the given Redis key on a Redis pipeline (JSON encoded)
 func (r *RedisCache) SetObjPipelined(ctx context.Context, tx redis.Pipeliner, key string, value any, expiration time.Duration) (err error) {
 	marshalledValue, err := json.Marshal(value)
 	if err != nil {

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -505,7 +505,7 @@ func TestGetBuilderLatestValue(t *testing.T) {
 	}
 
 	_, err = cache.client.TxPipelined(context.Background(), func(tx redis.Pipeliner) error {
-		return cache.SaveBuilderBid(tx, slot, parentHash, proposerPubkey, builderPubkey, time.Now().UTC(), getHeaderResp)
+		return cache.SaveBuilderBid(context.Background(), tx, slot, parentHash, proposerPubkey, builderPubkey, time.Now().UTC(), getHeaderResp)
 	})
 	require.NoError(t, err)
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1894,7 +1894,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	//
 	// Save to Redis
 	//
-	updateBidResult, err := api.redis.SaveBidAndUpdateTopBid(req.Context(), &bidTrace, payload, getPayloadResponse, getHeaderResponse, receivedAt, isCancellationEnabled, floorBidValue)
+	updateBidResult, err := api.redis.SaveBidAndUpdateTopBid(context.Background(), &bidTrace, payload, getPayloadResponse, getHeaderResponse, receivedAt, isCancellationEnabled, floorBidValue)
 	if err != nil {
 		log.WithError(err).Error("could not save bid and update top bids")
 		api.RespondError(w, http.StatusInternalServerError, "failed saving and updating bid")

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1751,7 +1751,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	}()
 
 	// Grab floor bid value
-	floorBidValue, err := api.redis.GetFloorBidValue(req.Context(), api.redis.NewPipeline(), payload.Slot(), payload.ParentHash(), payload.ProposerPubkey())
+	floorBidValue, err := api.redis.GetFloorBidValue(context.Background(), api.redis.NewPipeline(), payload.Slot(), payload.ParentHash(), payload.ProposerPubkey())
 	if err != nil {
 		log.WithError(err).Error("failed to get floor bid value from redis")
 	} else {
@@ -1823,7 +1823,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		go api.processOptimisticBlock(opts, simResultC)
 	} else {
 		// Simulate block (synchronously).
-		requestErr, validationErr := api.simulateBlock(req.Context(), opts) // success/error logging happens inside
+		requestErr, validationErr := api.simulateBlock(context.Background(), opts) // success/error logging happens inside
 		simResultC <- &blockSimResult{requestErr == nil, false, requestErr, validationErr}
 		validationDurationMs := time.Since(timeBeforeValidation).Milliseconds()
 		log = log.WithFields(logrus.Fields{


### PR DESCRIPTION
## 📝 Summary

Use Redis pipelining to reuse a single Redis connection for most calls in the block submission hot path.

See also:

- https://redis.io/docs/manual/pipelining/
- https://redis.uptrace.dev/guide/go-redis-pipelines.html
- https://github.com/bloXroute-Labs/mev-relay/blob/0ed56c6aab47da3f5cd48e846e86669be4375240/datastore/bid.go

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
