### PR TITLE
Redis: save ExecPayload in SSZ format (requires update of both builder-API and proposer-API ⚠️)

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -193,7 +193,7 @@ func (ds *Datastore) GetGetPayloadResponse(slot uint64, proposerPubkey, blockHas
 	_blockHash := strings.ToLower(blockHash)
 
 	// 1. try to get from Redis
-	resp, err := ds.redis.GetExecutionPayload(slot, _proposerPubkey, _blockHash)
+	resp, err := ds.redis.GetExecutionPayloadCapella(slot, _proposerPubkey, _blockHash)
 	if err != nil {
 		ds.log.WithError(err).Error("error getting execution payload from redis")
 	} else {


### PR DESCRIPTION
## 📝 Summary

Saving CapellaExecutionPaylaod SSZ-encoded in Redis should be a small performance improvement.

**⚠️ Important: changes need to get rolled out to builder-API and proposer-API simultaneously ⚠️**

This PR changes the Redis storage key for execution payloads, where the proposer API looks up the getPayload response

The recommended update sequence is as follows:
1. disable builder-API ingress
2. update proposer-API and builder-API
3. enable builder-API ingress

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
