### PR TITLE
refactor(redis): rename tx to pipeliner

### DIFF
--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -491,8 +491,8 @@ func TestGetBuilderLatestValue(t *testing.T) {
 		},
 	}
 
-	_, err = cache.client.TxPipelined(context.Background(), func(tx redis.Pipeliner) error {
-		return cache.SaveBuilderBid(context.Background(), tx, slot, parentHash, proposerPubkey, builderPubkey, time.Now().UTC(), getHeaderResp)
+	_, err = cache.client.TxPipelined(context.Background(), func(pipeliner redis.Pipeliner) error {
+		return cache.SaveBuilderBid(context.Background(), pipeliner, slot, parentHash, proposerPubkey, builderPubkey, time.Now().UTC(), getHeaderResp)
 	})
 	require.NoError(t, err)
 
@@ -518,7 +518,7 @@ func TestPipelineNilCheck(t *testing.T) {
 // 	err := cache.client.Set(context.Background(), key1, val, 0).Err()
 // 	require.NoError(t, err)
 
-// 	_, err = cache.client.TxPipelined(context.Background(), func(tx redis.Pipeliner) error {
+// 	_, err = cache.client.TxPipelined(context.Background(), func(pipeliner redis.Pipeliner) error {
 // 		c := tx.Get(context.Background(), key1)
 // 		_, err := tx.Exec(context.Background())
 // 		require.NoError(t, err)

--- a/datastore/utils.go
+++ b/datastore/utils.go
@@ -13,10 +13,10 @@ type BuilderBids struct {
 	bidValues map[string]*big.Int
 }
 
-func NewBuilderBidsFromRedis(ctx context.Context, r *RedisCache, tx redis.Pipeliner, slot uint64, parentHash, proposerPubkey string) (*BuilderBids, error) {
+func NewBuilderBidsFromRedis(ctx context.Context, r *RedisCache, pipeliner redis.Pipeliner, slot uint64, parentHash, proposerPubkey string) (*BuilderBids, error) {
 	keyBidValues := r.keyBlockBuilderLatestBidsValue(slot, parentHash, proposerPubkey)
-	c := tx.HGetAll(ctx, keyBidValues)
-	_, err := tx.Exec(ctx)
+	c := pipeliner.HGetAll(ctx, keyBidValues)
+	_, err := pipeliner.Exec(ctx)
 	if err != nil && !errors.Is(err, redis.Nil) {
 		return nil, err
 	}


### PR DESCRIPTION
"transaction" is exactly what we shouldn't call the pipeliner. Redis offers both, the latter differs precisely in that it is not atomic.

* [x] `make lint`. (a lot of depguard errors, but not related to these changes.)
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`