### PR TITLE
Return instead of using empty bidTrace

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1361,7 +1361,7 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 		bidTrace, err := api.redis.GetBidTrace(payload.Slot(), proposerPubkey.String(), payload.BlockHash())
 		if err != nil {
 			log.WithError(err).Error("failed to get bidTrace for delivered payload from redis")
-			bidTrace = &common.BidTraceV2{} //nolint:exhaustruct
+			return
 		}
 
 		err = api.db.SaveDeliveredPayload(bidTrace, payload, decodeTime, msNeededForPublishing)


### PR DESCRIPTION
## 📝 Summary

Returning instead of saving an empty bidTrace for delivered payloads. 

## ⛱ Motivation and Context

Using the zero value causes a nil ptr exception because we do not initialize the array fields of the struct. We should just return if we can't find the value in redis because we can't meaningfully save the Payload without any of the bidtrace fields. 

## 📚 References


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
