### PR TITLE
add slot to sim-lb request

### DIFF
--- a/services/api/blocksim_ratelimiter.go
+++ b/services/api/blocksim_ratelimiter.go
@@ -77,6 +77,7 @@ func (b *BlockSimulationRateLimiter) Send(context context.Context, payload *comm
 
 	// Prepare headers
 	headers := http.Header{}
+	headers.Add("X-Request-Slot", fmt.Sprint(payload.Slot()))
 	headers.Add("X-Request-ID", fmt.Sprintf("%d/%s", payload.Slot(), payload.BlockHash()))
 	if isHighPrio {
 		headers.Add("X-High-Priority", "true")


### PR DESCRIPTION
## 📝 Summary

Latest sim-lb supports slot header and will print additional timing logs: https://github.com/flashbots/prio-load-balancer/pull/21


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
