### PR TITLE
[fix] `redis.GetBidTrace` should return `err=redis.Nil` on missing item

### DIFF
--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -393,13 +393,11 @@ func (r *RedisCache) SaveBidTrace(ctx context.Context, tx redis.Pipeliner, trace
 	return r.SetObjPipelined(ctx, tx, key, trace, expiryBidCache)
 }
 
+// GetBidTrace returns (trace, nil), or (nil, redis.Nil) if the trace does not exist
 func (r *RedisCache) GetBidTrace(slot uint64, proposerPubkey, blockHash string) (*common.BidTraceV2, error) {
 	key := r.keyCacheBidTrace(slot, proposerPubkey, blockHash)
 	resp := new(common.BidTraceV2)
 	err := r.GetObj(key, resp)
-	if errors.Is(err, redis.Nil) {
-		return nil, nil
-	}
 	return resp, err
 }
 


### PR DESCRIPTION
## 📝 Summary

If `redis.GetBidTrace` doesn't find the item, it should return `redis.Nil` as error, instead of no error. This is only used in https://github.com/flashbots/mev-boost-relay/blob/getBidTrace-fix2/services/api/service.go#L1361 which would crash when saving the delivered payload when this happens (the bidTrace not being found in Redis).

Extends https://github.com/flashbots/mev-boost-relay/pull/467

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
