### PR TITLE
Fix false positive in boolean flag

### DIFF
--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -513,7 +513,6 @@ func (r *RedisCache) SaveBidAndUpdateTopBid(ctx context.Context, tx redis.Pipeli
 	if err != nil {
 		return state, err
 	}
-	state.WasBidSaved = true
 	builderBids.bidValues[payload.BuilderPubkey().String()] = payload.Value()
 
 	// Record time needed to save bid
@@ -543,6 +542,8 @@ func (r *RedisCache) SaveBidAndUpdateTopBid(ctx context.Context, tx redis.Pipeli
 		return state, err
 	}
 	state.IsNewTopBid = payload.Value().Cmp(state.TopBidValue) == 0
+	// An Exec happens in _updateTopBid.
+	state.WasBidSaved = true
 
 	// Record time needed to update top bid
 	nextTime = time.Now().UTC()


### PR DESCRIPTION
This caused some head scratching whilst debugging. Not sure about what to do here. Closing this in favor of a different diff is fine by me.

In short, we set a boolean flag `WasBidSaved`, which we also log as `wasBidSavedInRedis` as soon as we add a command to store the bid to the pipeline. But, when top bid == prev top bid, we return early and never execute the pipeline, making the flag a false positive. It and `WasTopBidUpdated` are also false positives in six or so early-return error branches, but currently do not get used in those scenarios.

⚠️ NOTE
Because this flag returned a false positive, Redis would not store the bid, but because we say it did, in `handleSubmitNewBlock`, memcached would actually store the payload! If I'm not mistaken, this would mean for bids which hit this path, when the proposer asks for a payload, it would not be found in Redis, but get served from memcached instead of postgres. For this narrow case, fixing the false positive would lead to worse performance for "non top bid bids".

Getting rid of the false positive is great, but the location the flag ends up getting set in is rather counter-intuitive. I think it's worth the trade-off, perhaps someone has ideas for how to better set this flag the first time Exec is called which happens to be in another function entirely. Perhaps it was never even the intention to drop the queued commands in the pipeline. Not sure.


---

## ✅ I have run these commands

* [x] `make lint`. Many errors, none my code.
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
