### PR TITLE
get known validators from CL client

### DIFF
--- a/beaconclient/mock_beacon_instance.go
+++ b/beaconclient/mock_beacon_instance.go
@@ -67,9 +67,15 @@ func (c *MockBeaconInstance) NumValidators() uint64 {
 	return uint64(len(c.validatorSet))
 }
 
-func (c *MockBeaconInstance) GetStateValidators(stateID string) (map[types.PubkeyHex]ValidatorResponseEntry, error) {
+func (c *MockBeaconInstance) GetStateValidators(stateID string) (*GetStateValidatorsResponse, error) {
 	c.addDelay()
-	return c.validatorSet, c.MockFetchValidatorsErr
+	validatorResp := &GetStateValidatorsResponse{ //nolint:exhaustruct
+		Data: make([]ValidatorResponseEntry, 0),
+	}
+	for _, entry := range c.validatorSet {
+		validatorResp.Data = append(validatorResp.Data, entry)
+	}
+	return validatorResp, c.MockFetchValidatorsErr
 }
 
 func (c *MockBeaconInstance) SyncStatus() (*SyncStatusPayloadData, error) {

--- a/beaconclient/mock_multi_beacon_client.go
+++ b/beaconclient/mock_multi_beacon_client.go
@@ -2,7 +2,6 @@ package beaconclient
 
 import (
 	"github.com/attestantio/go-eth2-client/spec/capella"
-	"github.com/flashbots/go-boost-utils/types"
 	"github.com/flashbots/mev-boost-relay/common"
 )
 
@@ -21,11 +20,11 @@ func (*MockMultiBeaconClient) SubscribeToHeadEvents(slotC chan HeadEventData) {}
 func (*MockMultiBeaconClient) SubscribeToPayloadAttributesEvents(payloadAttrC chan PayloadAttributesEvent) {
 }
 
-func (*MockMultiBeaconClient) FetchValidators(headSlot uint64) (map[types.PubkeyHex]ValidatorResponseEntry, error) {
-	return nil, nil
-}
+// func (*MockMultiBeaconClient) FetchValidators(headSlot uint64) (map[types.PubkeyHex]ValidatorResponseEntry, error) {
+// 	return nil, nil
+// }
 
-func (*MockMultiBeaconClient) GetStateValidators(stateID string) (map[types.PubkeyHex]ValidatorResponseEntry, error) {
+func (*MockMultiBeaconClient) GetStateValidators(stateID string) (*GetStateValidatorsResponse, error) {
 	return nil, nil
 }
 

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -135,20 +135,11 @@ type ValidatorResponseValidatorData struct {
 
 // GetStateValidators loads all active and pending validators
 // https://ethereum.github.io/beacon-APIs/#/Beacon/getStateValidators
-func (c *ProdBeaconInstance) GetStateValidators(stateID string) (map[types.PubkeyHex]ValidatorResponseEntry, error) {
+func (c *ProdBeaconInstance) GetStateValidators(stateID string) (*GetStateValidatorsResponse, error) {
 	uri := fmt.Sprintf("%s/eth/v1/beacon/states/%s/validators?status=active,pending", c.beaconURI, stateID)
 	vd := new(GetStateValidatorsResponse)
 	_, err := fetchBeacon(http.MethodGet, uri, nil, vd, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	newValidatorSet := make(map[types.PubkeyHex]ValidatorResponseEntry)
-	for _, vs := range vd.Data {
-		newValidatorSet[types.NewPubkeyHex(vs.Validator.Pubkey)] = vs
-	}
-
-	return newValidatorSet, nil
+	return vd, err
 }
 
 // SyncStatusPayload is the response payload for /eth/v1/node/syncing

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -1,59 +1,48 @@
 package datastore
 
-import (
-	"testing"
+// func setupTestDatastore(t *testing.T) *Datastore {
+// 	t.Helper()
+// 	var err error
 
-	"github.com/alicebob/miniredis/v2"
-	"github.com/flashbots/go-boost-utils/types"
-	"github.com/flashbots/mev-boost-relay/common"
-	"github.com/flashbots/mev-boost-relay/database"
-	"github.com/jinzhu/copier"
-	"github.com/stretchr/testify/require"
-)
+// 	redisTestServer, err := miniredis.Run()
+// 	require.NoError(t, err)
 
-func setupTestDatastore(t *testing.T) *Datastore {
-	t.Helper()
-	var err error
+// 	redisDs, err := NewRedisCache("", redisTestServer.Addr(), "")
+// 	require.NoError(t, err)
 
-	redisTestServer, err := miniredis.Run()
-	require.NoError(t, err)
+// 	// TODO: add support for testing datastore with memcached enabled
+// 	ds, err := NewDatastore(common.TestLog, redisDs, nil, database.MockDB{})
 
-	redisDs, err := NewRedisCache("", redisTestServer.Addr(), "")
-	require.NoError(t, err)
+// 	require.NoError(t, err)
 
-	// TODO: add support for testing datastore with memcached enabled
-	ds, err := NewDatastore(common.TestLog, redisDs, nil, database.MockDB{})
+// 	// we should not panic when fetching execution payload response, even when memcached is nil
+// 	_, err = ds.GetGetPayloadResponse(0, "foo", "bar")
+// 	require.NoError(t, err)
 
-	require.NoError(t, err)
+// 	return ds
+// }
 
-	// we should not panic when fetching execution payload response, even when memcached is nil
-	_, err = ds.GetGetPayloadResponse(0, "foo", "bar")
-	require.NoError(t, err)
+// func TestProdProposerValidatorRegistration(t *testing.T) {
+// 	ds := setupTestDatastore(t)
 
-	return ds
-}
+// 	var reg1 types.SignedValidatorRegistration
+// 	err := copier.Copy(&reg1, &common.ValidPayloadRegisterValidator)
+// 	require.NoError(t, err)
 
-func TestProdProposerValidatorRegistration(t *testing.T) {
-	ds := setupTestDatastore(t)
+// 	key := types.NewPubkeyHex(reg1.Message.Pubkey.String())
 
-	var reg1 types.SignedValidatorRegistration
-	err := copier.Copy(&reg1, &common.ValidPayloadRegisterValidator)
-	require.NoError(t, err)
+// 	// Set known validator and save registration
+// 	err = ds.redis.SetKnownValidator(key, 1)
+// 	require.NoError(t, err)
 
-	key := types.NewPubkeyHex(reg1.Message.Pubkey.String())
+// 	// Check if validator is known
+// 	cnt, err := ds.RefreshKnownValidators()
+// 	require.NoError(t, err)
+// 	require.Equal(t, 1, cnt)
+// 	require.True(t, ds.IsKnownValidator(key))
 
-	// Set known validator and save registration
-	err = ds.redis.SetKnownValidator(key, 1)
-	require.NoError(t, err)
-
-	// Check if validator is known
-	cnt, err := ds.RefreshKnownValidators()
-	require.NoError(t, err)
-	require.Equal(t, 1, cnt)
-	require.True(t, ds.IsKnownValidator(key))
-
-	// Copy the original registration
-	var reg2 types.SignedValidatorRegistration
-	err = copier.Copy(&reg2, &reg1)
-	require.NoError(t, err)
-}
+// 	// Copy the original registration
+// 	var reg2 types.SignedValidatorRegistration
+// 	err = copier.Copy(&reg2, &reg1)
+// 	require.NoError(t, err)
+// }

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -230,42 +230,42 @@ func (r *RedisCache) HSetObj(key, field string, value any, expiration time.Durat
 	return r.client.Expire(context.Background(), key, expiration).Err()
 }
 
-func (r *RedisCache) GetKnownValidators() (map[uint64]boostTypes.PubkeyHex, error) {
-	validators := make(map[uint64]boostTypes.PubkeyHex)
-	entries, err := r.readonlyClient.HGetAll(context.Background(), r.keyKnownValidators).Result()
-	if err != nil {
-		return nil, err
-	}
-	for proposerIndexStr, pubkey := range entries {
-		if strings.HasPrefix(proposerIndexStr, "0x") {
-			// remove -- it's an artifact of the previous storage by pubkey
-			r.client.HDel(context.Background(), r.keyKnownValidators, proposerIndexStr)
-			continue
-		}
-		proposerIndex, err := strconv.ParseUint(proposerIndexStr, 10, 64)
-		if err == nil {
-			validators[proposerIndex] = boostTypes.PubkeyHex(pubkey)
-		}
-	}
-	return validators, nil
-}
+// func (r *RedisCache) GetKnownValidators() (map[uint64]boostTypes.PubkeyHex, error) {
+// 	validators := make(map[uint64]boostTypes.PubkeyHex)
+// 	entries, err := r.readonlyClient.HGetAll(context.Background(), r.keyKnownValidators).Result()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	for proposerIndexStr, pubkey := range entries {
+// 		if strings.HasPrefix(proposerIndexStr, "0x") {
+// 			// remove -- it's an artifact of the previous storage by pubkey
+// 			r.client.HDel(context.Background(), r.keyKnownValidators, proposerIndexStr)
+// 			continue
+// 		}
+// 		proposerIndex, err := strconv.ParseUint(proposerIndexStr, 10, 64)
+// 		if err == nil {
+// 			validators[proposerIndex] = boostTypes.PubkeyHex(pubkey)
+// 		}
+// 	}
+// 	return validators, nil
+// }
 
-func (r *RedisCache) SetMultiKnownValidator(indexPkMap map[uint64]boostTypes.PubkeyHex) error {
-	values := []string{}
-	for proposerIndex, publickeyHex := range indexPkMap {
-		values = append(values, strconv.FormatUint(proposerIndex, 10), PubkeyHexToLowerStr(publickeyHex))
-	}
+// func (r *RedisCache) SetMultiKnownValidator(indexPkMap map[uint64]boostTypes.PubkeyHex) error {
+// 	values := []string{}
+// 	for proposerIndex, publickeyHex := range indexPkMap {
+// 		values = append(values, strconv.FormatUint(proposerIndex, 10), PubkeyHexToLowerStr(publickeyHex))
+// 	}
 
-	if len(values) == 0 {
-		return nil
-	}
+// 	if len(values) == 0 {
+// 		return nil
+// 	}
 
-	return r.client.HMSet(context.Background(), r.keyKnownValidators, values).Err()
-}
+// 	return r.client.HMSet(context.Background(), r.keyKnownValidators, values).Err()
+// }
 
-func (r *RedisCache) SetKnownValidator(pubkeyHex boostTypes.PubkeyHex, proposerIndex uint64) error {
-	return r.SetMultiKnownValidator(map[uint64]boostTypes.PubkeyHex{proposerIndex: pubkeyHex})
-}
+// func (r *RedisCache) SetKnownValidator(pubkeyHex boostTypes.PubkeyHex, proposerIndex uint64) error {
+// 	return r.SetMultiKnownValidator(map[uint64]boostTypes.PubkeyHex{proposerIndex: pubkeyHex})
+// }
 
 func (r *RedisCache) GetValidatorRegistrationTimestamp(proposerPubkey boostTypes.PubkeyHex) (uint64, error) {
 	timestamp, err := r.client.HGet(context.Background(), r.keyValidatorRegistrationTimestamp, strings.ToLower(proposerPubkey.String())).Uint64()

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -713,7 +713,7 @@ func (r *RedisCache) GetFloorBidValue(ctx context.Context, tx redis.Pipeliner, s
 	return floorValue, nil
 }
 
-func (r *RedisCache) NewPipeline() redis.Pipeliner { //nolint:ireturn
+func (r *RedisCache) NewPipeline() redis.Pipeliner { //nolint:ireturn,nolintlint
 	return r.client.Pipeline()
 }
 

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -84,7 +84,6 @@ type RedisCache struct {
 	prefixGetHeaderResponse           string
 	prefixGetPayloadResponse          string
 	prefixBidTrace                    string
-	prefixActiveValidators            string
 	prefixBlockBuilderLatestBids      string // latest bid for a given slot
 	prefixBlockBuilderLatestBidsValue string // value of latest bid for a given slot
 	prefixBlockBuilderLatestBidsTime  string // when the request was received, to avoid older requests overwriting newer ones after a slot validation
@@ -93,7 +92,6 @@ type RedisCache struct {
 	prefixFloorBidValue               string
 
 	// keys
-	keyKnownValidators                string
 	keyValidatorRegistrationTimestamp string
 
 	keyRelayConfig        string
@@ -125,7 +123,6 @@ func NewRedisCache(prefix, redisURI, readonlyURI string) (*RedisCache, error) {
 		prefixGetHeaderResponse:  fmt.Sprintf("%s/%s:cache-gethead-response", redisPrefix, prefix),
 		prefixGetPayloadResponse: fmt.Sprintf("%s/%s:cache-getpayload-response", redisPrefix, prefix),
 		prefixBidTrace:           fmt.Sprintf("%s/%s:cache-bid-trace", redisPrefix, prefix),
-		prefixActiveValidators:   fmt.Sprintf("%s/%s:active-validators", redisPrefix, prefix), // one entry per hour
 
 		prefixBlockBuilderLatestBids:      fmt.Sprintf("%s/%s:block-builder-latest-bid", redisPrefix, prefix),       // hashmap for slot+parentHash+proposerPubkey with builderPubkey as field
 		prefixBlockBuilderLatestBidsValue: fmt.Sprintf("%s/%s:block-builder-latest-bid-value", redisPrefix, prefix), // hashmap for slot+parentHash+proposerPubkey with builderPubkey as field
@@ -134,7 +131,6 @@ func NewRedisCache(prefix, redisURI, readonlyURI string) (*RedisCache, error) {
 		prefixFloorBid:                    fmt.Sprintf("%s/%s:bid-floor", redisPrefix, prefix),                      // prefix:slot_parentHash_proposerPubkey
 		prefixFloorBidValue:               fmt.Sprintf("%s/%s:bid-floor-value", redisPrefix, prefix),                // prefix:slot_parentHash_proposerPubkey
 
-		keyKnownValidators:                fmt.Sprintf("%s/%s:known-validators", redisPrefix, prefix),
 		keyValidatorRegistrationTimestamp: fmt.Sprintf("%s/%s:validator-registration-timestamp", redisPrefix, prefix),
 		keyRelayConfig:                    fmt.Sprintf("%s/%s:relay-config", redisPrefix, prefix),
 
@@ -229,43 +225,6 @@ func (r *RedisCache) HSetObj(key, field string, value any, expiration time.Durat
 
 	return r.client.Expire(context.Background(), key, expiration).Err()
 }
-
-// func (r *RedisCache) GetKnownValidators() (map[uint64]boostTypes.PubkeyHex, error) {
-// 	validators := make(map[uint64]boostTypes.PubkeyHex)
-// 	entries, err := r.readonlyClient.HGetAll(context.Background(), r.keyKnownValidators).Result()
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	for proposerIndexStr, pubkey := range entries {
-// 		if strings.HasPrefix(proposerIndexStr, "0x") {
-// 			// remove -- it's an artifact of the previous storage by pubkey
-// 			r.client.HDel(context.Background(), r.keyKnownValidators, proposerIndexStr)
-// 			continue
-// 		}
-// 		proposerIndex, err := strconv.ParseUint(proposerIndexStr, 10, 64)
-// 		if err == nil {
-// 			validators[proposerIndex] = boostTypes.PubkeyHex(pubkey)
-// 		}
-// 	}
-// 	return validators, nil
-// }
-
-// func (r *RedisCache) SetMultiKnownValidator(indexPkMap map[uint64]boostTypes.PubkeyHex) error {
-// 	values := []string{}
-// 	for proposerIndex, publickeyHex := range indexPkMap {
-// 		values = append(values, strconv.FormatUint(proposerIndex, 10), PubkeyHexToLowerStr(publickeyHex))
-// 	}
-
-// 	if len(values) == 0 {
-// 		return nil
-// 	}
-
-// 	return r.client.HMSet(context.Background(), r.keyKnownValidators, values).Err()
-// }
-
-// func (r *RedisCache) SetKnownValidator(pubkeyHex boostTypes.PubkeyHex, proposerIndex uint64) error {
-// 	return r.SetMultiKnownValidator(map[uint64]boostTypes.PubkeyHex{proposerIndex: pubkeyHex})
-// }
 
 func (r *RedisCache) GetValidatorRegistrationTimestamp(proposerPubkey boostTypes.PubkeyHex) (uint64, error) {
 	timestamp, err := r.client.HGet(context.Background(), r.keyValidatorRegistrationTimestamp, strings.ToLower(proposerPubkey.String())).Uint64()

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -86,80 +86,79 @@ func TestRedisValidatorRegistration(t *testing.T) {
 	})
 }
 
-func TestRedisKnownValidators(t *testing.T) {
-	cache := setupTestRedis(t)
+// func TestRedisKnownValidators(t *testing.T) {
+// 	cache := setupTestRedis(t)
 
-	t.Run("Can save and get known validators", func(t *testing.T) {
-		key1 := types.NewPubkeyHex("0x1a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249")
-		index1 := uint64(1)
-		key2 := types.NewPubkeyHex("0x2a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249")
-		index2 := uint64(2)
-		require.NoError(t, cache.SetKnownValidator(key1, index1))
-		require.NoError(t, cache.SetKnownValidator(key2, index2))
+// 	t.Run("Can save and get known validators", func(t *testing.T) {
+// 		key1 := types.NewPubkeyHex("0x1a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249")
+// 		index1 := uint64(1)
+// 		key2 := types.NewPubkeyHex("0x2a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249")
+// 		index2 := uint64(2)
+// 		require.NoError(t, cache.SetKnownValidator(key1, index1))
+// 		require.NoError(t, cache.SetKnownValidator(key2, index2))
 
-		knownVals, err := cache.GetKnownValidators()
-		require.NoError(t, err)
-		require.Equal(t, 2, len(knownVals))
-		require.Contains(t, knownVals, index1)
-		require.Equal(t, key1, knownVals[index1])
-		require.Contains(t, knownVals, index2)
-		require.Equal(t, key2, knownVals[index2])
-	})
+// 		knownVals, err := cache.GetKnownValidators()
+// 		require.NoError(t, err)
+// 		require.Equal(t, 2, len(knownVals))
+// 		require.Contains(t, knownVals, index1)
+// 		require.Equal(t, key1, knownVals[index1])
+// 		require.Contains(t, knownVals, index2)
+// 		require.Equal(t, key2, knownVals[index2])
+// 	})
 
-	t.Run("Can save multi and get known validators", func(t *testing.T) {
-		key1 := types.NewPubkeyHex("0x1a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249")
-		index1 := uint64(1)
-		key2 := types.NewPubkeyHex("0x2a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249")
-		index2 := uint64(2)
+// 	t.Run("Can save multi and get known validators", func(t *testing.T) {
+// 		key1 := types.NewPubkeyHex("0x1a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249")
+// 		index1 := uint64(1)
+// 		key2 := types.NewPubkeyHex("0x2a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249")
+// 		index2 := uint64(2)
 
-		indexPkMap := map[uint64]types.PubkeyHex{index1: key1, index2: key2}
-		require.NoError(t, cache.SetMultiKnownValidator(indexPkMap))
+// 		indexPkMap := map[uint64]types.PubkeyHex{index1: key1, index2: key2}
+// 		require.NoError(t, cache.SetMultiKnownValidator(indexPkMap))
 
-		knownVals, err := cache.GetKnownValidators()
-		require.NoError(t, err)
-		require.Equal(t, 2, len(knownVals))
-		require.Contains(t, knownVals, index1)
-		require.Equal(t, key1, knownVals[index1])
-		require.Contains(t, knownVals, index2)
-		require.Equal(t, key2, knownVals[index2])
-	})
-}
+// 		knownVals, err := cache.GetKnownValidators()
+// 		require.NoError(t, err)
+// 		require.Equal(t, 2, len(knownVals))
+// 		require.Contains(t, knownVals, index1)
+// 		require.Equal(t, key1, knownVals[index1])
+// 		require.Contains(t, knownVals, index2)
+// 		require.Equal(t, key2, knownVals[index2])
+// 	})
+// }
 
-func TestRedisValidatorRegistrations(t *testing.T) {
-	cache := setupTestRedis(t)
+// func TestRedisValidatorRegistrations(t *testing.T) {
+// 	cache := setupTestRedis(t)
 
-	t.Run("Can save and get validator registrations", func(t *testing.T) {
-		key1 := types.NewPubkeyHex("0x1a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249")
-		index1 := uint64(1)
-		require.NoError(t, cache.SetKnownValidator(key1, index1))
+// 	t.Run("Can save and get validator registrations", func(t *testing.T) {
+// 		key1 := types.NewPubkeyHex("0x1a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249")
+// 		// index1 := uint64(1)
+// 		// require.NoError(t, cache.SetKnownValidator(key1, index1))
 
-		knownVals, err := cache.GetKnownValidators()
-		require.NoError(t, err)
-		require.Equal(t, 1, len(knownVals))
-		require.Contains(t, knownVals, index1)
+// 		// knownVals, err := cache.GetKnownValidators()
+// 		// require.NoError(t, err)
+// 		// require.Equal(t, 1, len(knownVals))
+// 		// require.Contains(t, knownVals, index1)
 
-		// Create a signed registration for key1
-		pubkey1, err := types.HexToPubkey(knownVals[index1].String())
-		require.NoError(t, err)
-		entry := types.SignedValidatorRegistration{
-			Message: &types.RegisterValidatorRequestMessage{
-				FeeRecipient: types.Address{0x02},
-				GasLimit:     5000,
-				Timestamp:    0xffffffff,
-				Pubkey:       pubkey1,
-			},
-			Signature: types.Signature{},
-		}
+// 		// Create a signed registration for key1
+// 		// require.NoError(t, err)
+// 		entry := types.SignedValidatorRegistration{
+// 			Message: &types.RegisterValidatorRequestMessage{
+// 				FeeRecipient: types.Address{0x02},
+// 				GasLimit:     5000,
+// 				Timestamp:    0xffffffff,
+// 				Pubkey:       key1,
+// 			},
+// 			Signature: types.Signature{},
+// 		}
 
-		pkHex := types.NewPubkeyHex(entry.Message.Pubkey.String())
-		err = cache.SetValidatorRegistrationTimestamp(pkHex, entry.Message.Timestamp)
-		require.NoError(t, err)
+// 		pkHex := types.NewPubkeyHex(entry.Message.Pubkey.String())
+// 		err := cache.SetValidatorRegistrationTimestamp(pkHex, entry.Message.Timestamp)
+// 		require.NoError(t, err)
 
-		reg, err := cache.GetValidatorRegistrationTimestamp(key1)
-		require.NoError(t, err)
-		require.Equal(t, uint64(0xffffffff), reg)
-	})
-}
+// 		reg, err := cache.GetValidatorRegistrationTimestamp(key1)
+// 		require.NoError(t, err)
+// 		require.Equal(t, uint64(0xffffffff), reg)
+// 	})
+// }
 
 func TestRedisProposerDuties(t *testing.T) {
 	cache := setupTestRedis(t)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/go-redis/redis/v9 v9.0.0-rc.1
 	github.com/gorilla/mux v1.8.0
 	github.com/holiman/uint256 v1.2.2
-	github.com/jinzhu/copier v0.3.5
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/lib/pq v1.10.8
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -389,8 +389,6 @@ github.com/iris-contrib/pongo2 v0.0.1/go.mod h1:Ssh+00+3GAZqSQb30AvBRNxBx7rf0Gqw
 github.com/iris-contrib/schema v0.0.1/go.mod h1:urYA3uvUNG1TIIjOSCzHr9/LmbQo8LrOcOqfqxa4hXw=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/jinzhu/copier v0.3.5 h1:GlvfUwHk62RokgqVNvYsku0TATCF7bAHVwEXoBh3iJg=
-github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
 github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=

--- a/services/api/optimistic_test.go
+++ b/services/api/optimistic_test.go
@@ -126,12 +126,12 @@ func startTestBackend(t *testing.T) (*phase0.BLSPubKey, *bls.SecretKey, *testBac
 	backend.relay.db = mockDB
 
 	// Prepare redis
-	err = backend.relay.redis.SetKnownValidator(boostTypes.NewPubkeyHex(pubkey.String()), proposerInd)
-	require.NoError(t, err)
+	// err = backend.relay.redis.SetKnownValidator(boostTypes.NewPubkeyHex(pubkey.String()), proposerInd)
+	// require.NoError(t, err)
 
-	count, err := backend.relay.datastore.RefreshKnownValidators()
-	require.NoError(t, err)
-	require.Equal(t, count, 1)
+	// count, err := backend.relay.datastore.RefreshKnownValidators()
+	// require.NoError(t, err)
+	// require.Equal(t, count, 1)
 
 	backend.relay.headSlot.Store(40)
 	return &pubkey, sk, backend

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -778,21 +778,6 @@ func (api *RelayAPI) prepareBuildersForSlot(headSlot uint64) {
 	api.blockBuildersCache = newCache
 }
 
-// func (api *RelayAPI) startKnownValidatorUpdates() {
-// 	for {
-// 		// Refresh known validators
-// 		cnt, err := api.datastore.RefreshKnownValidators()
-// 		if err != nil {
-// 			api.log.WithError(err).Error("error getting known validators")
-// 		} else {
-// 			api.log.WithField("cnt", cnt).Info("updated known validators")
-// 		}
-
-// 		// Wait for one epoch (at the beginning, because initially the validators have already been queried)
-// 		time.Sleep(common.DurationPerEpoch / 2)
-// 	}
-// }
-
 func (api *RelayAPI) RespondError(w http.ResponseWriter, code int, message string) {
 	api.Respond(w, code, HTTPErrorResp{code, message})
 }

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -423,9 +423,6 @@ func (api *RelayAPI) StartServer() (err error) {
 
 	// start things specific for the proposer API
 	if api.opts.ProposerAPI {
-		// Update list of known validators, and start refresh loop
-		go api.startKnownValidatorUpdates()
-
 		// Start the validator registration db-save processor
 		api.log.Infof("starting %d validator registration processors", numValidatorRegProcessors)
 		for i := 0; i < numValidatorRegProcessors; i++ {
@@ -684,6 +681,10 @@ func (api *RelayAPI) processNewSlot(headSlot uint64) {
 		go api.prepareBuildersForSlot(headSlot)
 	}
 
+	if api.opts.ProposerAPI {
+		go api.datastore.RefreshKnownValidators(api.beaconClient, headSlot)
+	}
+
 	// log
 	epoch := headSlot / common.SlotsPerEpoch
 	api.log.WithFields(logrus.Fields{
@@ -777,20 +778,20 @@ func (api *RelayAPI) prepareBuildersForSlot(headSlot uint64) {
 	api.blockBuildersCache = newCache
 }
 
-func (api *RelayAPI) startKnownValidatorUpdates() {
-	for {
-		// Refresh known validators
-		cnt, err := api.datastore.RefreshKnownValidators()
-		if err != nil {
-			api.log.WithError(err).Error("error getting known validators")
-		} else {
-			api.log.WithField("cnt", cnt).Info("updated known validators")
-		}
+// func (api *RelayAPI) startKnownValidatorUpdates() {
+// 	for {
+// 		// Refresh known validators
+// 		cnt, err := api.datastore.RefreshKnownValidators()
+// 		if err != nil {
+// 			api.log.WithError(err).Error("error getting known validators")
+// 		} else {
+// 			api.log.WithField("cnt", cnt).Info("updated known validators")
+// 		}
 
-		// Wait for one epoch (at the beginning, because initially the validators have already been queried)
-		time.Sleep(common.DurationPerEpoch / 2)
-	}
-}
+// 		// Wait for one epoch (at the beginning, because initially the validators have already been queried)
+// 		time.Sleep(common.DurationPerEpoch / 2)
+// 	}
+// }
 
 func (api *RelayAPI) RespondError(w http.ResponseWriter, code int, message string) {
 	api.Respond(w, code, HTTPErrorResp{code, message})

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -144,39 +144,39 @@ func (be *testBackend) requestWithUA(method, path, userAgent string, payload any
 	return rr
 }
 
-func generateSignedValidatorRegistration(sk *bls.SecretKey, feeRecipient types.Address, timestamp uint64) (*types.SignedValidatorRegistration, error) {
-	var err error
-	if sk == nil {
-		sk, _, err = bls.GenerateNewKeypair()
-		if err != nil {
-			return nil, err
-		}
-	}
+// func generateSignedValidatorRegistration(sk *bls.SecretKey, feeRecipient types.Address, timestamp uint64) (*types.SignedValidatorRegistration, error) {
+// 	var err error
+// 	if sk == nil {
+// 		sk, _, err = bls.GenerateNewKeypair()
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 	}
 
-	blsPubKey, _ := bls.PublicKeyFromSecretKey(sk)
+// 	blsPubKey, _ := bls.PublicKeyFromSecretKey(sk)
 
-	var pubKey types.PublicKey
-	err = pubKey.FromSlice(bls.PublicKeyToBytes(blsPubKey))
-	if err != nil {
-		return nil, err
-	}
-	msg := &types.RegisterValidatorRequestMessage{
-		FeeRecipient: feeRecipient,
-		Timestamp:    timestamp,
-		Pubkey:       pubKey,
-		GasLimit:     278234191203,
-	}
+// 	var pubKey types.PublicKey
+// 	err = pubKey.FromSlice(bls.PublicKeyToBytes(blsPubKey))
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	msg := &types.RegisterValidatorRequestMessage{
+// 		FeeRecipient: feeRecipient,
+// 		Timestamp:    timestamp,
+// 		Pubkey:       pubKey,
+// 		GasLimit:     278234191203,
+// 	}
 
-	sig, err := types.SignMessage(msg, builderSigningDomain, sk)
-	if err != nil {
-		return nil, err
-	}
+// 	sig, err := types.SignMessage(msg, builderSigningDomain, sk)
+// 	if err != nil {
+// 		return nil, err
+// 	}
 
-	return &types.SignedValidatorRegistration{
-		Message:   msg,
-		Signature: sig,
-	}, nil
-}
+// 	return &types.SignedValidatorRegistration{
+// 		Message:   msg,
+// 		Signature: sig,
+// 	}, nil
+// }
 
 func TestWebserver(t *testing.T) {
 	t.Run("errors when webserver is already existing", func(t *testing.T) {
@@ -203,29 +203,29 @@ func TestStatus(t *testing.T) {
 func TestRegisterValidator(t *testing.T) {
 	path := "/eth/v1/builder/validators"
 
-	t.Run("Normal function", func(t *testing.T) {
-		backend := newTestBackend(t, 1)
-		pubkeyHex := common.ValidPayloadRegisterValidator.Message.Pubkey.PubkeyHex()
-		index := uint64(17)
-		err := backend.redis.SetKnownValidator(pubkeyHex, index)
-		require.NoError(t, err)
+	// t.Run("Normal function", func(t *testing.T) {
+	// 	backend := newTestBackend(t, 1)
+	// 	pubkeyHex := common.ValidPayloadRegisterValidator.Message.Pubkey.PubkeyHex()
+	// 	index := uint64(17)
+	// 	err := backend.redis.SetKnownValidator(pubkeyHex, index)
+	// 	require.NoError(t, err)
 
-		// Update datastore
-		_, err = backend.datastore.RefreshKnownValidators()
-		require.NoError(t, err)
-		require.True(t, backend.datastore.IsKnownValidator(pubkeyHex))
-		pkH, ok := backend.datastore.GetKnownValidatorPubkeyByIndex(index)
-		require.True(t, ok)
-		require.Equal(t, pubkeyHex, pkH)
+	// 	// Update datastore
+	// 	_, err = backend.datastore.RefreshKnownValidators()
+	// 	require.NoError(t, err)
+	// 	require.True(t, backend.datastore.IsKnownValidator(pubkeyHex))
+	// 	pkH, ok := backend.datastore.GetKnownValidatorPubkeyByIndex(index)
+	// 	require.True(t, ok)
+	// 	require.Equal(t, pubkeyHex, pkH)
 
-		payload := []types.SignedValidatorRegistration{common.ValidPayloadRegisterValidator}
-		rr := backend.request(http.MethodPost, path, payload)
-		require.Equal(t, http.StatusOK, rr.Code)
-		time.Sleep(20 * time.Millisecond) // registrations are processed asynchronously
+	// 	payload := []types.SignedValidatorRegistration{common.ValidPayloadRegisterValidator}
+	// 	rr := backend.request(http.MethodPost, path, payload)
+	// 	require.Equal(t, http.StatusOK, rr.Code)
+	// 	time.Sleep(20 * time.Millisecond) // registrations are processed asynchronously
 
-		isKnown := backend.datastore.IsKnownValidator(pubkeyHex)
-		require.True(t, isKnown)
-	})
+	// 	isKnown := backend.datastore.IsKnownValidator(pubkeyHex)
+	// 	require.True(t, isKnown)
+	// })
 
 	t.Run("not a known validator", func(t *testing.T) {
 		backend := newTestBackend(t, 1)
@@ -234,34 +234,34 @@ func TestRegisterValidator(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, rr.Code)
 	})
 
-	t.Run("Reject registration for >10sec into the future", func(t *testing.T) {
-		backend := newTestBackend(t, 1)
+	// t.Run("Reject registration for >10sec into the future", func(t *testing.T) {
+	// 	backend := newTestBackend(t, 1)
 
-		// Allow +10 sec
-		td := uint64(time.Now().Unix())
-		payload, err := generateSignedValidatorRegistration(nil, types.Address{1}, td+10)
-		require.NoError(t, err)
-		err = backend.redis.SetKnownValidator(payload.Message.Pubkey.PubkeyHex(), 1)
-		require.NoError(t, err)
-		_, err = backend.datastore.RefreshKnownValidators()
-		require.NoError(t, err)
+	// 	// Allow +10 sec
+	// 	td := uint64(time.Now().Unix())
+	// 	payload, err := generateSignedValidatorRegistration(nil, types.Address{1}, td+10)
+	// 	require.NoError(t, err)
+	// 	err = backend.redis.SetKnownValidator(payload.Message.Pubkey.PubkeyHex(), 1)
+	// 	require.NoError(t, err)
+	// 	_, err = backend.datastore.RefreshKnownValidators()
+	// 	require.NoError(t, err)
 
-		rr := backend.request(http.MethodPost, path, []types.SignedValidatorRegistration{*payload})
-		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	// 	rr := backend.request(http.MethodPost, path, []types.SignedValidatorRegistration{*payload})
+	// 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 
-		// Disallow +11 sec
-		td = uint64(time.Now().Unix())
-		payload, err = generateSignedValidatorRegistration(nil, types.Address{1}, td+12)
-		require.NoError(t, err)
-		err = backend.redis.SetKnownValidator(payload.Message.Pubkey.PubkeyHex(), 1)
-		require.NoError(t, err)
-		_, err = backend.datastore.RefreshKnownValidators()
-		require.NoError(t, err)
+	// 	// Disallow +11 sec
+	// 	td = uint64(time.Now().Unix())
+	// 	payload, err = generateSignedValidatorRegistration(nil, types.Address{1}, td+12)
+	// 	require.NoError(t, err)
+	// 	err = backend.redis.SetKnownValidator(payload.Message.Pubkey.PubkeyHex(), 1)
+	// 	require.NoError(t, err)
+	// 	_, err = backend.datastore.RefreshKnownValidators()
+	// 	require.NoError(t, err)
 
-		rr = backend.request(http.MethodPost, path, []types.SignedValidatorRegistration{*payload})
-		require.Equal(t, http.StatusBadRequest, rr.Code)
-		require.Contains(t, rr.Body.String(), "timestamp too far in the future")
-	})
+	// 	rr = backend.request(http.MethodPost, path, []types.SignedValidatorRegistration{*payload})
+	// 	require.Equal(t, http.StatusBadRequest, rr.Code)
+	// 	require.Contains(t, rr.Body.String(), "timestamp too far in the future")
+	// })
 }
 
 func TestGetHeader(t *testing.T) {

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -127,9 +127,6 @@ func (hk *Housekeeper) processNewSlot(headSlot uint64) {
 	}
 	hk.headSlot.Store(headSlot)
 
-	// kick of a possible validator update
-	// go hk.updateKnownValidators()
-
 	log := hk.log.WithFields(logrus.Fields{
 		"headSlot":     headSlot,
 		"headSlotPos":  common.SlotPos(headSlot),
@@ -158,126 +155,6 @@ func (hk *Housekeeper) processNewSlot(headSlot uint64) {
 		"slotStartNextEpoch": (currentEpoch + 1) * common.SlotsPerEpoch,
 	}).Infof("updated headSlot to %d", headSlot)
 }
-
-// func (hk *Housekeeper) saveKnownValidators(indexPkMap map[uint64]types.PubkeyHex) {
-// 	err := hk.redis.SetMultiKnownValidator(indexPkMap)
-// 	if err != nil {
-// 		hk.log.WithError(err).Error("failed to set known validators in Redis")
-// 	} else {
-// 		for proposerIndex, publickeyHex := range indexPkMap {
-// 			hk.proposersAlreadySaved[proposerIndex] = publickeyHex.String()
-// 		}
-// 	}
-// }
-
-// updateKnownValidators queries the full list of known validators from the beacon node
-// and stores it in redis. For the CL client this is an expensive operation and takes a bunch
-// of resources. This is why we schedule the requests for slot 4 and 20 of every epoch,
-// 6 seconds into the slot (on suggestion of @potuz). It's also run once at startup.
-// func (hk *Housekeeper) updateKnownValidators_todelete() {
-// 	// Ensure there's only one at a time
-// 	if isUpdating := hk.lastValdatorIsUpdating.Swap(true); isUpdating {
-// 		return
-// 	}
-// 	defer hk.lastValdatorIsUpdating.Store(false)
-
-// 	// Load data and prepare logs
-// 	headSlot := hk.headSlot.Load()
-// 	headSlotPos := common.SlotPos(headSlot) // 1-based position in epoch (32 slots, 1..32)
-// 	lastUpdateSlot := hk.lastValdatorUpdateSlot.Load()
-// 	log := hk.log.WithFields(logrus.Fields{
-// 		"headSlot":       headSlot,
-// 		"headSlotPos":    headSlotPos,
-// 		"lastUpdateSlot": lastUpdateSlot,
-// 		"method":         "updateKnownValidators",
-// 	})
-
-// 	// Abort if we already had this slot
-// 	if headSlot <= lastUpdateSlot {
-// 		return
-// 	}
-
-// 	// Minimum amount of slots between updates
-// 	slotsSinceLastUpdate := headSlot - lastUpdateSlot
-// 	if slotsSinceLastUpdate < 6 {
-// 		return
-// 	}
-
-// 	log.Debug("updateKnownValidators init")
-
-// 	// Force update after a longer time since last successful update
-// 	forceUpdate := slotsSinceLastUpdate > 32
-
-// 	// Proceed only if forced, or on slot-position 4 or 20
-// 	if !forceUpdate && headSlotPos != 4 && headSlotPos != 20 {
-// 		return
-// 	}
-
-// 	// Wait for 6s into the slot
-// 	time.Sleep(6 * time.Second)
-
-// 	//
-// 	// Execute update now
-// 	//
-// 	// Query beacon node for known validators
-// 	log.Info("Querying validators from beacon node... (this may take a while)")
-// 	timeStartFetching := time.Now()
-// 	validators, err := hk.beaconClient.GetStateValidators(beaconclient.StateIDHead) // head is fastest
-// 	if err != nil {
-// 		log.WithError(err).Error("failed to fetch validators from all beacon nodes")
-// 		return
-// 	}
-
-// 	numValidators := len(validators)
-// 	log = log.WithField("numKnownValidators", numValidators)
-// 	log.WithField("durationFetchValidatorsMs", time.Since(timeStartFetching).Milliseconds()).Infof("received validators from beacon-node")
-
-// 	// Store total number of validators
-// 	err = hk.redis.SetStats(datastore.RedisStatsFieldValidatorsTotal, fmt.Sprint(numValidators))
-// 	if err != nil {
-// 		log.WithError(err).Error("failed to set stats for RedisStatsFieldValidatorsTotal")
-// 	}
-
-// 	// At this point, consider the update successful
-// 	hk.lastValdatorUpdateSlot.Store(headSlot)
-
-// 	// Update Redis with validators
-// 	log.Debug("Writing to Redis...")
-// 	timeStartWriting := time.Now()
-
-// 	// This writes a large amount of validators to redis (~600k), which can take a while
-// 	i := 0
-// 	newValidators := 0
-// 	bufferSize := 10000
-// 	indexPkMap := make(map[uint64]types.PubkeyHex)
-// 	for _, validator := range validators {
-// 		i++
-
-// 		// avoid resaving if index->pubkey mapping is the same
-// 		prevPubkeyForIndex := hk.proposersAlreadySaved[validator.Index]
-// 		if prevPubkeyForIndex == validator.Validator.Pubkey {
-// 			continue
-// 		}
-
-// 		indexPkMap[validator.Index] = types.PubkeyHex(validator.Validator.Pubkey)
-
-// 		if i%bufferSize == 0 {
-// 			hk.saveKnownValidators(indexPkMap)
-// 			newValidators += bufferSize
-// 			indexPkMap = make(map[uint64]types.PubkeyHex)
-// 			log.Debugf("wrote known validators to redis: %d / %d", i, numValidators)
-// 		}
-// 	}
-
-// 	hk.saveKnownValidators(indexPkMap)
-// 	newValidators += len(indexPkMap)
-// 	log.Debugf("wrote known validators to redis: %d / %d", i, numValidators)
-
-// 	log.WithFields(logrus.Fields{
-// 		"durationRedisWrite": time.Since(timeStartWriting).Seconds(),
-// 		"newValidators":      newValidators,
-// 	}).Info("updateKnownValidators done")
-// }
 
 func (hk *Housekeeper) updateProposerDuties(headSlot uint64) {
 	// Should only happen once at a time

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -53,9 +53,6 @@ type Housekeeper struct {
 
 	headSlot uberatomic.Uint64
 
-	lastValdatorUpdateSlot uberatomic.Uint64
-	lastValdatorIsUpdating uberatomic.Bool
-
 	proposersAlreadySaved map[uint64]string // to avoid repeating redis writes
 }
 
@@ -131,7 +128,7 @@ func (hk *Housekeeper) processNewSlot(headSlot uint64) {
 	hk.headSlot.Store(headSlot)
 
 	// kick of a possible validator update
-	go hk.updateKnownValidators()
+	// go hk.updateKnownValidators()
 
 	log := hk.log.WithFields(logrus.Fields{
 		"headSlot":     headSlot,
@@ -162,125 +159,125 @@ func (hk *Housekeeper) processNewSlot(headSlot uint64) {
 	}).Infof("updated headSlot to %d", headSlot)
 }
 
-func (hk *Housekeeper) saveKnownValidators(indexPkMap map[uint64]types.PubkeyHex) {
-	err := hk.redis.SetMultiKnownValidator(indexPkMap)
-	if err != nil {
-		hk.log.WithError(err).Error("failed to set known validators in Redis")
-	} else {
-		for proposerIndex, publickeyHex := range indexPkMap {
-			hk.proposersAlreadySaved[proposerIndex] = publickeyHex.String()
-		}
-	}
-}
+// func (hk *Housekeeper) saveKnownValidators(indexPkMap map[uint64]types.PubkeyHex) {
+// 	err := hk.redis.SetMultiKnownValidator(indexPkMap)
+// 	if err != nil {
+// 		hk.log.WithError(err).Error("failed to set known validators in Redis")
+// 	} else {
+// 		for proposerIndex, publickeyHex := range indexPkMap {
+// 			hk.proposersAlreadySaved[proposerIndex] = publickeyHex.String()
+// 		}
+// 	}
+// }
 
 // updateKnownValidators queries the full list of known validators from the beacon node
 // and stores it in redis. For the CL client this is an expensive operation and takes a bunch
 // of resources. This is why we schedule the requests for slot 4 and 20 of every epoch,
 // 6 seconds into the slot (on suggestion of @potuz). It's also run once at startup.
-func (hk *Housekeeper) updateKnownValidators() {
-	// Ensure there's only one at a time
-	if isUpdating := hk.lastValdatorIsUpdating.Swap(true); isUpdating {
-		return
-	}
-	defer hk.lastValdatorIsUpdating.Store(false)
+// func (hk *Housekeeper) updateKnownValidators_todelete() {
+// 	// Ensure there's only one at a time
+// 	if isUpdating := hk.lastValdatorIsUpdating.Swap(true); isUpdating {
+// 		return
+// 	}
+// 	defer hk.lastValdatorIsUpdating.Store(false)
 
-	// Load data and prepare logs
-	headSlot := hk.headSlot.Load()
-	headSlotPos := common.SlotPos(headSlot) // 1-based position in epoch (32 slots, 1..32)
-	lastUpdateSlot := hk.lastValdatorUpdateSlot.Load()
-	log := hk.log.WithFields(logrus.Fields{
-		"headSlot":       headSlot,
-		"headSlotPos":    headSlotPos,
-		"lastUpdateSlot": lastUpdateSlot,
-		"method":         "updateKnownValidators",
-	})
+// 	// Load data and prepare logs
+// 	headSlot := hk.headSlot.Load()
+// 	headSlotPos := common.SlotPos(headSlot) // 1-based position in epoch (32 slots, 1..32)
+// 	lastUpdateSlot := hk.lastValdatorUpdateSlot.Load()
+// 	log := hk.log.WithFields(logrus.Fields{
+// 		"headSlot":       headSlot,
+// 		"headSlotPos":    headSlotPos,
+// 		"lastUpdateSlot": lastUpdateSlot,
+// 		"method":         "updateKnownValidators",
+// 	})
 
-	// Abort if we already had this slot
-	if headSlot <= lastUpdateSlot {
-		return
-	}
+// 	// Abort if we already had this slot
+// 	if headSlot <= lastUpdateSlot {
+// 		return
+// 	}
 
-	// Minimum amount of slots between updates
-	slotsSinceLastUpdate := headSlot - lastUpdateSlot
-	if slotsSinceLastUpdate < 6 {
-		return
-	}
+// 	// Minimum amount of slots between updates
+// 	slotsSinceLastUpdate := headSlot - lastUpdateSlot
+// 	if slotsSinceLastUpdate < 6 {
+// 		return
+// 	}
 
-	log.Debug("updateKnownValidators init")
+// 	log.Debug("updateKnownValidators init")
 
-	// Force update after a longer time since last successful update
-	forceUpdate := slotsSinceLastUpdate > 32
+// 	// Force update after a longer time since last successful update
+// 	forceUpdate := slotsSinceLastUpdate > 32
 
-	// Proceed only if forced, or on slot-position 4 or 20
-	if !forceUpdate && headSlotPos != 4 && headSlotPos != 20 {
-		return
-	}
+// 	// Proceed only if forced, or on slot-position 4 or 20
+// 	if !forceUpdate && headSlotPos != 4 && headSlotPos != 20 {
+// 		return
+// 	}
 
-	// Wait for 6s into the slot
-	time.Sleep(6 * time.Second)
+// 	// Wait for 6s into the slot
+// 	time.Sleep(6 * time.Second)
 
-	//
-	// Execute update now
-	//
-	// Query beacon node for known validators
-	log.Info("Querying validators from beacon node... (this may take a while)")
-	timeStartFetching := time.Now()
-	validators, err := hk.beaconClient.GetStateValidators(beaconclient.StateIDHead) // head is fastest
-	if err != nil {
-		log.WithError(err).Error("failed to fetch validators from all beacon nodes")
-		return
-	}
+// 	//
+// 	// Execute update now
+// 	//
+// 	// Query beacon node for known validators
+// 	log.Info("Querying validators from beacon node... (this may take a while)")
+// 	timeStartFetching := time.Now()
+// 	validators, err := hk.beaconClient.GetStateValidators(beaconclient.StateIDHead) // head is fastest
+// 	if err != nil {
+// 		log.WithError(err).Error("failed to fetch validators from all beacon nodes")
+// 		return
+// 	}
 
-	numValidators := len(validators)
-	log = log.WithField("numKnownValidators", numValidators)
-	log.WithField("durationFetchValidatorsMs", time.Since(timeStartFetching).Milliseconds()).Infof("received validators from beacon-node")
+// 	numValidators := len(validators)
+// 	log = log.WithField("numKnownValidators", numValidators)
+// 	log.WithField("durationFetchValidatorsMs", time.Since(timeStartFetching).Milliseconds()).Infof("received validators from beacon-node")
 
-	// Store total number of validators
-	err = hk.redis.SetStats(datastore.RedisStatsFieldValidatorsTotal, fmt.Sprint(numValidators))
-	if err != nil {
-		log.WithError(err).Error("failed to set stats for RedisStatsFieldValidatorsTotal")
-	}
+// 	// Store total number of validators
+// 	err = hk.redis.SetStats(datastore.RedisStatsFieldValidatorsTotal, fmt.Sprint(numValidators))
+// 	if err != nil {
+// 		log.WithError(err).Error("failed to set stats for RedisStatsFieldValidatorsTotal")
+// 	}
 
-	// At this point, consider the update successful
-	hk.lastValdatorUpdateSlot.Store(headSlot)
+// 	// At this point, consider the update successful
+// 	hk.lastValdatorUpdateSlot.Store(headSlot)
 
-	// Update Redis with validators
-	log.Debug("Writing to Redis...")
-	timeStartWriting := time.Now()
+// 	// Update Redis with validators
+// 	log.Debug("Writing to Redis...")
+// 	timeStartWriting := time.Now()
 
-	// This writes a large amount of validators to redis (~600k), which can take a while
-	i := 0
-	newValidators := 0
-	bufferSize := 10000
-	indexPkMap := make(map[uint64]types.PubkeyHex)
-	for _, validator := range validators {
-		i++
+// 	// This writes a large amount of validators to redis (~600k), which can take a while
+// 	i := 0
+// 	newValidators := 0
+// 	bufferSize := 10000
+// 	indexPkMap := make(map[uint64]types.PubkeyHex)
+// 	for _, validator := range validators {
+// 		i++
 
-		// avoid resaving if index->pubkey mapping is the same
-		prevPubkeyForIndex := hk.proposersAlreadySaved[validator.Index]
-		if prevPubkeyForIndex == validator.Validator.Pubkey {
-			continue
-		}
+// 		// avoid resaving if index->pubkey mapping is the same
+// 		prevPubkeyForIndex := hk.proposersAlreadySaved[validator.Index]
+// 		if prevPubkeyForIndex == validator.Validator.Pubkey {
+// 			continue
+// 		}
 
-		indexPkMap[validator.Index] = types.PubkeyHex(validator.Validator.Pubkey)
+// 		indexPkMap[validator.Index] = types.PubkeyHex(validator.Validator.Pubkey)
 
-		if i%bufferSize == 0 {
-			hk.saveKnownValidators(indexPkMap)
-			newValidators += bufferSize
-			indexPkMap = make(map[uint64]types.PubkeyHex)
-			log.Debugf("wrote known validators to redis: %d / %d", i, numValidators)
-		}
-	}
+// 		if i%bufferSize == 0 {
+// 			hk.saveKnownValidators(indexPkMap)
+// 			newValidators += bufferSize
+// 			indexPkMap = make(map[uint64]types.PubkeyHex)
+// 			log.Debugf("wrote known validators to redis: %d / %d", i, numValidators)
+// 		}
+// 	}
 
-	hk.saveKnownValidators(indexPkMap)
-	newValidators += len(indexPkMap)
-	log.Debugf("wrote known validators to redis: %d / %d", i, numValidators)
+// 	hk.saveKnownValidators(indexPkMap)
+// 	newValidators += len(indexPkMap)
+// 	log.Debugf("wrote known validators to redis: %d / %d", i, numValidators)
 
-	log.WithFields(logrus.Fields{
-		"durationRedisWrite": time.Since(timeStartWriting).Seconds(),
-		"newValidators":      newValidators,
-	}).Info("updateKnownValidators done")
-}
+// 	log.WithFields(logrus.Fields{
+// 		"durationRedisWrite": time.Since(timeStartWriting).Seconds(),
+// 		"newValidators":      newValidators,
+// 	}).Info("updateKnownValidators done")
+// }
 
 func (hk *Housekeeper) updateProposerDuties(headSlot uint64) {
 	// Should only happen once at a time


### PR DESCRIPTION
## 📝 Summary

Instead of piping known validators from redis, get them straight from CL client in the proposer API

(it's an expensive request on Redis, one of the main bottlenecks!)

---

This makes and https://github.com/flashbots/mev-boost-relay/pull/439 made our Redis load drop a whole lot:

![Screenshot 2023-05-31 at 14 22 06](https://github.com/flashbots/mev-boost-relay/assets/116939/9382fed8-673f-4c27-b932-c93851dbdab1)
![Screenshot 2023-05-31 at 14 22 40](https://github.com/flashbots/mev-boost-relay/assets/116939/34c3764e-9c41-4ff8-9677-277dfd20105e)


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
