### PR TITLE
Remove bellatrix from wrapper types

### DIFF
--- a/beaconclient/beacon_client_test.go
+++ b/beaconclient/beacon_client_test.go
@@ -198,7 +198,6 @@ func TestFetchValidators(t *testing.T) {
 		backend.beaconInstances[2].MockFetchValidatorsErr = nil
 		backend.beaconInstances[2].AddValidator(entry)
 
-		// t.Log("beacon0/1/2 validators:", backend.beaconInstances[0].NumValidators(), backend.beaconInstances[1].NumValidators(), backend.beaconInstances[2].NumValidators())
 		validators, err = backend.beaconClient.GetStateValidators("1")
 		require.NoError(t, err)
 		require.Equal(t, 1, len(validators.Data))

--- a/common/test_utils.go
+++ b/common/test_utils.go
@@ -67,7 +67,7 @@ var ValidPayloadRegisterValidator = boostTypes.SignedValidatorRegistration{
 func TestBuilderSubmitBlockRequest(sk *bls.SecretKey, bid *BidTraceV2) BuilderSubmitBlockRequest {
 	signature, err := boostTypes.SignMessage(bid, boostTypes.DomainBuilder, sk)
 	check(err, " SignMessage: ", bid, sk)
-	return BuilderSubmitBlockRequest{ //nolint:exhaustruct
+	return BuilderSubmitBlockRequest{
 		Capella: &capella.SubmitBlockRequest{
 			Message:   &bid.BidTrace,
 			Signature: [96]byte(signature),

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -4,33 +4,8 @@ import (
 	"testing"
 
 	consensusspec "github.com/attestantio/go-eth2-client/spec"
-	"github.com/attestantio/go-eth2-client/spec/bellatrix"
-	"github.com/attestantio/go-eth2-client/spec/phase0"
-	boostTypes "github.com/flashbots/go-boost-utils/types"
 	"github.com/stretchr/testify/require"
 )
-
-func TestBoostBidToBidTrace(t *testing.T) {
-	bidTrace := boostTypes.BidTrace{
-		Slot:                 uint64(25),
-		ParentHash:           boostTypes.Hash{0x02, 0x03},
-		BuilderPubkey:        boostTypes.PublicKey{0x04, 0x05},
-		ProposerPubkey:       boostTypes.PublicKey{0x06, 0x07},
-		ProposerFeeRecipient: boostTypes.Address{0x08, 0x09},
-		GasLimit:             uint64(50),
-		GasUsed:              uint64(100),
-		Value:                boostTypes.U256Str{0x0a},
-	}
-	convertedBidTrace := BoostBidToBidTrace(&bidTrace)
-	require.Equal(t, bidTrace.Slot, convertedBidTrace.Slot)
-	require.Equal(t, phase0.Hash32(bidTrace.ParentHash), convertedBidTrace.ParentHash)
-	require.Equal(t, phase0.BLSPubKey(bidTrace.BuilderPubkey), convertedBidTrace.BuilderPubkey)
-	require.Equal(t, phase0.BLSPubKey(bidTrace.ProposerPubkey), convertedBidTrace.ProposerPubkey)
-	require.Equal(t, bellatrix.ExecutionAddress(bidTrace.ProposerFeeRecipient), convertedBidTrace.ProposerFeeRecipient)
-	require.Equal(t, bidTrace.GasLimit, convertedBidTrace.GasLimit)
-	require.Equal(t, bidTrace.GasUsed, convertedBidTrace.GasUsed)
-	require.Equal(t, bidTrace.Value.BigInt().String(), convertedBidTrace.Value.ToBig().String())
-}
 
 func TestDataVersion(t *testing.T) {
 	require.Equal(t, ForkVersionStringBellatrix, consensusspec.DataVersionBellatrix.String())

--- a/common/utils.go
+++ b/common/utils.go
@@ -213,7 +213,7 @@ func CreateTestBlockSubmission(t *testing.T, builderPubkey string, value *big.In
 	builderPk, err := StrToPhase0Pubkey(builderPubkey)
 	require.NoError(t, err)
 
-	payload = &BuilderSubmitBlockRequest{ //nolint:exhaustruct
+	payload = &BuilderSubmitBlockRequest{
 		Capella: &capella.SubmitBlockRequest{
 			Message: &v1.BidTrace{ //nolint:exhaustruct
 				BuilderPubkey:  builderPk,

--- a/database/typesconv_test.go
+++ b/database/typesconv_test.go
@@ -24,5 +24,5 @@ func TestExecutionPayloadEntryToExecutionPayload(t *testing.T) {
 
 	payload, err := ExecutionPayloadEntryToExecutionPayload(entry)
 	require.NoError(t, err)
-	require.Equal(t, "0x1bafdc454116b605005364976b134d761dd736cb4788d25c835783b46daeb121", payload.Capella.Capella.BlockHash.String())
+	require.Equal(t, "0x1bafdc454116b605005364976b134d761dd736cb4788d25c835783b46daeb121", payload.Capella.BlockHash.String())
 }

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/attestantio/go-builder-client/api"
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/flashbots/go-boost-utils/types"
 	"github.com/flashbots/mev-boost-relay/beaconclient"
@@ -190,7 +191,7 @@ func (ds *Datastore) SaveValidatorRegistration(entry types.SignedValidatorRegist
 }
 
 // GetGetPayloadResponse returns the getPayload response from memory or Redis or Database
-func (ds *Datastore) GetGetPayloadResponse(log *logrus.Entry, slot uint64, proposerPubkey, blockHash string) (*common.VersionedExecutionPayload, error) {
+func (ds *Datastore) GetGetPayloadResponse(log *logrus.Entry, slot uint64, proposerPubkey, blockHash string) (*api.VersionedExecutionPayload, error) {
 	log = log.WithField("datastoreMethod", "GetGetPayloadResponse")
 	_proposerPubkey := strings.ToLower(proposerPubkey)
 	_blockHash := strings.ToLower(blockHash)

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -46,7 +46,7 @@ func TestGetPayloadDatabaseFallback(t *testing.T) {
 	ds := setupTestDatastore(t, mockDB)
 	payload, err := ds.GetGetPayloadResponse(common.TestLog, 1, "a", "b")
 	require.NoError(t, err)
-	require.Equal(t, "0x1bafdc454116b605005364976b134d761dd736cb4788d25c835783b46daeb121", payload.Capella.Capella.BlockHash.String())
+	require.Equal(t, "0x1bafdc454116b605005364976b134d761dd736cb4788d25c835783b46daeb121", payload.Capella.BlockHash.String())
 }
 
 // func TestProdProposerValidatorRegistration(t *testing.T) {

--- a/datastore/execution_payload.go
+++ b/datastore/execution_payload.go
@@ -1,9 +1,12 @@
 package datastore
 
-import "github.com/flashbots/mev-boost-relay/common"
+import (
+	"github.com/attestantio/go-builder-client/api"
+	"github.com/flashbots/mev-boost-relay/common"
+)
 
 // ExecutionPayloadRepository defines methods to fetch and store execution engine payloads
 type ExecutionPayloadRepository interface {
-	GetExecutionPayload(slot uint64, proposerPubKey, blockHash string) (*common.VersionedExecutionPayload, error)
+	GetExecutionPayload(slot uint64, proposerPubKey, blockHash string) (*api.VersionedExecutionPayload, error)
 	SaveExecutionPayload(slot uint64, proposerPubKey, blockHash string, payload *common.GetPayloadResponse) error
 }

--- a/datastore/memcached.go
+++ b/datastore/memcached.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/attestantio/go-builder-client/api"
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/flashbots/go-utils/cli"
 	"github.com/flashbots/mev-boost-relay/common"
@@ -39,7 +40,7 @@ func (m *Memcached) SaveExecutionPayload(slot uint64, proposerPubKey, blockHash 
 
 // GetExecutionPayload attempts to fetch execution engine payload from memcached using composite key of slot,
 // proposer public key, block hash, and cache prefix if specified.
-func (m *Memcached) GetExecutionPayload(slot uint64, proposerPubKey, blockHash string) (*common.VersionedExecutionPayload, error) {
+func (m *Memcached) GetExecutionPayload(slot uint64, proposerPubKey, blockHash string) (*api.VersionedExecutionPayload, error) {
 	// TODO: standardize key format with redis cache and re-use the same function(s)
 	key := fmt.Sprintf("boost-relay/%s:cache-getpayload-response:%d_%s_%s", m.keyPrefix, slot, proposerPubKey, blockHash)
 	item, err := m.client.Get(key)
@@ -47,7 +48,7 @@ func (m *Memcached) GetExecutionPayload(slot uint64, proposerPubKey, blockHash s
 		return nil, err
 	}
 
-	result := new(common.VersionedExecutionPayload)
+	result := new(api.VersionedExecutionPayload)
 	if err = result.UnmarshalJSON(item.Value); err != nil {
 		return nil, err
 	}

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -367,8 +367,8 @@ func (r *RedisCache) SaveExecutionPayloadCapella(ctx context.Context, tx redis.P
 	return tx.Set(ctx, key, b, expiryBidCache).Err()
 }
 
-func (r *RedisCache) GetExecutionPayloadCapella(slot uint64, proposerPubkey, blockHash string) (*common.VersionedExecutionPayload, error) {
-	resp := new(common.VersionedExecutionPayload)
+func (r *RedisCache) GetExecutionPayloadCapella(slot uint64, proposerPubkey, blockHash string) (*api.VersionedExecutionPayload, error) {
+	resp := new(api.VersionedExecutionPayload)
 	capellaPayload := new(capella.ExecutionPayload)
 
 	key := r.keyExecPayloadCapella(slot, proposerPubkey, blockHash)
@@ -382,9 +382,8 @@ func (r *RedisCache) GetExecutionPayloadCapella(slot uint64, proposerPubkey, blo
 		return nil, err
 	}
 
-	resp.Capella = new(api.VersionedExecutionPayload)
-	resp.Capella.Capella = capellaPayload
-	resp.Capella.Version = consensusspec.DataVersionCapella
+	resp.Capella = capellaPayload
+	resp.Version = consensusspec.DataVersionCapella
 	return resp, nil
 }
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1391,7 +1391,8 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 	// respond to the HTTP request
 	api.RespondOK(w, getPayloadResp)
 	log = log.WithFields(logrus.Fields{
-		"numTx":       getPayloadResp.NumTx(),
+		// TODO: get tx field when https://github.com/attestantio/go-builder-client/pull/14 is merged
+		// "numTx":       getPayloadResp.NumTx(),
 		"blockNumber": payload.BlockNumber(),
 	})
 	log.Info("execution payload delivered")

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -370,7 +370,6 @@ func TestDataApiGetDataProposerPayloadDelivered(t *testing.T) {
 
 		for _, invalidBlockHash := range invalidBlockHashes {
 			rr := backend.request(http.MethodGet, path+"?block_hash="+invalidBlockHash, nil)
-			t.Log(invalidBlockHash)
 			require.Equal(t, http.StatusBadRequest, rr.Code)
 			require.Contains(t, rr.Body.String(), "invalid block_hash argument")
 		}
@@ -383,8 +382,6 @@ func TestBuilderSubmitBlockSSZ(t *testing.T) {
 	req := new(common.BuilderSubmitBlockRequest)
 	err := json.Unmarshal(requestPayloadJSONBytes, &req)
 	require.NoError(t, err)
-
-	t.Log(req.Capella)
 
 	reqSSZ, err := req.Capella.MarshalSSZ()
 	require.NoError(t, err)

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -16,7 +16,6 @@ import (
 	builderCapella "github.com/attestantio/go-builder-client/api/capella"
 	v1 "github.com/attestantio/go-builder-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/flashbots/go-boost-utils/bls"
 	"github.com/flashbots/go-boost-utils/types"
 	"github.com/flashbots/mev-boost-relay/beaconclient"
@@ -385,6 +384,8 @@ func TestBuilderSubmitBlockSSZ(t *testing.T) {
 	err := json.Unmarshal(requestPayloadJSONBytes, &req)
 	require.NoError(t, err)
 
+	t.Log(req.Capella)
+
 	reqSSZ, err := req.Capella.MarshalSSZ()
 	require.NoError(t, err)
 	require.Equal(t, 352239, len(reqSSZ))
@@ -407,7 +408,8 @@ func TestBuilderSubmitBlock(t *testing.T) {
 	parentHash := "0xbd3291854dc822b7ec585925cda0e18f06af28fa2886e15f52d52dd4b6f94ed6"
 	feeRec, err := types.HexToAddress("0x5cc0dde14e7256340cc820415a6022a7d1c93a35")
 	require.NoError(t, err)
-	withdrawalsRoot, err := hexutil.Decode("0xb15ed76298ff84a586b1d875df08b6676c98dfe9c7cd73fab88450348d8e70c8")
+	var withdrawalsRoot types.Hash
+	err = withdrawalsRoot.UnmarshalText([]byte("0xb15ed76298ff84a586b1d875df08b6676c98dfe9c7cd73fab88450348d8e70c8"))
 	require.NoError(t, err)
 	prevRandao := "0x9962816e9d0a39fd4c80935338a741dc916d1545694e41eb5a505e1a3098f9e4"
 

--- a/services/api/utils.go
+++ b/services/api/utils.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 
+	"github.com/attestantio/go-builder-client/api"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	utilcapella "github.com/attestantio/go-eth2-client/util/capella"
@@ -46,33 +47,7 @@ func ComputeWithdrawalsRoot(w []*capella.Withdrawal) (phase0.Root, error) {
 	return withdrawals.HashTreeRoot()
 }
 
-func EqExecutionPayloadToHeader(bb *common.SignedBlindedBeaconBlock, payload *common.VersionedExecutionPayload) error {
-	if bb.Bellatrix != nil { // process Bellatrix beacon block
-		if payload.Bellatrix == nil {
-			return ErrPayloadMismatchBellatrix
-		}
-		bbHeaderHtr, err := bb.Bellatrix.Message.Body.ExecutionPayloadHeader.HashTreeRoot()
-		if err != nil {
-			return err
-		}
-
-		payloadHeader, err := boostTypes.PayloadToPayloadHeader(payload.Bellatrix.Data)
-		if err != nil {
-			return err
-		}
-		payloadHeaderHtr, err := payloadHeader.HashTreeRoot()
-		if err != nil {
-			return err
-		}
-
-		if bbHeaderHtr != payloadHeaderHtr {
-			return ErrHeaderHTRMismatch
-		}
-
-		// bellatrix block and payload are equal
-		return nil
-	}
-
+func EqExecutionPayloadToHeader(bb *common.SignedBlindedBeaconBlock, payload *api.VersionedExecutionPayload) error {
 	if bb.Capella != nil { // process Capella beacon block
 		if payload.Capella == nil {
 			return ErrPayloadMismatchCapella
@@ -83,7 +58,7 @@ func EqExecutionPayloadToHeader(bb *common.SignedBlindedBeaconBlock, payload *co
 			return err
 		}
 
-		payloadHeader, err := common.CapellaPayloadToPayloadHeader(payload.Capella.Capella)
+		payloadHeader, err := common.CapellaPayloadToPayloadHeader(payload.Capella)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Removing bellatrix from wrapper types as part of https://github.com/flashbots/mev-boost-relay/issues/476 to migrate to attestant types.
## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
