### PR TITLE
Optimistic relaying v2: header only parsing.

### DIFF
--- a/common/test_utils.go
+++ b/common/test_utils.go
@@ -2,14 +2,16 @@ package common
 
 import (
 	"compress/gzip"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"os"
 	"testing"
 
 	"github.com/attestantio/go-builder-client/api/capella"
-	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	bellatrixspec "github.com/attestantio/go-eth2-client/spec/bellatrix"
 	consensuscapella "github.com/attestantio/go-eth2-client/spec/capella"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/flashbots/go-boost-utils/bls"
 	boostTypes "github.com/flashbots/go-boost-utils/types"
 	"github.com/sirupsen/logrus"
@@ -70,7 +72,7 @@ func TestBuilderSubmitBlockRequest(sk *bls.SecretKey, bid *BidTraceV2) BuilderSu
 			Message:   &bid.BidTrace,
 			Signature: [96]byte(signature),
 			ExecutionPayload: &consensuscapella.ExecutionPayload{ //nolint:exhaustruct
-				Transactions: []bellatrix.Transaction{[]byte{0x03}},
+				Transactions: []bellatrixspec.Transaction{[]byte{0x03}},
 				Timestamp:    bid.Slot * 12, // 12 seconds per slot.
 				PrevRandao:   _HexToHash("01234567890123456789012345678901"),
 				Withdrawals:  []*consensuscapella.Withdrawal{},
@@ -97,4 +99,30 @@ func LoadGzippedJSON(t *testing.T, filename string, dst any) {
 	b := LoadGzippedBytes(t, filename)
 	err := json.Unmarshal(b, dst)
 	require.NoError(t, err)
+}
+
+func TestBuilderSubmitBlockRequestV2(sk *bls.SecretKey, bid *BidTraceV2) *SubmitBlockRequest {
+	signature, err := boostTypes.SignMessage(bid, boostTypes.DomainBuilder, sk)
+	check(err, " SignMessage: ", bid, sk)
+
+	wRoot, err := hex.DecodeString("792930bbd5baac43bcc798ee49aa8185ef76bb3b44ba62b91d86ae569e4bb535")
+	check(err)
+	return &SubmitBlockRequest{
+		Message: &bid.BidTrace,
+		ExecutionPayloadHeader: &consensuscapella.ExecutionPayloadHeader{ //nolint:exhaustruct
+			TransactionsRoot: [32]byte{},
+			Timestamp:        bid.Slot * 12, // 12 seconds per slot.
+			PrevRandao:       _HexToHash("01234567890123456789012345678901"),
+			WithdrawalsRoot:  phase0.Root(wRoot),
+			ExtraData: []byte{
+				0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+				0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+				0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+				0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+			},
+		},
+		Signature:    [96]byte(signature),
+		Transactions: []bellatrixspec.Transaction{[]byte{0x03}},
+		Withdrawals:  []*consensuscapella.Withdrawal{},
+	}
 }

--- a/common/types_spec.go
+++ b/common/types_spec.go
@@ -14,6 +14,7 @@ import (
 	utilcapella "github.com/attestantio/go-eth2-client/util/capella"
 	"github.com/flashbots/go-boost-utils/bls"
 	boostTypes "github.com/flashbots/go-boost-utils/types"
+	"github.com/holiman/uint256"
 )
 
 var (
@@ -69,6 +70,34 @@ func BuildGetHeaderResponse(payload *BuilderSubmitBlockRequest, sk *bls.SecretKe
 		}, nil
 	}
 	return nil, ErrEmptyPayload
+}
+
+func BuildGetHeaderResponseHeaderOnly(value *uint256.Int, header *consensuscapella.ExecutionPayloadHeader, sk *bls.SecretKey, pubkey *boostTypes.PublicKey, domain boostTypes.Domain) (*GetHeaderResponse, error) {
+	builderBid := capella.BuilderBid{
+		Value:  value,
+		Header: header,
+		Pubkey: *(*phase0.BLSPubKey)(pubkey),
+	}
+
+	sig, err := boostTypes.SignMessage(&builderBid, domain, sk)
+	if err != nil {
+		return nil, err
+	}
+
+	signedBuilderBid := &capella.SignedBuilderBid{
+		Message:   &builderBid,
+		Signature: phase0.BLSSignature(sig),
+	}
+
+	return &GetHeaderResponse{
+		Capella: &spec.VersionedSignedBuilderBid{
+			Version:   consensusspec.DataVersionCapella,
+			Capella:   signedBuilderBid,
+			Bellatrix: nil,
+		},
+		Bellatrix: nil,
+	}, nil
+
 }
 
 func BuildGetPayloadResponse(payload *BuilderSubmitBlockRequest) (*GetPayloadResponse, error) {


### PR DESCRIPTION
## 📝 Summary

v2 of the optimistic relaying [roadmap](https://github.com/michaelneuder/optimistic-relay-documentation/blob/main/towards-epbs.md), which does optimistic header only parsing of an SSZ encoded bid and marks the bid eligible immediately. 

> NOTE: the overall approach of this change was to not touch the `handleSubmitNewBlock` path at all. Since that logic is already relatively stable at this point, I thought it would be best to leave it alone and not try to refactor it into functions that can be used with the `handleSubmitNewBlockV2` path. This results in some amount of copied code, which I cite in the change log below. As v2 optimistic relaying gets tested and starts running in prod, we can start refactoring to reduce duplicate code. 

change log: 
1. `common/types.go` –– Adding the `SubmitBlockRequest` type to the common package. This type is was discussed in https://github.com/attestantio/go-builder-client/pull/8. The first three fields are enough to construct the `getHeaderResponse` and thus qualify the bid for the auction. The last two fields (txns and withdrawals) are needed to construct the full `ExecutionPayload` that is part of the `getPayloadResponse`. This type has the normal SSZ methods, but also includes the `UnmarshalSSZHeaderOnly` function, which parses only the first three fields of the type (with the offsets). 
2. `common/types_spec.go` –– Adding the `BuildGetHeaderResponseHeaderOnly` function which builds the `getHeaderResponse` using the full header that is passed in (not using the txn slice to construct the txn root).
3. `datastore/redis.go` –– Modify `SaveBidAndUpdateTopBid` to only save the `ExecutionPayload` if the `getPayloadResponse` is not nil. This allows us to use that function as is to save only the getHeader response and avoid code duplication in that path.
4. `services/api/service.go` –– 
   * [lines 1940-1985] copied from `handleSubmitNewBlock`
   * [lines 1940-1985] copied from `handleSubmitNewBlock`
   * [lines 1940-1985] copied from `handleSubmitNewBlock`

## ⛱ Motivation and Context

This change represents the next phase of optimistic relaying, which is an iterative approach of evolving mev-boost to look more like enshrined PBS. See [this post](https://ethresear.ch/t/why-enshrine-proposer-builder-separation-a-viable-path-to-epbs/15710) for more context.

## 📚 References

[Why enshrine proposer builder separation?](https://ethresear.ch/t/why-enshrine-proposer-builder-separation-a-viable-path-to-epbs/15710)
[roadmap](https://github.com/michaelneuder/optimistic-relay-documentation/blob/main/towards-epbs.md)
[optimistic relays and where to find them](https://frontier.tech/optimistic-relays-and-where-to-find-them)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
