### PR TITLE
disable 'active validators'

### DIFF
--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -29,9 +29,6 @@ var (
 	ErrAnotherPayloadAlreadyDeliveredForSlot = errors.New("another payload block hash for slot was already delivered")
 	ErrPastSlotAlreadyDelivered              = errors.New("payload for past slot was already delivered")
 
-	// activeValidatorsHours  = cli.GetEnvInt("ACTIVE_VALIDATOR_HOURS", 3)
-	// expiryActiveValidators = time.Duration(activeValidatorsHours) * time.Hour // careful with this setting - for each hour a hash set is created with each active proposer as field. for a lot of hours this can take a lot of space in redis.
-
 	// Docs about redis settings: https://redis.io/docs/reference/clients/
 	redisConnectionPoolSize = cli.GetEnvInt("REDIS_CONNECTION_POOL_SIZE", 0) // 0 means use default (10 per CPU)
 	redisMinIdleConnections = cli.GetEnvInt("REDIS_MIN_IDLE_CONNECTIONS", 0) // 0 means use default
@@ -160,11 +157,6 @@ func (r *RedisCache) keyCacheGetPayloadResponse(slot uint64, proposerPubkey, blo
 func (r *RedisCache) keyCacheBidTrace(slot uint64, proposerPubkey, blockHash string) string {
 	return fmt.Sprintf("%s:%d_%s_%s", r.prefixBidTrace, slot, proposerPubkey, blockHash)
 }
-
-// keyActiveValidators returns the key for the date + hour of the given time
-// func (r *RedisCache) keyActiveValidators(t time.Time) string {
-// 	return fmt.Sprintf("%s:%s", r.prefixActiveValidators, t.UTC().Format("2006-01-02T15"))
-// }
 
 // keyLatestBidByBuilder returns the key for the getHeader response the latest bid by a specific builder
 func (r *RedisCache) keyLatestBidByBuilder(slot uint64, parentHash, proposerPubkey, builderPubkey string) string {
@@ -297,35 +289,6 @@ func (r *RedisCache) SetValidatorRegistrationTimestampIfNewer(proposerPubkey boo
 func (r *RedisCache) SetValidatorRegistrationTimestamp(proposerPubkey boostTypes.PubkeyHex, timestamp uint64) error {
 	return r.client.HSet(context.Background(), r.keyValidatorRegistrationTimestamp, proposerPubkey.String(), timestamp).Err()
 }
-
-// func (r *RedisCache) SetActiveValidator(pubkeyHex boostTypes.PubkeyHex) error {
-// 	key := r.keyActiveValidators(time.Now())
-// 	err := r.client.HSet(context.Background(), key, PubkeyHexToLowerStr(pubkeyHex), "1").Err()
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	// set expiry
-// 	return r.client.Expire(context.Background(), key, expiryActiveValidators).Err()
-// }
-
-// func (r *RedisCache) GetActiveValidators() (map[boostTypes.PubkeyHex]bool, error) {
-// 	hours := activeValidatorsHours
-// 	now := time.Now()
-// 	validators := make(map[boostTypes.PubkeyHex]bool)
-// 	for i := 0; i < hours; i++ {
-// 		key := r.keyActiveValidators(now.Add(time.Duration(-i) * time.Hour))
-// 		entries, err := r.readonlyClient.HGetAll(context.Background(), key).Result()
-// 		if err != nil {
-// 			return nil, err
-// 		}
-// 		for pubkey := range entries {
-// 			validators[boostTypes.PubkeyHex(pubkey)] = true
-// 		}
-// 	}
-
-// 	return validators, nil
-// }
 
 func (r *RedisCache) CheckAndSetLastSlotAndHashDelivered(slot uint64, hash string) (err error) {
 	// More details about Redis optimistic locking:

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -29,8 +29,8 @@ var (
 	ErrAnotherPayloadAlreadyDeliveredForSlot = errors.New("another payload block hash for slot was already delivered")
 	ErrPastSlotAlreadyDelivered              = errors.New("payload for past slot was already delivered")
 
-	activeValidatorsHours  = cli.GetEnvInt("ACTIVE_VALIDATOR_HOURS", 3)
-	expiryActiveValidators = time.Duration(activeValidatorsHours) * time.Hour // careful with this setting - for each hour a hash set is created with each active proposer as field. for a lot of hours this can take a lot of space in redis.
+	// activeValidatorsHours  = cli.GetEnvInt("ACTIVE_VALIDATOR_HOURS", 3)
+	// expiryActiveValidators = time.Duration(activeValidatorsHours) * time.Hour // careful with this setting - for each hour a hash set is created with each active proposer as field. for a lot of hours this can take a lot of space in redis.
 
 	// Docs about redis settings: https://redis.io/docs/reference/clients/
 	redisConnectionPoolSize = cli.GetEnvInt("REDIS_CONNECTION_POOL_SIZE", 0) // 0 means use default (10 per CPU)
@@ -162,9 +162,9 @@ func (r *RedisCache) keyCacheBidTrace(slot uint64, proposerPubkey, blockHash str
 }
 
 // keyActiveValidators returns the key for the date + hour of the given time
-func (r *RedisCache) keyActiveValidators(t time.Time) string {
-	return fmt.Sprintf("%s:%s", r.prefixActiveValidators, t.UTC().Format("2006-01-02T15"))
-}
+// func (r *RedisCache) keyActiveValidators(t time.Time) string {
+// 	return fmt.Sprintf("%s:%s", r.prefixActiveValidators, t.UTC().Format("2006-01-02T15"))
+// }
 
 // keyLatestBidByBuilder returns the key for the getHeader response the latest bid by a specific builder
 func (r *RedisCache) keyLatestBidByBuilder(slot uint64, parentHash, proposerPubkey, builderPubkey string) string {
@@ -298,34 +298,34 @@ func (r *RedisCache) SetValidatorRegistrationTimestamp(proposerPubkey boostTypes
 	return r.client.HSet(context.Background(), r.keyValidatorRegistrationTimestamp, proposerPubkey.String(), timestamp).Err()
 }
 
-func (r *RedisCache) SetActiveValidator(pubkeyHex boostTypes.PubkeyHex) error {
-	key := r.keyActiveValidators(time.Now())
-	err := r.client.HSet(context.Background(), key, PubkeyHexToLowerStr(pubkeyHex), "1").Err()
-	if err != nil {
-		return err
-	}
+// func (r *RedisCache) SetActiveValidator(pubkeyHex boostTypes.PubkeyHex) error {
+// 	key := r.keyActiveValidators(time.Now())
+// 	err := r.client.HSet(context.Background(), key, PubkeyHexToLowerStr(pubkeyHex), "1").Err()
+// 	if err != nil {
+// 		return err
+// 	}
 
-	// set expiry
-	return r.client.Expire(context.Background(), key, expiryActiveValidators).Err()
-}
+// 	// set expiry
+// 	return r.client.Expire(context.Background(), key, expiryActiveValidators).Err()
+// }
 
-func (r *RedisCache) GetActiveValidators() (map[boostTypes.PubkeyHex]bool, error) {
-	hours := activeValidatorsHours
-	now := time.Now()
-	validators := make(map[boostTypes.PubkeyHex]bool)
-	for i := 0; i < hours; i++ {
-		key := r.keyActiveValidators(now.Add(time.Duration(-i) * time.Hour))
-		entries, err := r.readonlyClient.HGetAll(context.Background(), key).Result()
-		if err != nil {
-			return nil, err
-		}
-		for pubkey := range entries {
-			validators[boostTypes.PubkeyHex(pubkey)] = true
-		}
-	}
+// func (r *RedisCache) GetActiveValidators() (map[boostTypes.PubkeyHex]bool, error) {
+// 	hours := activeValidatorsHours
+// 	now := time.Now()
+// 	validators := make(map[boostTypes.PubkeyHex]bool)
+// 	for i := 0; i < hours; i++ {
+// 		key := r.keyActiveValidators(now.Add(time.Duration(-i) * time.Hour))
+// 		entries, err := r.readonlyClient.HGetAll(context.Background(), key).Result()
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 		for pubkey := range entries {
+// 			validators[boostTypes.PubkeyHex(pubkey)] = true
+// 		}
+// 	}
 
-	return validators, nil
-}
+// 	return validators, nil
+// }
 
 func (r *RedisCache) CheckAndSetLastSlotAndHashDelivered(slot uint64, hash string) (err error) {
 	// More details about Redis optimistic locking:

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -187,18 +187,6 @@ func TestRedisProposerDuties(t *testing.T) {
 	require.Equal(t, duties[0].Entry.Message.FeeRecipient, duties2[0].Entry.Message.FeeRecipient)
 }
 
-// func TestActiveValidators(t *testing.T) {
-// 	pk1 := types.NewPubkeyHex("0x8016d3229030424cfeff6c5b813970ea193f8d012cfa767270ca9057d58eddc556e96c14544bf4c038dbed5f24aa8da0")
-// 	cache := setupTestRedis(t)
-// 	err := cache.SetActiveValidator(pk1)
-// 	require.NoError(t, err)
-
-// 	vals, err := cache.GetActiveValidators()
-// 	require.NoError(t, err)
-// 	require.Equal(t, 1, len(vals))
-// 	require.True(t, vals[pk1])
-// }
-
 func TestBuilderBids(t *testing.T) {
 	slot := uint64(2)
 	parentHash := "0x13e606c7b3d1faad7e83503ce3dedce4c6bb89b0c28ffb240d713c7b110b9747"

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -187,17 +187,17 @@ func TestRedisProposerDuties(t *testing.T) {
 	require.Equal(t, duties[0].Entry.Message.FeeRecipient, duties2[0].Entry.Message.FeeRecipient)
 }
 
-func TestActiveValidators(t *testing.T) {
-	pk1 := types.NewPubkeyHex("0x8016d3229030424cfeff6c5b813970ea193f8d012cfa767270ca9057d58eddc556e96c14544bf4c038dbed5f24aa8da0")
-	cache := setupTestRedis(t)
-	err := cache.SetActiveValidator(pk1)
-	require.NoError(t, err)
+// func TestActiveValidators(t *testing.T) {
+// 	pk1 := types.NewPubkeyHex("0x8016d3229030424cfeff6c5b813970ea193f8d012cfa767270ca9057d58eddc556e96c14544bf4c038dbed5f24aa8da0")
+// 	cache := setupTestRedis(t)
+// 	err := cache.SetActiveValidator(pk1)
+// 	require.NoError(t, err)
 
-	vals, err := cache.GetActiveValidators()
-	require.NoError(t, err)
-	require.Equal(t, 1, len(vals))
-	require.True(t, vals[pk1])
-}
+// 	vals, err := cache.GetActiveValidators()
+// 	require.NoError(t, err)
+// 	require.Equal(t, 1, len(vals))
+// 	require.True(t, vals[pk1])
+// }
 
 func TestBuilderBids(t *testing.T) {
 	slot := uint64(2)

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -78,7 +78,6 @@ var (
 	pathInternalBuilderCollateral = "/internal/v1/builder/collateral/{pubkey:0x[a-fA-F0-9]+}"
 
 	// number of goroutines to save active validator
-	// numActiveValidatorProcessors = cli.GetEnvInt("NUM_ACTIVE_VALIDATOR_PROCESSORS", 10)
 	numValidatorRegProcessors = cli.GetEnvInt("NUM_VALIDATOR_REG_PROCESSORS", 10)
 
 	// various timings
@@ -182,7 +181,6 @@ type RelayAPI struct {
 
 	blockSimRateLimiter IBlockSimRateLimiter
 
-	// activeValidatorC chan boostTypes.PubkeyHex
 	validatorRegC chan boostTypes.SignedValidatorRegistration
 
 	// used to wait on any active getPayload calls on shutdown
@@ -272,7 +270,6 @@ func NewRelayAPI(opts RelayAPIOpts) (api *RelayAPI, err error) {
 		proposerDutiesResponse: &[]byte{},
 		blockSimRateLimiter:    NewBlockSimulationRateLimiter(opts.BlockSimURL),
 
-		// activeValidatorC: make(chan boostTypes.PubkeyHex, 450_000),
 		validatorRegC: make(chan boostTypes.SignedValidatorRegistration, 450_000),
 	}
 
@@ -429,12 +426,6 @@ func (api *RelayAPI) StartServer() (err error) {
 		// Update list of known validators, and start refresh loop
 		go api.startKnownValidatorUpdates()
 
-		// Start the worker pool to process active validators
-		// api.log.Infof("starting %d active validator processors", numActiveValidatorProcessors)
-		// for i := 0; i < numActiveValidatorProcessors; i++ {
-		// 	go api.startActiveValidatorProcessor()
-		// }
-
 		// Start the validator registration db-save processor
 		api.log.Infof("starting %d validator registration processors", numValidatorRegProcessors)
 		for i := 0; i < numValidatorRegProcessors; i++ {
@@ -506,17 +497,6 @@ func (api *RelayAPI) StopServer() (err error) {
 	return api.srv.Shutdown(context.Background())
 }
 
-// startActiveValidatorProcessor keeps listening on the channel and saving active validators to redis
-// func (api *RelayAPI) startActiveValidatorProcessor() {
-// 	for pubkey := range api.activeValidatorC {
-// 		err := api.redis.SetActiveValidator(pubkey)
-// 		if err != nil {
-// 			api.log.WithError(err).Infof("error setting active validator")
-// 		}
-// 	}
-// }
-
-// startActiveValidatorProcessor keeps listening on the channel and saving active validators to redis
 func (api *RelayAPI) startValidatorRegistrationDBProcessor() {
 	for valReg := range api.validatorRegC {
 		err := api.datastore.SaveValidatorRegistration(valReg)
@@ -1007,14 +987,6 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 			handleError(regLog, http.StatusBadRequest, fmt.Sprintf("not a known validator: %s", pkHex.String()))
 			return
 		}
-
-		// Keep track of active validators
-		// numRegActive += 1
-		// select {
-		// case api.activeValidatorC <- pkHex:
-		// default:
-		// 	regLog.Error("active validator channel full")
-		// }
 
 		// Check for a previous registration timestamp
 		prevTimestamp, err := api.redis.GetValidatorRegistrationTimestamp(pkHex)

--- a/services/website/html.go
+++ b/services/website/html.go
@@ -24,7 +24,6 @@ type StatusHTMLData struct { //nolint:musttag
 	RelayPubkey                 string
 	ValidatorsTotal             uint64
 	ValidatorsRegistered        uint64
-	ValidatorsActive            uint64
 	BellatrixForkVersion        string
 	CapellaForkVersion          string
 	GenesisForkVersion          string

--- a/services/website/website.go
+++ b/services/website/website.go
@@ -94,7 +94,6 @@ func NewWebserver(opts *WebserverOpts) (*Webserver, error) {
 	server.statusHTMLData = StatusHTMLData{
 		Network:                     opts.NetworkDetails.Name,
 		RelayPubkey:                 opts.RelayPubkeyHex,
-		ValidatorsActive:            0,
 		ValidatorsTotal:             0,
 		ValidatorsRegistered:        0,
 		BellatrixForkVersion:        opts.NetworkDetails.BellatrixForkVersionHex,
@@ -166,10 +165,10 @@ func (srv *Webserver) updateHTML() {
 		srv.log.WithError(err).Error("error getting number of registered validators in updateStatusHTMLData")
 	}
 
-	_activeVals, err := srv.redis.GetActiveValidators()
-	if err != nil {
-		srv.log.WithError(err).Error("error getting active validators in updateStatusHTMLData")
-	}
+	// _activeVals, err := srv.redis.GetActiveValidators()
+	// if err != nil {
+	// 	srv.log.WithError(err).Error("error getting active validators in updateStatusHTMLData")
+	// }
 
 	payloads, err := srv.db.GetRecentDeliveredPayloads(database.GetPayloadsFilters{Limit: 30})
 	if err != nil {
@@ -208,7 +207,6 @@ func (srv *Webserver) updateHTML() {
 
 	srv.statusHTMLData.ValidatorsTotal = _validatorsTotalInt
 	srv.statusHTMLData.ValidatorsRegistered = _numRegistered
-	srv.statusHTMLData.ValidatorsActive = uint64(len(_activeVals))
 	srv.statusHTMLData.NumPayloadsDelivered = _numPayloadsDelivered
 	srv.statusHTMLData.HeadSlot = _latestSlotInt
 

--- a/services/website/website.go
+++ b/services/website/website.go
@@ -165,11 +165,6 @@ func (srv *Webserver) updateHTML() {
 		srv.log.WithError(err).Error("error getting number of registered validators in updateStatusHTMLData")
 	}
 
-	// _activeVals, err := srv.redis.GetActiveValidators()
-	// if err != nil {
-	// 	srv.log.WithError(err).Error("error getting active validators in updateStatusHTMLData")
-	// }
-
 	payloads, err := srv.db.GetRecentDeliveredPayloads(database.GetPayloadsFilters{Limit: 30})
 	if err != nil {
 		srv.log.WithError(err).Error("error getting recent payloads")

--- a/services/website/website.html
+++ b/services/website/website.html
@@ -186,19 +186,15 @@
 
                     <table class="pure-table pure-table-horizontal">
                         <tbody>
-                            <tr title="Currently active or pending validators on Ethereum PoS.">
+                            <tr title="Currently active or pending validators on Ethereum PoS">
                                 <td>Validators total</td>
                                 <td>{{ .ValidatorsTotal | prettyInt }}</td>
                             </tr>
-                            <!-- <tr title="Validators who have sent a registration at least once. ">
+                            <tr title="Validators who have sent a registration at least once">
                                 <td>Validators registered</td>
                                 <td>{{ .ValidatorsRegistered| prettyInt }}</td>
-                            </tr> -->
-                            <tr title="Validators who sent a registration in the last 3 hours.">
-                                <td>Validators connected</td>
-                                <td>{{ .ValidatorsActive| prettyInt }}</td>
                             </tr>
-                            <tr>
+                            <tr title="Last slot delivered through this relay">
                                 <td>Latest slot</td>
                                 <td>{{ .HeadSlot| prettyInt }}</td>
                             </tr>

--- a/testdata/website-htmldata.json
+++ b/testdata/website-htmldata.json
@@ -3,7 +3,6 @@
     "RelayPubkey": "0x845bd072b7cd566f02faeb0a4033ce9399e42839ced64e8b2adcfc859ed1e8e1a5a293336a49feac6d9a5edb779be53a",
     "ValidatorsTotal": 1973,
     "ValidatorsRegistered": 355,
-    "ValidatorsActive": 297,
     "CapellaForkVersion": "0x90000072",
     "BellatrixForkVersion": "0x90000071",
     "GenesisForkVersion": "0x90000069",


### PR DESCRIPTION
## 📝 Summary

Active validators is very heavy on Redis, and does not rely on validated signatures. Removed it altogether

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
