### PR TITLE
Minor additional logging for block submissions

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1565,10 +1565,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 			collateral: big.NewInt(0),
 		}
 	}
-	log = log.WithFields(logrus.Fields{
-		"builderEntry":      builderEntry,
-		"builderIsHighPrio": builderEntry.status.IsHighPrio,
-	})
+	log = log.WithField("builderIsHighPrio", builderEntry.status.IsHighPrio)
 
 	// Timestamp check
 	expectedTimestamp := api.genesisInfo.Data.GenesisTime + (payload.Slot() * common.SecondsPerSlot)
@@ -1889,8 +1886,14 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	pf.RedisUpdate = uint64(nextTime.Sub(prevTime).Microseconds())
 	pf.Total = uint64(nextTime.Sub(receivedAt).Microseconds())
 
-	// All done
-	log.Info("received block from builder")
+	// All done, log with profiling information
+	log.WithFields(logrus.Fields{
+		"profileDecodeUs":    pf.Decode,
+		"profilePrechecksUs": pf.Prechecks,
+		"profileSimUs":       pf.Simulation,
+		"profileRedisUs":     pf.RedisUpdate,
+		"profileTotalUs":     pf.Total,
+	}).Info("received block from builder")
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1523,6 +1523,7 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 	prevTime = nextTime
 
 	log = log.WithFields(logrus.Fields{
+		"payloadBytes":           len(requestPayloadBytes),
 		"timestampAfterDecoding": time.Now().UTC().UnixMilli(),
 		"slot":                   payload.Slot(),
 		"builderPubkey":          payload.BuilderPubkey().String(),


### PR DESCRIPTION
## 📝 Summary

* Log `payloadBytes`
* Log all profile metrics at end of successful request (with `received block from builder`)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
