### PR TITLE
Replace some expectCont with expectOk

### DIFF
--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -744,7 +744,7 @@ func TestCheckSubmissionSlotDetails(t *testing.T) {
 					},
 				},
 			},
-			expectCont: false,
+			expectOk: false,
 		},
 		{
 			description: "non_deneb_slot",
@@ -761,7 +761,7 @@ func TestCheckSubmissionSlotDetails(t *testing.T) {
 					},
 				},
 			},
-			expectCont: false,
+			expectOk: false,
 		},
 		{
 			description: "failure_past_slot",


### PR DESCRIPTION
## 📝 Summary

Looks there were a couple of leftover `expectCont` that didn't get renamed. Probably new tests.

## ⛱ Motivation and Context

This are unknown fields and will cause test failures.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
