### PR TITLE
fix EligibleAt null / NewNullTime

### DIFF
--- a/database/types.go
+++ b/database/types.go
@@ -22,10 +22,12 @@ func NewNullString(s string) sql.NullString {
 	}
 }
 
+// NewNullTime returns a sql.NullTime with the given time.Time. If the time is
+// the zero value, the NullTime is invalid.
 func NewNullTime(t time.Time) sql.NullTime {
 	return sql.NullTime{
 		Time:  t,
-		Valid: true,
+		Valid: t != time.Time{},
 	}
 }
 

--- a/database/types_test.go
+++ b/database/types_test.go
@@ -1,0 +1,19 @@
+package database
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNullTime(t *testing.T) {
+	var t1 time.Time
+	nt1 := NewNullTime(t1)
+	require.False(t, nt1.Valid)
+
+	t1 = time.Now()
+	nt1 = NewNullTime(t1)
+	require.True(t, nt1.Valid)
+	require.Equal(t, t1, nt1.Time)
+}


### PR DESCRIPTION
## 📝 Summary

Fixes https://github.com/flashbots/mev-boost-relay/issues/470

`NewNullTime` would always return a valid time, even if the input is null time. This is fixed in this PR.

TODO?
- add a migration to fix the existing data? It's a lot of data and would probably take quite long to run, so maybe not

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
