### PR TITLE
[cleanup] remove bellatrix from main paths

### DIFF
--- a/services/api/blocksim_ratelimiter.go
+++ b/services/api/blocksim_ratelimiter.go
@@ -71,9 +71,9 @@ func (b *BlockSimulationRateLimiter) Send(context context.Context, payload *comm
 	var simReq *jsonrpc.JSONRPCRequest
 	if payload.Capella != nil {
 		simReq = jsonrpc.NewJSONRPCRequest("1", "flashbots_validateBuilderSubmissionV2", payload)
-	} else if payload.Bellatrix != nil {
-		simReq = jsonrpc.NewJSONRPCRequest("1", "flashbots_validateBuilderSubmissionV1", payload)
 	}
+	// TODO: add deneb support.
+
 	_, requestErr, validationErr = SendJSONRPCRequest(&b.client, *simReq, b.blockSimURL, isHighPrio, fastTrack)
 	return requestErr, validationErr
 }


### PR DESCRIPTION
## 📝 Summary

1. remove bellatrix logic from the main code paths. leaving the types alone for now to ensure any rollback is minimal and easy.
2. add todos where we will need to add deneb support

## ⛱ Motivation and Context

1. the bellatrix code is stale
2. this will help position us to get the deneb code in place asap

## 📚 References

https://github.com/flashbots/mev-boost-relay/issues/430

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
