### PR TITLE
Make attestantio import names consistent

### DIFF
--- a/common/ssz_test.go
+++ b/common/ssz_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/attestantio/go-builder-client/api/capella"
-	"github.com/attestantio/go-builder-client/spec"
+	builderApiCapella "github.com/attestantio/go-builder-client/api/capella"
+	builderSpec "github.com/attestantio/go-builder-client/spec"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
 )
@@ -45,7 +45,7 @@ func TestSSZBuilderSubmission(t *testing.T) {
 }
 
 func TestSSZGetHeaderResponse(t *testing.T) {
-	payload := new(spec.VersionedSignedBuilderBid)
+	payload := new(builderSpec.VersionedSignedBuilderBid)
 
 	byteValue, err := os.ReadFile("../testdata/getHeaderResponseCapella_Mainnet.json")
 	require.NoError(t, err)
@@ -72,14 +72,14 @@ func BenchmarkDecoding(b *testing.B) {
 	sszBytes, err := os.ReadFile("../testdata/getHeaderResponseCapella_Mainnet.ssz")
 	require.NoError(b, err)
 
-	payload := new(spec.VersionedSignedBuilderBid)
+	payload := new(builderSpec.VersionedSignedBuilderBid)
 	b.Run("json", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			err = json.Unmarshal(jsonBytes, &payload)
 			require.NoError(b, err)
 		}
 	})
-	payload.Capella = new(capella.SignedBuilderBid)
+	payload.Capella = new(builderApiCapella.SignedBuilderBid)
 	b.Run("ssz", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			err = payload.Capella.UnmarshalSSZ(sszBytes)

--- a/common/types.go
+++ b/common/types.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"strings"
 
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
-	consensusbellatrix "github.com/attestantio/go-eth2-client/spec/bellatrix"
-	consensuscapella "github.com/attestantio/go-eth2-client/spec/capella"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/flashbots/go-boost-utils/ssz"
 	boostTypes "github.com/flashbots/go-boost-utils/types"
@@ -163,13 +163,13 @@ func (p PubkeyHex) String() string {
 }
 
 type BuilderGetValidatorsResponseEntry struct {
-	Slot           uint64                             `json:"slot,string"`
-	ValidatorIndex uint64                             `json:"validator_index,string"`
-	Entry          *apiv1.SignedValidatorRegistration `json:"entry"`
+	Slot           uint64                                    `json:"slot,string"`
+	ValidatorIndex uint64                                    `json:"validator_index,string"`
+	Entry          *builderApiV1.SignedValidatorRegistration `json:"entry"`
 }
 
 type BidTraceV2 struct {
-	apiv1.BidTrace
+	builderApiV1.BidTrace
 	BlockNumber uint64 `db:"block_number" json:"block_number,string"`
 	NumTx       uint64 `db:"num_tx"       json:"num_tx,string"`
 }
@@ -216,7 +216,7 @@ func (b *BidTraceV2) UnmarshalJSON(data []byte) error {
 	b.NumTx = params.NumTx
 	b.BlockNumber = params.BlockNumber
 
-	bidTrace := new(apiv1.BidTrace)
+	bidTrace := new(builderApiV1.BidTrace)
 	err = json.Unmarshal(data, bidTrace)
 	if err != nil {
 		return err
@@ -303,7 +303,7 @@ func (b *BidTraceV2WithTimestampJSON) ToCSVRecord() []string {
 }
 
 type BlockSubmissionInfo struct {
-	BidTrace                   *apiv1.BidTrace
+	BidTrace                   *builderApiV1.BidTrace
 	Slot                       uint64
 	BlockHash                  phase0.Hash32
 	ParentHash                 phase0.Hash32
@@ -311,7 +311,7 @@ type BlockSubmissionInfo struct {
 	ExecutionPayloadParentHash phase0.Hash32
 	Builder                    phase0.BLSPubKey
 	Proposer                   phase0.BLSPubKey
-	ProposerFeeRecipient       consensusbellatrix.ExecutionAddress
+	ProposerFeeRecipient       bellatrix.ExecutionAddress
 	GasUsed                    uint64
 	GasLimit                   uint64
 	Timestamp                  uint64
@@ -319,6 +319,6 @@ type BlockSubmissionInfo struct {
 	Value                      *uint256.Int
 	PrevRandao                 phase0.Hash32
 	Signature                  phase0.BLSSignature
-	Transactions               []consensusbellatrix.Transaction
-	Withdrawals                []*consensuscapella.Withdrawal
+	Transactions               []bellatrix.Transaction
+	Withdrawals                []*capella.Withdrawal
 }

--- a/common/types_spec.go
+++ b/common/types_spec.go
@@ -4,18 +4,18 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/attestantio/go-builder-client/api"
-	"github.com/attestantio/go-builder-client/api/capella"
-	"github.com/attestantio/go-builder-client/api/deneb"
-	"github.com/attestantio/go-builder-client/spec"
-	consensusapi "github.com/attestantio/go-eth2-client/api"
-	apiv1capella "github.com/attestantio/go-eth2-client/api/v1/capella"
-	apiv1deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
-	consensusspec "github.com/attestantio/go-eth2-client/spec"
-	consensuscapella "github.com/attestantio/go-eth2-client/spec/capella"
-	consensusdeneb "github.com/attestantio/go-eth2-client/spec/deneb"
+	builderApi "github.com/attestantio/go-builder-client/api"
+	builderApiCapella "github.com/attestantio/go-builder-client/api/capella"
+	builderApiDeneb "github.com/attestantio/go-builder-client/api/deneb"
+	builderSpec "github.com/attestantio/go-builder-client/spec"
+	eth2Api "github.com/attestantio/go-eth2-client/api"
+	eth2ApiV1Capella "github.com/attestantio/go-eth2-client/api/v1/capella"
+	eth2ApiV1Deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/capella"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	utildeneb "github.com/attestantio/go-eth2-client/util/deneb"
+	eth2UtilDeneb "github.com/attestantio/go-eth2-client/util/deneb"
 	"github.com/flashbots/go-boost-utils/bls"
 	"github.com/flashbots/go-boost-utils/ssz"
 	boostTypes "github.com/flashbots/go-boost-utils/types"
@@ -39,7 +39,7 @@ var NilResponse = struct{}{}
 
 var ZeroU256 = boostTypes.IntToU256(0)
 
-func BuildGetHeaderResponse(payload *VersionedSubmitBlockRequest, sk *bls.SecretKey, pubkey *phase0.BLSPubKey, domain phase0.Domain) (*spec.VersionedSignedBuilderBid, error) {
+func BuildGetHeaderResponse(payload *VersionedSubmitBlockRequest, sk *bls.SecretKey, pubkey *phase0.BLSPubKey, domain phase0.Domain) (*builderSpec.VersionedSignedBuilderBid, error) {
 	if payload == nil {
 		return nil, ErrMissingRequest
 	}
@@ -48,9 +48,9 @@ func BuildGetHeaderResponse(payload *VersionedSubmitBlockRequest, sk *bls.Secret
 		return nil, ErrMissingSecretKey
 	}
 
-	versionedPayload := &api.VersionedExecutionPayload{Version: payload.Version}
+	versionedPayload := &builderApi.VersionedExecutionPayload{Version: payload.Version}
 	switch payload.Version {
-	case consensusspec.DataVersionCapella:
+	case spec.DataVersionCapella:
 		versionedPayload.Capella = payload.Capella.ExecutionPayload
 		header, err := utils.PayloadToPayloadHeader(versionedPayload)
 		if err != nil {
@@ -60,11 +60,11 @@ func BuildGetHeaderResponse(payload *VersionedSubmitBlockRequest, sk *bls.Secret
 		if err != nil {
 			return nil, err
 		}
-		return &spec.VersionedSignedBuilderBid{
-			Version: consensusspec.DataVersionCapella,
+		return &builderSpec.VersionedSignedBuilderBid{
+			Version: spec.DataVersionCapella,
 			Capella: signedBuilderBid.Capella,
 		}, nil
-	case consensusspec.DataVersionDeneb:
+	case spec.DataVersionDeneb:
 		versionedPayload.Deneb = payload.Deneb.ExecutionPayload
 		header, err := utils.PayloadToPayloadHeader(versionedPayload)
 		if err != nil {
@@ -74,47 +74,47 @@ func BuildGetHeaderResponse(payload *VersionedSubmitBlockRequest, sk *bls.Secret
 		if err != nil {
 			return nil, err
 		}
-		return &spec.VersionedSignedBuilderBid{
-			Version: consensusspec.DataVersionDeneb,
+		return &builderSpec.VersionedSignedBuilderBid{
+			Version: spec.DataVersionDeneb,
 			Deneb:   signedBuilderBid.Deneb,
 		}, nil
-	case consensusspec.DataVersionUnknown, consensusspec.DataVersionPhase0, consensusspec.DataVersionAltair, consensusspec.DataVersionBellatrix:
+	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair, spec.DataVersionBellatrix:
 		return nil, ErrInvalidVersion
 	default:
 		return nil, ErrEmptyPayload
 	}
 }
 
-func BuildGetPayloadResponse(payload *VersionedSubmitBlockRequest) (*api.VersionedSubmitBlindedBlockResponse, error) {
+func BuildGetPayloadResponse(payload *VersionedSubmitBlockRequest) (*builderApi.VersionedSubmitBlindedBlockResponse, error) {
 	switch payload.Version {
-	case consensusspec.DataVersionCapella:
-		return &api.VersionedSubmitBlindedBlockResponse{
-			Version: consensusspec.DataVersionCapella,
+	case spec.DataVersionCapella:
+		return &builderApi.VersionedSubmitBlindedBlockResponse{
+			Version: spec.DataVersionCapella,
 			Capella: payload.Capella.ExecutionPayload,
 		}, nil
-	case consensusspec.DataVersionDeneb:
-		return &api.VersionedSubmitBlindedBlockResponse{
-			Version: consensusspec.DataVersionDeneb,
-			Deneb: &deneb.ExecutionPayloadAndBlobsBundle{
+	case spec.DataVersionDeneb:
+		return &builderApi.VersionedSubmitBlindedBlockResponse{
+			Version: spec.DataVersionDeneb,
+			Deneb: &builderApiDeneb.ExecutionPayloadAndBlobsBundle{
 				ExecutionPayload: payload.Deneb.ExecutionPayload,
 				BlobsBundle:      payload.Deneb.BlobsBundle,
 			},
 		}, nil
-	case consensusspec.DataVersionUnknown, consensusspec.DataVersionPhase0, consensusspec.DataVersionAltair, consensusspec.DataVersionBellatrix:
+	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair, spec.DataVersionBellatrix:
 		return nil, ErrInvalidVersion
 	}
 	return nil, ErrEmptyPayload
 }
 
-func BuilderBlockRequestToSignedBuilderBid(payload *VersionedSubmitBlockRequest, header *api.VersionedExecutionPayloadHeader, sk *bls.SecretKey, pubkey *phase0.BLSPubKey, domain phase0.Domain) (*spec.VersionedSignedBuilderBid, error) {
+func BuilderBlockRequestToSignedBuilderBid(payload *VersionedSubmitBlockRequest, header *builderApi.VersionedExecutionPayloadHeader, sk *bls.SecretKey, pubkey *phase0.BLSPubKey, domain phase0.Domain) (*builderSpec.VersionedSignedBuilderBid, error) {
 	value, err := payload.Value()
 	if err != nil {
 		return nil, err
 	}
 
 	switch payload.Version {
-	case consensusspec.DataVersionCapella:
-		builderBid := capella.BuilderBid{
+	case spec.DataVersionCapella:
+		builderBid := builderApiCapella.BuilderBid{
 			Value:  value,
 			Header: header.Capella,
 			Pubkey: *pubkey,
@@ -125,30 +125,30 @@ func BuilderBlockRequestToSignedBuilderBid(payload *VersionedSubmitBlockRequest,
 			return nil, err
 		}
 
-		return &spec.VersionedSignedBuilderBid{
-			Version: consensusspec.DataVersionCapella,
-			Capella: &capella.SignedBuilderBid{
+		return &builderSpec.VersionedSignedBuilderBid{
+			Version: spec.DataVersionCapella,
+			Capella: &builderApiCapella.SignedBuilderBid{
 				Message:   &builderBid,
 				Signature: sig,
 			},
 		}, nil
-	case consensusspec.DataVersionDeneb:
+	case spec.DataVersionDeneb:
 		var blobRoots []phase0.Root
 		for i, blob := range payload.Deneb.BlobsBundle.Blobs {
-			blobRootHelper := utildeneb.BeaconBlockBlob{Blob: blob}
+			blobRootHelper := eth2UtilDeneb.BeaconBlockBlob{Blob: blob}
 			root, err := blobRootHelper.HashTreeRoot()
 			if err != nil {
 				return nil, errors.Wrap(err, fmt.Sprintf("failed to calculate blob root at blob index %d", i))
 			}
 			blobRoots = append(blobRoots, root)
 		}
-		blindedBlobRoots := deneb.BlindedBlobsBundle{
+		blindedBlobRoots := builderApiDeneb.BlindedBlobsBundle{
 			Commitments: payload.Deneb.BlobsBundle.Commitments,
 			Proofs:      payload.Deneb.BlobsBundle.Proofs,
 			BlobRoots:   blobRoots,
 		}
 
-		builderBid := deneb.BuilderBid{
+		builderBid := builderApiDeneb.BuilderBid{
 			Value:              value,
 			Header:             header.Deneb,
 			BlindedBlobsBundle: &blindedBlobRoots,
@@ -160,52 +160,52 @@ func BuilderBlockRequestToSignedBuilderBid(payload *VersionedSubmitBlockRequest,
 			return nil, err
 		}
 
-		return &spec.VersionedSignedBuilderBid{
-			Version: consensusspec.DataVersionDeneb,
-			Deneb: &deneb.SignedBuilderBid{
+		return &builderSpec.VersionedSignedBuilderBid{
+			Version: spec.DataVersionDeneb,
+			Deneb: &builderApiDeneb.SignedBuilderBid{
 				Message:   &builderBid,
 				Signature: sig,
 			},
 		}, nil
-	case consensusspec.DataVersionUnknown, consensusspec.DataVersionPhase0, consensusspec.DataVersionAltair, consensusspec.DataVersionBellatrix:
+	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair, spec.DataVersionBellatrix:
 		fallthrough
 	default:
 		return nil, errors.Wrap(ErrInvalidVersion, fmt.Sprintf("%s is not supported", payload.Version.String()))
 	}
 }
 
-func SignedBlindedBeaconBlockToBeaconBlock(signedBlindedBeaconBlock *VersionedSignedBlindedBlockRequest, blockPayload *api.VersionedSubmitBlindedBlockResponse) (*VersionedSignedBlockRequest, error) {
+func SignedBlindedBeaconBlockToBeaconBlock(signedBlindedBeaconBlock *VersionedSignedBlindedBlockRequest, blockPayload *builderApi.VersionedSubmitBlindedBlockResponse) (*VersionedSignedBlockRequest, error) {
 	signedBeaconBlock := VersionedSignedBlockRequest{
-		consensusapi.VersionedBlockRequest{ //nolint:exhaustruct
+		eth2Api.VersionedBlockRequest{ //nolint:exhaustruct
 			Version: signedBlindedBeaconBlock.Version,
 		},
 	}
 	switch signedBlindedBeaconBlock.Version {
-	case consensusspec.DataVersionCapella:
+	case spec.DataVersionCapella:
 		capellaBlindedBlock := signedBlindedBeaconBlock.Capella
 		signedBeaconBlock.Capella = CapellaUnblindSignedBlock(capellaBlindedBlock, blockPayload.Capella)
-	case consensusspec.DataVersionDeneb:
+	case spec.DataVersionDeneb:
 		denebBlindedBlock := signedBlindedBeaconBlock.Deneb.SignedBlindedBlock
 		blockRoot, err := denebBlindedBlock.Message.HashTreeRoot()
 		if err != nil {
 			return nil, err
 		}
 		signedBeaconBlock.Deneb = DenebUnblindSignedBlock(denebBlindedBlock, blockPayload.Deneb, blockRoot)
-	case consensusspec.DataVersionUnknown, consensusspec.DataVersionPhase0, consensusspec.DataVersionAltair, consensusspec.DataVersionBellatrix:
+	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair, spec.DataVersionBellatrix:
 		return nil, errors.Wrap(ErrInvalidVersion, fmt.Sprintf("%s is not supported", signedBlindedBeaconBlock.Version.String()))
 	}
 	return &signedBeaconBlock, nil
 }
 
-func CapellaUnblindSignedBlock(blindedBlock *apiv1capella.SignedBlindedBeaconBlock, executionPayload *consensuscapella.ExecutionPayload) *consensuscapella.SignedBeaconBlock {
-	return &consensuscapella.SignedBeaconBlock{
+func CapellaUnblindSignedBlock(blindedBlock *eth2ApiV1Capella.SignedBlindedBeaconBlock, executionPayload *capella.ExecutionPayload) *capella.SignedBeaconBlock {
+	return &capella.SignedBeaconBlock{
 		Signature: blindedBlock.Signature,
-		Message: &consensuscapella.BeaconBlock{
+		Message: &capella.BeaconBlock{
 			Slot:          blindedBlock.Message.Slot,
 			ProposerIndex: blindedBlock.Message.ProposerIndex,
 			ParentRoot:    blindedBlock.Message.ParentRoot,
 			StateRoot:     blindedBlock.Message.StateRoot,
-			Body: &consensuscapella.BeaconBlockBody{
+			Body: &capella.BeaconBlockBody{
 				BLSToExecutionChanges: blindedBlock.Message.Body.BLSToExecutionChanges,
 				RANDAOReveal:          blindedBlock.Message.Body.RANDAOReveal,
 				ETH1Data:              blindedBlock.Message.Body.ETH1Data,
@@ -222,14 +222,14 @@ func CapellaUnblindSignedBlock(blindedBlock *apiv1capella.SignedBlindedBeaconBlo
 	}
 }
 
-func DenebUnblindSignedBlock(blindedBlock *apiv1deneb.SignedBlindedBeaconBlock, blockPayload *deneb.ExecutionPayloadAndBlobsBundle, blockRoot phase0.Root) *apiv1deneb.SignedBlockContents {
-	denebBlobSidecars := make([]*consensusdeneb.SignedBlobSidecar, len(blockPayload.BlobsBundle.Blobs))
+func DenebUnblindSignedBlock(blindedBlock *eth2ApiV1Deneb.SignedBlindedBeaconBlock, blockPayload *builderApiDeneb.ExecutionPayloadAndBlobsBundle, blockRoot phase0.Root) *eth2ApiV1Deneb.SignedBlockContents {
+	denebBlobSidecars := make([]*deneb.SignedBlobSidecar, len(blockPayload.BlobsBundle.Blobs))
 
 	for i := range denebBlobSidecars {
-		denebBlobSidecars[i] = &consensusdeneb.SignedBlobSidecar{
-			Message: &consensusdeneb.BlobSidecar{
+		denebBlobSidecars[i] = &deneb.SignedBlobSidecar{
+			Message: &deneb.BlobSidecar{
 				BlockRoot:       blockRoot,
-				Index:           consensusdeneb.BlobIndex(i),
+				Index:           deneb.BlobIndex(i),
 				Slot:            blindedBlock.Message.Slot,
 				BlockParentRoot: blindedBlock.Message.ParentRoot,
 				ProposerIndex:   blindedBlock.Message.ProposerIndex,
@@ -240,14 +240,14 @@ func DenebUnblindSignedBlock(blindedBlock *apiv1deneb.SignedBlindedBeaconBlock, 
 			Signature: denebBlobSidecars[i].Signature,
 		}
 	}
-	return &apiv1deneb.SignedBlockContents{
-		SignedBlock: &consensusdeneb.SignedBeaconBlock{
-			Message: &consensusdeneb.BeaconBlock{
+	return &eth2ApiV1Deneb.SignedBlockContents{
+		SignedBlock: &deneb.SignedBeaconBlock{
+			Message: &deneb.BeaconBlock{
 				Slot:          blindedBlock.Message.Slot,
 				ProposerIndex: blindedBlock.Message.ProposerIndex,
 				ParentRoot:    blindedBlock.Message.ParentRoot,
 				StateRoot:     blindedBlock.Message.StateRoot,
-				Body: &consensusdeneb.BeaconBlockBody{
+				Body: &deneb.BeaconBlockBody{
 					BLSToExecutionChanges: blindedBlock.Message.Body.BLSToExecutionChanges,
 					RANDAOReveal:          blindedBlock.Message.Body.RANDAOReveal,
 					ETH1Data:              blindedBlock.Message.Body.ETH1Data,
@@ -291,23 +291,23 @@ func (r *BuilderBlockValidationRequest) MarshalJSON() ([]byte, error) {
 }
 
 type VersionedSubmitBlockRequest struct {
-	spec.VersionedSubmitBlockRequest
+	builderSpec.VersionedSubmitBlockRequest
 }
 
 func (r *VersionedSubmitBlockRequest) UnmarshalSSZ(input []byte) error {
 	var err error
 
-	deneb := new(deneb.SubmitBlockRequest)
-	if err = deneb.UnmarshalSSZ(input); err == nil {
-		r.Version = consensusspec.DataVersionDeneb
-		r.Deneb = deneb
+	builderApiDeneb := new(builderApiDeneb.SubmitBlockRequest)
+	if err = builderApiDeneb.UnmarshalSSZ(input); err == nil {
+		r.Version = spec.DataVersionDeneb
+		r.Deneb = builderApiDeneb
 		return nil
 	}
 
-	capella := new(capella.SubmitBlockRequest)
-	if err = capella.UnmarshalSSZ(input); err == nil {
-		r.Version = consensusspec.DataVersionCapella
-		r.Capella = capella
+	builderApiCapella := new(builderApiCapella.SubmitBlockRequest)
+	if err = builderApiCapella.UnmarshalSSZ(input); err == nil {
+		r.Version = spec.DataVersionCapella
+		r.Capella = builderApiCapella
 		return nil
 	}
 	return errors.Wrap(err, "failed to unmarshal SubmitBlockRequest SSZ")
@@ -315,11 +315,11 @@ func (r *VersionedSubmitBlockRequest) UnmarshalSSZ(input []byte) error {
 
 func (r *VersionedSubmitBlockRequest) MarshalJSON() ([]byte, error) {
 	switch r.Version {
-	case consensusspec.DataVersionCapella:
+	case spec.DataVersionCapella:
 		return json.Marshal(r.Capella)
-	case consensusspec.DataVersionDeneb:
+	case spec.DataVersionDeneb:
 		return json.Marshal(r.Deneb)
-	case consensusspec.DataVersionUnknown, consensusspec.DataVersionPhase0, consensusspec.DataVersionAltair, consensusspec.DataVersionBellatrix:
+	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair, spec.DataVersionBellatrix:
 		fallthrough
 	default:
 		return nil, errors.Wrap(ErrInvalidVersion, fmt.Sprintf("%d is not supported", r.Version))
@@ -329,32 +329,32 @@ func (r *VersionedSubmitBlockRequest) MarshalJSON() ([]byte, error) {
 func (r *VersionedSubmitBlockRequest) UnmarshalJSON(input []byte) error {
 	var err error
 
-	deneb := new(deneb.SubmitBlockRequest)
-	if err = json.Unmarshal(input, deneb); err == nil {
-		r.Version = consensusspec.DataVersionDeneb
-		r.Deneb = deneb
+	builderApiDeneb := new(builderApiDeneb.SubmitBlockRequest)
+	if err = json.Unmarshal(input, builderApiDeneb); err == nil {
+		r.Version = spec.DataVersionDeneb
+		r.Deneb = builderApiDeneb
 		return nil
 	}
-	capella := new(capella.SubmitBlockRequest)
-	if err = json.Unmarshal(input, capella); err == nil {
-		r.Version = consensusspec.DataVersionCapella
-		r.Capella = capella
+	builderApiCapella := new(builderApiCapella.SubmitBlockRequest)
+	if err = json.Unmarshal(input, builderApiCapella); err == nil {
+		r.Version = spec.DataVersionCapella
+		r.Capella = builderApiCapella
 		return nil
 	}
 	return errors.Wrap(err, "failed to unmarshal SubmitBlockRequest")
 }
 
 type VersionedSignedBlockRequest struct {
-	consensusapi.VersionedBlockRequest
+	eth2Api.VersionedBlockRequest
 }
 
 func (r *VersionedSignedBlockRequest) MarshalJSON() ([]byte, error) {
 	switch r.Version {
-	case consensusspec.DataVersionCapella:
+	case spec.DataVersionCapella:
 		return json.Marshal(r.Capella)
-	case consensusspec.DataVersionDeneb:
+	case spec.DataVersionDeneb:
 		return json.Marshal(r.Deneb)
-	case consensusspec.DataVersionUnknown, consensusspec.DataVersionPhase0, consensusspec.DataVersionAltair, consensusspec.DataVersionBellatrix:
+	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair, spec.DataVersionBellatrix:
 		fallthrough
 	default:
 		return nil, errors.Wrap(ErrInvalidVersion, fmt.Sprintf("%d is not supported", r.Version))
@@ -364,33 +364,33 @@ func (r *VersionedSignedBlockRequest) MarshalJSON() ([]byte, error) {
 func (r *VersionedSignedBlockRequest) UnmarshalJSON(input []byte) error {
 	var err error
 
-	deneb := new(apiv1deneb.SignedBlockContents)
-	if err = json.Unmarshal(input, deneb); err == nil {
-		r.Version = consensusspec.DataVersionDeneb
-		r.Deneb = deneb
+	builderApiDeneb := new(eth2ApiV1Deneb.SignedBlockContents)
+	if err = json.Unmarshal(input, builderApiDeneb); err == nil {
+		r.Version = spec.DataVersionDeneb
+		r.Deneb = builderApiDeneb
 		return nil
 	}
 
-	capella := new(consensuscapella.SignedBeaconBlock)
-	if err = json.Unmarshal(input, capella); err == nil {
-		r.Version = consensusspec.DataVersionCapella
-		r.Capella = capella
+	builderApiCapella := new(capella.SignedBeaconBlock)
+	if err = json.Unmarshal(input, builderApiCapella); err == nil {
+		r.Version = spec.DataVersionCapella
+		r.Capella = builderApiCapella
 		return nil
 	}
 	return errors.Wrap(err, "failed to unmarshal SignedBeaconBlockRequest")
 }
 
 type VersionedSignedBlindedBlockRequest struct {
-	consensusapi.VersionedBlindedBlockRequest
+	eth2Api.VersionedBlindedBlockRequest
 }
 
 func (r *VersionedSignedBlindedBlockRequest) MarshalJSON() ([]byte, error) {
 	switch r.Version {
-	case consensusspec.DataVersionCapella:
+	case spec.DataVersionCapella:
 		return json.Marshal(r.Capella)
-	case consensusspec.DataVersionDeneb:
+	case spec.DataVersionDeneb:
 		return json.Marshal(r.Deneb)
-	case consensusspec.DataVersionUnknown, consensusspec.DataVersionPhase0, consensusspec.DataVersionAltair, consensusspec.DataVersionBellatrix:
+	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair, spec.DataVersionBellatrix:
 		fallthrough
 	default:
 		return nil, errors.Wrap(ErrInvalidVersion, fmt.Sprintf("%d is not supported", r.Version))
@@ -400,17 +400,17 @@ func (r *VersionedSignedBlindedBlockRequest) MarshalJSON() ([]byte, error) {
 func (r *VersionedSignedBlindedBlockRequest) UnmarshalJSON(input []byte) error {
 	var err error
 
-	deneb := new(apiv1deneb.SignedBlindedBlockContents)
-	if err = json.Unmarshal(input, deneb); err == nil {
-		r.Version = consensusspec.DataVersionDeneb
-		r.Deneb = deneb
+	builderApiDeneb := new(eth2ApiV1Deneb.SignedBlindedBlockContents)
+	if err = json.Unmarshal(input, builderApiDeneb); err == nil {
+		r.Version = spec.DataVersionDeneb
+		r.Deneb = builderApiDeneb
 		return nil
 	}
 
-	capella := new(apiv1capella.SignedBlindedBeaconBlock)
-	if err = json.Unmarshal(input, capella); err == nil {
-		r.Version = consensusspec.DataVersionCapella
-		r.Capella = capella
+	builderApiCapella := new(eth2ApiV1Capella.SignedBlindedBeaconBlock)
+	if err = json.Unmarshal(input, builderApiCapella); err == nil {
+		r.Version = spec.DataVersionCapella
+		r.Capella = builderApiCapella
 		return nil
 	}
 	return errors.Wrap(err, "failed to unmarshal SignedBlindedBeaconBlock")

--- a/common/types_spec.go
+++ b/common/types_spec.go
@@ -297,17 +297,17 @@ type VersionedSubmitBlockRequest struct {
 func (r *VersionedSubmitBlockRequest) UnmarshalSSZ(input []byte) error {
 	var err error
 
-	builderApiDeneb := new(builderApiDeneb.SubmitBlockRequest)
-	if err = builderApiDeneb.UnmarshalSSZ(input); err == nil {
+	denebRequest := new(builderApiDeneb.SubmitBlockRequest)
+	if err = denebRequest.UnmarshalSSZ(input); err == nil {
 		r.Version = spec.DataVersionDeneb
-		r.Deneb = builderApiDeneb
+		r.Deneb = denebRequest
 		return nil
 	}
 
-	builderApiCapella := new(builderApiCapella.SubmitBlockRequest)
-	if err = builderApiCapella.UnmarshalSSZ(input); err == nil {
+	capellaRequest := new(builderApiCapella.SubmitBlockRequest)
+	if err = capellaRequest.UnmarshalSSZ(input); err == nil {
 		r.Version = spec.DataVersionCapella
-		r.Capella = builderApiCapella
+		r.Capella = capellaRequest
 		return nil
 	}
 	return errors.Wrap(err, "failed to unmarshal SubmitBlockRequest SSZ")
@@ -329,16 +329,17 @@ func (r *VersionedSubmitBlockRequest) MarshalJSON() ([]byte, error) {
 func (r *VersionedSubmitBlockRequest) UnmarshalJSON(input []byte) error {
 	var err error
 
-	builderApiDeneb := new(builderApiDeneb.SubmitBlockRequest)
-	if err = json.Unmarshal(input, builderApiDeneb); err == nil {
+	denebRequest := new(builderApiDeneb.SubmitBlockRequest)
+	if err = json.Unmarshal(input, denebRequest); err == nil {
 		r.Version = spec.DataVersionDeneb
-		r.Deneb = builderApiDeneb
+		r.Deneb = denebRequest
 		return nil
 	}
-	builderApiCapella := new(builderApiCapella.SubmitBlockRequest)
-	if err = json.Unmarshal(input, builderApiCapella); err == nil {
+
+	capellaRequest := new(builderApiCapella.SubmitBlockRequest)
+	if err = json.Unmarshal(input, capellaRequest); err == nil {
 		r.Version = spec.DataVersionCapella
-		r.Capella = builderApiCapella
+		r.Capella = capellaRequest
 		return nil
 	}
 	return errors.Wrap(err, "failed to unmarshal SubmitBlockRequest")
@@ -364,17 +365,17 @@ func (r *VersionedSignedBlockRequest) MarshalJSON() ([]byte, error) {
 func (r *VersionedSignedBlockRequest) UnmarshalJSON(input []byte) error {
 	var err error
 
-	builderApiDeneb := new(eth2ApiV1Deneb.SignedBlockContents)
-	if err = json.Unmarshal(input, builderApiDeneb); err == nil {
+	denebContents := new(eth2ApiV1Deneb.SignedBlockContents)
+	if err = json.Unmarshal(input, denebContents); err == nil {
 		r.Version = spec.DataVersionDeneb
-		r.Deneb = builderApiDeneb
+		r.Deneb = denebContents
 		return nil
 	}
 
-	builderApiCapella := new(capella.SignedBeaconBlock)
-	if err = json.Unmarshal(input, builderApiCapella); err == nil {
+	capellaBlock := new(capella.SignedBeaconBlock)
+	if err = json.Unmarshal(input, capellaBlock); err == nil {
 		r.Version = spec.DataVersionCapella
-		r.Capella = builderApiCapella
+		r.Capella = capellaBlock
 		return nil
 	}
 	return errors.Wrap(err, "failed to unmarshal SignedBeaconBlockRequest")
@@ -400,17 +401,17 @@ func (r *VersionedSignedBlindedBlockRequest) MarshalJSON() ([]byte, error) {
 func (r *VersionedSignedBlindedBlockRequest) UnmarshalJSON(input []byte) error {
 	var err error
 
-	builderApiDeneb := new(eth2ApiV1Deneb.SignedBlindedBlockContents)
-	if err = json.Unmarshal(input, builderApiDeneb); err == nil {
+	denebContents := new(eth2ApiV1Deneb.SignedBlindedBlockContents)
+	if err = json.Unmarshal(input, denebContents); err == nil {
 		r.Version = spec.DataVersionDeneb
-		r.Deneb = builderApiDeneb
+		r.Deneb = denebContents
 		return nil
 	}
 
-	builderApiCapella := new(eth2ApiV1Capella.SignedBlindedBeaconBlock)
-	if err = json.Unmarshal(input, builderApiCapella); err == nil {
+	capellaBlock := new(eth2ApiV1Capella.SignedBlindedBeaconBlock)
+	if err = json.Unmarshal(input, capellaBlock); err == nil {
 		r.Version = spec.DataVersionCapella
-		r.Capella = builderApiCapella
+		r.Capella = capellaBlock
 		return nil
 	}
 	return errors.Wrap(err, "failed to unmarshal SignedBlindedBeaconBlock")

--- a/common/types_spec_test.go
+++ b/common/types_spec_test.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/attestantio/go-builder-client/api/deneb"
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
-	spec "github.com/attestantio/go-builder-client/spec"
-	consensusspec "github.com/attestantio/go-eth2-client/spec"
+	builderApiDeneb "github.com/attestantio/go-builder-client/api/deneb"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
+	builderSpec "github.com/attestantio/go-builder-client/spec"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
-	denebspec "github.com/attestantio/go-eth2-client/spec/deneb"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
@@ -78,23 +78,23 @@ func TestBuildGetPayloadResponse(t *testing.T) {
 		resp, err := BuildGetPayloadResponse(submitBlockData)
 		require.NoError(t, err)
 
-		require.Equal(t, consensusspec.DataVersionCapella, resp.Version)
+		require.Equal(t, spec.DataVersionCapella, resp.Version)
 		require.Equal(t, "0x1bafdc454116b605005364976b134d761dd736cb4788d25c835783b46daeb121", resp.Capella.BlockHash.String())
 	})
 
 	t.Run("Deneb", func(t *testing.T) {
-		// TODO: (deneb) add block request from goerli / devnet
+		// TODO: (builderApiDeneb) add block request from goerli / devnet
 		submitBlockData := &VersionedSubmitBlockRequest{
-			VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-				Version: consensusspec.DataVersionDeneb,
-				Deneb: &deneb.SubmitBlockRequest{
-					ExecutionPayload: &denebspec.ExecutionPayload{
+			VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+				Version: spec.DataVersionDeneb,
+				Deneb: &builderApiDeneb.SubmitBlockRequest{
+					ExecutionPayload: &deneb.ExecutionPayload{
 						BaseFeePerGas: uint256.NewInt(123),
 						BlockHash:     phase0.Hash32{0x09},
 						Transactions:  []bellatrix.Transaction{},
 					},
-					BlobsBundle: &deneb.BlobsBundle{},
-					Message:     &apiv1.BidTrace{},
+					BlobsBundle: &builderApiDeneb.BlobsBundle{},
+					Message:     &builderApiV1.BidTrace{},
 				},
 			},
 		}
@@ -102,7 +102,7 @@ func TestBuildGetPayloadResponse(t *testing.T) {
 		resp, err := BuildGetPayloadResponse(submitBlockData)
 		require.NoError(t, err)
 
-		require.Equal(t, consensusspec.DataVersionDeneb, resp.Version)
+		require.Equal(t, spec.DataVersionDeneb, resp.Version)
 		require.Equal(t, "0x0900000000000000000000000000000000000000000000000000000000000000", resp.Deneb.ExecutionPayload.BlockHash.String())
 	})
 }

--- a/common/types_spec_test.go
+++ b/common/types_spec_test.go
@@ -83,7 +83,7 @@ func TestBuildGetPayloadResponse(t *testing.T) {
 	})
 
 	t.Run("Deneb", func(t *testing.T) {
-		// TODO: (builderApiDeneb) add block request from goerli / devnet
+		// TODO: (deneb) add block request from goerli / devnet
 		submitBlockData := &VersionedSubmitBlockRequest{
 			VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
 				Version: spec.DataVersionDeneb,

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -3,12 +3,12 @@ package common
 import (
 	"testing"
 
-	consensusspec "github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDataVersion(t *testing.T) {
-	require.Equal(t, ForkVersionStringBellatrix, consensusspec.DataVersionBellatrix.String())
-	require.Equal(t, ForkVersionStringCapella, consensusspec.DataVersionCapella.String())
-	require.Equal(t, ForkVersionStringDeneb, consensusspec.DataVersionDeneb.String())
+	require.Equal(t, ForkVersionStringBellatrix, spec.DataVersionBellatrix.String())
+	require.Equal(t, ForkVersionStringCapella, spec.DataVersionCapella.String())
+	require.Equal(t, ForkVersionStringDeneb, spec.DataVersionDeneb.String())
 }

--- a/common/utils.go
+++ b/common/utils.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/attestantio/go-builder-client/api"
-	"github.com/attestantio/go-builder-client/api/deneb"
-	consensusspec "github.com/attestantio/go-eth2-client/spec"
+	builderApi "github.com/attestantio/go-builder-client/api"
+	builderApiDeneb "github.com/attestantio/go-builder-client/api/deneb"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -276,22 +276,22 @@ func GetBlockSubmissionInfo(submission *VersionedSubmitBlockRequest) (*BlockSubm
 	}, nil
 }
 
-func GetBlockSubmissionExecutionPayload(submission *VersionedSubmitBlockRequest) (*api.VersionedSubmitBlindedBlockResponse, error) {
+func GetBlockSubmissionExecutionPayload(submission *VersionedSubmitBlockRequest) (*builderApi.VersionedSubmitBlindedBlockResponse, error) {
 	switch submission.Version {
-	case consensusspec.DataVersionCapella:
-		return &api.VersionedSubmitBlindedBlockResponse{
-			Version: consensusspec.DataVersionCapella,
+	case spec.DataVersionCapella:
+		return &builderApi.VersionedSubmitBlindedBlockResponse{
+			Version: spec.DataVersionCapella,
 			Capella: submission.Capella.ExecutionPayload,
 		}, nil
-	case consensusspec.DataVersionDeneb:
-		return &api.VersionedSubmitBlindedBlockResponse{
-			Version: consensusspec.DataVersionDeneb,
-			Deneb: &deneb.ExecutionPayloadAndBlobsBundle{
+	case spec.DataVersionDeneb:
+		return &builderApi.VersionedSubmitBlindedBlockResponse{
+			Version: spec.DataVersionDeneb,
+			Deneb: &builderApiDeneb.ExecutionPayloadAndBlobsBundle{
 				ExecutionPayload: submission.Deneb.ExecutionPayload,
 				BlobsBundle:      submission.Deneb.BlobsBundle,
 			},
 		}, nil
-	case consensusspec.DataVersionUnknown, consensusspec.DataVersionPhase0, consensusspec.DataVersionAltair, consensusspec.DataVersionBellatrix:
+	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair, spec.DataVersionBellatrix:
 		return nil, ErrInvalidForkVersion
 	}
 	return nil, ErrEmptyPayload

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -7,13 +7,13 @@ import (
 	"os"
 	"testing"
 
-	"github.com/attestantio/go-builder-client/api/bellatrix"
-	"github.com/attestantio/go-builder-client/api/capella"
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
-	"github.com/attestantio/go-builder-client/spec"
-	consensusspec "github.com/attestantio/go-eth2-client/spec"
-	consensusbellatrix "github.com/attestantio/go-eth2-client/spec/bellatrix"
-	consensuscapella "github.com/attestantio/go-eth2-client/spec/capella"
+	builderApiBellatrix "github.com/attestantio/go-builder-client/api/bellatrix"
+	builderApiCapella "github.com/attestantio/go-builder-client/api/capella"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
+	builderSpec "github.com/attestantio/go-builder-client/spec"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/ethereum/go-ethereum/common"
 	boostTypes "github.com/flashbots/go-boost-utils/types"
 	"github.com/stretchr/testify/require"
@@ -114,28 +114,28 @@ func TestGetBlockSubmissionInfo(t *testing.T) {
 		err      string
 	}{
 		{
-			name: "valid capella",
+			name: "valid builderApiCapella",
 			payload: &VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &capella.SubmitBlockRequest{
-						Message:          &apiv1.BidTrace{},
-						ExecutionPayload: &consensuscapella.ExecutionPayload{},
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
+						Message:          &builderApiV1.BidTrace{},
+						ExecutionPayload: &capella.ExecutionPayload{},
 					},
 				},
 			},
 			expected: &BlockSubmissionInfo{
-				BidTrace: &apiv1.BidTrace{},
+				BidTrace: &builderApiV1.BidTrace{},
 			},
 		},
 		{
 			name: "unsupported version",
 			payload: &VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionBellatrix,
-					Bellatrix: &bellatrix.SubmitBlockRequest{
-						Message:          &apiv1.BidTrace{},
-						ExecutionPayload: &consensusbellatrix.ExecutionPayload{},
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionBellatrix,
+					Bellatrix: &builderApiBellatrix.SubmitBlockRequest{
+						Message:          &builderApiV1.BidTrace{},
+						ExecutionPayload: &bellatrix.ExecutionPayload{},
 					},
 				},
 			},
@@ -145,8 +145,8 @@ func TestGetBlockSubmissionInfo(t *testing.T) {
 		{
 			name: "missing data",
 			payload: &VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
 				},
 			},
 			expected: nil,
@@ -155,10 +155,10 @@ func TestGetBlockSubmissionInfo(t *testing.T) {
 		{
 			name: "missing message",
 			payload: &VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &capella.SubmitBlockRequest{
-						ExecutionPayload: &consensuscapella.ExecutionPayload{},
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
+						ExecutionPayload: &capella.ExecutionPayload{},
 					},
 				},
 			},
@@ -168,10 +168,10 @@ func TestGetBlockSubmissionInfo(t *testing.T) {
 		{
 			name: "missing execution payload",
 			payload: &VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &capella.SubmitBlockRequest{
-						Message: &apiv1.BidTrace{},
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
+						Message: &builderApiV1.BidTrace{},
 					},
 				},
 			},

--- a/database/database.go
+++ b/database/database.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
 	"github.com/flashbots/mev-boost-relay/common"
 	"github.com/flashbots/mev-boost-relay/database/migrations"
 	"github.com/flashbots/mev-boost-relay/database/vars"
@@ -48,7 +48,7 @@ type IDatabaseService interface {
 	IncBlockBuilderStatsAfterGetPayload(builderPubkey string) error
 
 	InsertBuilderDemotion(submitBlockRequest *common.VersionedSubmitBlockRequest, simError error) error
-	UpdateBuilderDemotion(trace *common.BidTraceV2, signedBlock *common.VersionedSignedBlockRequest, signedRegistration *apiv1.SignedValidatorRegistration) error
+	UpdateBuilderDemotion(trace *common.BidTraceV2, signedBlock *common.VersionedSignedBlockRequest, signedRegistration *builderApiV1.SignedValidatorRegistration) error
 	GetBuilderDemotion(trace *common.BidTraceV2) (*BuilderDemotionEntry, error)
 
 	GetTooLateGetPayload(slot uint64) (entries []*TooLateGetPayloadEntry, err error)
@@ -574,7 +574,7 @@ func (s *DatabaseService) InsertBuilderDemotion(submitBlockRequest *common.Versi
 	return err
 }
 
-func (s *DatabaseService) UpdateBuilderDemotion(trace *common.BidTraceV2, signedBlock *common.VersionedSignedBlockRequest, signedRegistration *apiv1.SignedValidatorRegistration) error {
+func (s *DatabaseService) UpdateBuilderDemotion(trace *common.BidTraceV2, signedBlock *common.VersionedSignedBlockRequest, signedRegistration *builderApiV1.SignedValidatorRegistration) error {
 	_signedBeaconBlock, err := json.Marshal(signedBlock)
 	if err != nil {
 		return err

--- a/database/mockdb.go
+++ b/database/mockdb.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
 	"github.com/flashbots/mev-boost-relay/common"
 )
 
@@ -162,7 +162,7 @@ func (db MockDB) InsertBuilderDemotion(submitBlockRequest *common.VersionedSubmi
 	return nil
 }
 
-func (db MockDB) UpdateBuilderDemotion(trace *common.BidTraceV2, signedBlock *common.VersionedSignedBlockRequest, signedRegistration *apiv1.SignedValidatorRegistration) error {
+func (db MockDB) UpdateBuilderDemotion(trace *common.BidTraceV2, signedBlock *common.VersionedSignedBlockRequest, signedRegistration *builderApiV1.SignedValidatorRegistration) error {
 	pubkey := trace.BuilderPubkey.String()
 	_, ok := db.Builders[pubkey]
 	if !ok {

--- a/database/types.go
+++ b/database/types.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
 	"github.com/flashbots/go-boost-utils/utils"
 )
 
@@ -61,7 +61,7 @@ type ValidatorRegistrationEntry struct {
 	Signature    string `db:"signature"`
 }
 
-func (reg ValidatorRegistrationEntry) ToSignedValidatorRegistration() (*apiv1.SignedValidatorRegistration, error) {
+func (reg ValidatorRegistrationEntry) ToSignedValidatorRegistration() (*builderApiV1.SignedValidatorRegistration, error) {
 	pubkey, err := utils.HexToPubkey(reg.Pubkey)
 	if err != nil {
 		return nil, err
@@ -77,8 +77,8 @@ func (reg ValidatorRegistrationEntry) ToSignedValidatorRegistration() (*apiv1.Si
 		return nil, err
 	}
 
-	return &apiv1.SignedValidatorRegistration{
-		Message: &apiv1.ValidatorRegistration{
+	return &builderApiV1.SignedValidatorRegistration{
+		Message: &builderApiV1.ValidatorRegistration{
 			Pubkey:       pubkey,
 			FeeRecipient: feeRec,
 			Timestamp:    time.Unix(int64(reg.Timestamp), 0),
@@ -88,7 +88,7 @@ func (reg ValidatorRegistrationEntry) ToSignedValidatorRegistration() (*apiv1.Si
 	}, nil
 }
 
-func SignedValidatorRegistrationToEntry(valReg apiv1.SignedValidatorRegistration) ValidatorRegistrationEntry {
+func SignedValidatorRegistrationToEntry(valReg builderApiV1.SignedValidatorRegistration) ValidatorRegistrationEntry {
 	return ValidatorRegistrationEntry{
 		Pubkey:       valReg.Message.Pubkey.String(),
 		FeeRecipient: valReg.Message.FeeRecipient.String(),

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/attestantio/go-builder-client/api"
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
+	builderApi "github.com/attestantio/go-builder-client/api"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/flashbots/mev-boost-relay/beaconclient"
 	"github.com/flashbots/mev-boost-relay/common"
@@ -173,7 +173,7 @@ func (ds *Datastore) NumRegisteredValidators() (uint64, error) {
 }
 
 // SaveValidatorRegistration saves a validator registration into both Redis and the database
-func (ds *Datastore) SaveValidatorRegistration(entry apiv1.SignedValidatorRegistration) error {
+func (ds *Datastore) SaveValidatorRegistration(entry builderApiV1.SignedValidatorRegistration) error {
 	// First save in the database
 	err := ds.db.SaveValidatorRegistration(database.SignedValidatorRegistrationToEntry(entry))
 	if err != nil {
@@ -191,7 +191,7 @@ func (ds *Datastore) SaveValidatorRegistration(entry apiv1.SignedValidatorRegist
 }
 
 // GetGetPayloadResponse returns the getPayload response from memory or Redis or Database
-func (ds *Datastore) GetGetPayloadResponse(log *logrus.Entry, slot uint64, proposerPubkey, blockHash string) (*api.VersionedSubmitBlindedBlockResponse, error) {
+func (ds *Datastore) GetGetPayloadResponse(log *logrus.Entry, slot uint64, proposerPubkey, blockHash string) (*builderApi.VersionedSubmitBlindedBlockResponse, error) {
 	log = log.WithField("datastoreMethod", "GetGetPayloadResponse")
 	_proposerPubkey := strings.ToLower(proposerPubkey)
 	_blockHash := strings.ToLower(blockHash)

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/attestantio/go-builder-client/api/deneb"
-	consensusdeneb "github.com/attestantio/go-eth2-client/spec/deneb"
+	builderApiDeneb "github.com/attestantio/go-builder-client/api/deneb"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/flashbots/mev-boost-relay/common"
 	"github.com/flashbots/mev-boost-relay/database"
 	"github.com/holiman/uint256"
@@ -54,12 +54,12 @@ func TestGetPayloadDatabaseFallback(t *testing.T) {
 }
 
 func TestGetPayloadDatabaseDeneb(t *testing.T) {
-	// TODO: (deneb) add execution payload and blobs bundle from goerli / devnet
-	payloadBytes, err := json.Marshal(&deneb.ExecutionPayloadAndBlobsBundle{
-		ExecutionPayload: &consensusdeneb.ExecutionPayload{
+	// TODO: (builderApiDeneb) add execution payload and blobs bundle from goerli / devnet
+	payloadBytes, err := json.Marshal(&builderApiDeneb.ExecutionPayloadAndBlobsBundle{
+		ExecutionPayload: &deneb.ExecutionPayload{
 			BaseFeePerGas: uint256.NewInt(5),
 		},
-		BlobsBundle: &deneb.BlobsBundle{},
+		BlobsBundle: &builderApiDeneb.BlobsBundle{},
 	})
 	require.NoError(t, err)
 

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -54,7 +54,7 @@ func TestGetPayloadDatabaseFallback(t *testing.T) {
 }
 
 func TestGetPayloadDatabaseDeneb(t *testing.T) {
-	// TODO: (builderApiDeneb) add execution payload and blobs bundle from goerli / devnet
+	// TODO: (deneb) add execution payload and blobs bundle from goerli / devnet
 	payloadBytes, err := json.Marshal(&builderApiDeneb.ExecutionPayloadAndBlobsBundle{
 		ExecutionPayload: &deneb.ExecutionPayload{
 			BaseFeePerGas: uint256.NewInt(5),

--- a/datastore/execution_payload.go
+++ b/datastore/execution_payload.go
@@ -1,11 +1,11 @@
 package datastore
 
 import (
-	"github.com/attestantio/go-builder-client/api"
+	builderApi "github.com/attestantio/go-builder-client/api"
 )
 
 // ExecutionPayloadRepository defines methods to fetch and store execution engine payloads
 type ExecutionPayloadRepository interface {
-	GetExecutionPayload(slot uint64, proposerPubKey, blockHash string) (*api.VersionedSubmitBlindedBlockResponse, error)
-	SaveExecutionPayload(slot uint64, proposerPubKey, blockHash string, payload *api.VersionedSubmitBlindedBlockResponse) error
+	GetExecutionPayload(slot uint64, proposerPubKey, blockHash string) (*builderApi.VersionedSubmitBlindedBlockResponse, error)
+	SaveExecutionPayload(slot uint64, proposerPubKey, blockHash string, payload *builderApi.VersionedSubmitBlindedBlockResponse) error
 }

--- a/datastore/memcached.go
+++ b/datastore/memcached.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/attestantio/go-builder-client/api"
+	builderApi "github.com/attestantio/go-builder-client/api"
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/flashbots/go-utils/cli"
 )
@@ -24,7 +24,7 @@ type Memcached struct {
 // SaveExecutionPayload attempts to insert execution engine payload to memcached using composite key of slot,
 // proposer public key, block hash, and cache prefix if specified. Note that writes to the same key value
 // (i.e. same slot, proposer public key, and block hash) will overwrite the existing entry.
-func (m *Memcached) SaveExecutionPayload(slot uint64, proposerPubKey, blockHash string, payload *api.VersionedSubmitBlindedBlockResponse) error {
+func (m *Memcached) SaveExecutionPayload(slot uint64, proposerPubKey, blockHash string, payload *builderApi.VersionedSubmitBlindedBlockResponse) error {
 	// TODO: standardize key format with redis cache and re-use the same function(s)
 	key := fmt.Sprintf("boost-relay/%s:cache-getpayload-response:%d_%s_%s", m.keyPrefix, slot, proposerPubKey, blockHash)
 
@@ -39,7 +39,7 @@ func (m *Memcached) SaveExecutionPayload(slot uint64, proposerPubKey, blockHash 
 
 // GetExecutionPayload attempts to fetch execution engine payload from memcached using composite key of slot,
 // proposer public key, block hash, and cache prefix if specified.
-func (m *Memcached) GetExecutionPayload(slot uint64, proposerPubKey, blockHash string) (*api.VersionedSubmitBlindedBlockResponse, error) {
+func (m *Memcached) GetExecutionPayload(slot uint64, proposerPubKey, blockHash string) (*builderApi.VersionedSubmitBlindedBlockResponse, error) {
 	// TODO: standardize key format with redis cache and re-use the same function(s)
 	key := fmt.Sprintf("boost-relay/%s:cache-getpayload-response:%d_%s_%s", m.keyPrefix, slot, proposerPubKey, blockHash)
 	item, err := m.client.Get(key)
@@ -47,7 +47,7 @@ func (m *Memcached) GetExecutionPayload(slot uint64, proposerPubKey, blockHash s
 		return nil, err
 	}
 
-	result := new(api.VersionedSubmitBlindedBlockResponse)
+	result := new(builderApi.VersionedSubmitBlindedBlockResponse)
 	if err = result.UnmarshalJSON(item.Value); err != nil {
 		return nil, err
 	}

--- a/datastore/memcached_test.go
+++ b/datastore/memcached_test.go
@@ -8,15 +8,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/attestantio/go-builder-client/api"
-	"github.com/attestantio/go-builder-client/api/capella"
-	"github.com/attestantio/go-builder-client/api/deneb"
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
-	"github.com/attestantio/go-builder-client/spec"
-	consensusspec "github.com/attestantio/go-eth2-client/spec"
+	builderApi "github.com/attestantio/go-builder-client/api"
+	builderApiCapella "github.com/attestantio/go-builder-client/api/capella"
+	builderApiDeneb "github.com/attestantio/go-builder-client/api/deneb"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
+	builderSpec "github.com/attestantio/go-builder-client/spec"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
-	capellaspec "github.com/attestantio/go-eth2-client/spec/capella"
-	denebspec "github.com/attestantio/go-eth2-client/spec/deneb"
+	"github.com/attestantio/go-eth2-client/spec/capella"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/flashbots/go-boost-utils/bls"
@@ -35,15 +35,15 @@ var (
 	ErrNoMemcachedServers = errors.New("no memcached servers specified")
 )
 
-func testBuilderSubmitBlockRequest(pubkey phase0.BLSPubKey, signature phase0.BLSSignature, version consensusspec.DataVersion) common.VersionedSubmitBlockRequest {
+func testBuilderSubmitBlockRequest(pubkey phase0.BLSPubKey, signature phase0.BLSSignature, version spec.DataVersion) common.VersionedSubmitBlockRequest {
 	switch version {
-	case consensusspec.DataVersionDeneb:
+	case spec.DataVersionDeneb:
 		return common.VersionedSubmitBlockRequest{
-			VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-				Version: consensusspec.DataVersionDeneb,
-				Deneb: &deneb.SubmitBlockRequest{
+			VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+				Version: spec.DataVersionDeneb,
+				Deneb: &builderApiDeneb.SubmitBlockRequest{
 					Signature: signature,
-					Message: &apiv1.BidTrace{
+					Message: &builderApiV1.BidTrace{
 						Slot:                 1,
 						ParentHash:           phase0.Hash32{0x01},
 						BlockHash:            phase0.Hash32{0x09},
@@ -54,7 +54,7 @@ func testBuilderSubmitBlockRequest(pubkey phase0.BLSPubKey, signature phase0.BLS
 						GasLimit:             5002,
 						GasUsed:              5003,
 					},
-					ExecutionPayload: &denebspec.ExecutionPayload{
+					ExecutionPayload: &deneb.ExecutionPayload{
 						ParentHash:    phase0.Hash32{0x01},
 						FeeRecipient:  bellatrix.ExecutionAddress{0x02},
 						StateRoot:     phase0.Root{0x03},
@@ -70,21 +70,21 @@ func testBuilderSubmitBlockRequest(pubkey phase0.BLSPubKey, signature phase0.BLS
 						BlockHash:     phase0.Hash32{0x09},
 						Transactions:  []bellatrix.Transaction{},
 					},
-					BlobsBundle: &deneb.BlobsBundle{
-						Commitments: []denebspec.KzgCommitment{},
-						Proofs:      []denebspec.KzgProof{},
-						Blobs:       []denebspec.Blob{},
+					BlobsBundle: &builderApiDeneb.BlobsBundle{
+						Commitments: []deneb.KzgCommitment{},
+						Proofs:      []deneb.KzgProof{},
+						Blobs:       []deneb.Blob{},
 					},
 				},
 			},
 		}
-	case consensusspec.DataVersionCapella:
+	case spec.DataVersionCapella:
 		return common.VersionedSubmitBlockRequest{
-			VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-				Version: consensusspec.DataVersionCapella,
-				Capella: &capella.SubmitBlockRequest{
+			VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+				Version: spec.DataVersionCapella,
+				Capella: &builderApiCapella.SubmitBlockRequest{
 					Signature: signature,
-					Message: &apiv1.BidTrace{
+					Message: &builderApiV1.BidTrace{
 						Slot:                 1,
 						ParentHash:           phase0.Hash32{0x01},
 						BlockHash:            phase0.Hash32{0x09},
@@ -95,7 +95,7 @@ func testBuilderSubmitBlockRequest(pubkey phase0.BLSPubKey, signature phase0.BLS
 						GasLimit:             5002,
 						GasUsed:              5003,
 					},
-					ExecutionPayload: &capellaspec.ExecutionPayload{
+					ExecutionPayload: &capella.ExecutionPayload{
 						ParentHash:    phase0.Hash32{0x01},
 						FeeRecipient:  bellatrix.ExecutionAddress{0x02},
 						StateRoot:     phase0.Root{0x03},
@@ -114,7 +114,7 @@ func testBuilderSubmitBlockRequest(pubkey phase0.BLSPubKey, signature phase0.BLS
 				},
 			},
 		}
-	case consensusspec.DataVersionUnknown, consensusspec.DataVersionPhase0, consensusspec.DataVersionAltair, consensusspec.DataVersionBellatrix:
+	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair, spec.DataVersionBellatrix:
 		fallthrough
 	default:
 		return common.VersionedSubmitBlockRequest{}
@@ -188,7 +188,7 @@ func TestMemcached(t *testing.T) {
 		},
 		{
 			Description: "Given a valid builder submit block request, we expect to successfully store and retrieve the value from memcached",
-			Input:       testBuilderSubmitBlockRequest(builderPk, builderSk, consensusspec.DataVersionCapella),
+			Input:       testBuilderSubmitBlockRequest(builderPk, builderSk, spec.DataVersionCapella),
 			TestSuite: func(tc *test) func(*testing.T) {
 				return func(t *testing.T) {
 					t.Helper()
@@ -207,7 +207,7 @@ func TestMemcached(t *testing.T) {
 						"expected no error when marshalling execution payload response but found [%v]", err,
 					)
 
-					out := new(api.VersionedSubmitBlindedBlockResponse)
+					out := new(builderApi.VersionedSubmitBlindedBlockResponse)
 					err = out.UnmarshalJSON(inputBytes)
 					require.NoError(
 						t,
@@ -244,7 +244,7 @@ func TestMemcached(t *testing.T) {
 		},
 		{
 			Description: "Given a valid builder submit block request, updates to the same key should overwrite existing entry and return the last written value",
-			Input:       testBuilderSubmitBlockRequest(builderPk, builderSk, consensusspec.DataVersionDeneb),
+			Input:       testBuilderSubmitBlockRequest(builderPk, builderSk, spec.DataVersionDeneb),
 			TestSuite: func(tc *test) func(*testing.T) {
 				return func(t *testing.T) {
 					t.Helper()
@@ -281,7 +281,7 @@ func TestMemcached(t *testing.T) {
 		},
 		{
 			Description: fmt.Sprintf("Given a valid builder submit block request, memcached entry should expire after %d seconds", defaultMemcachedExpirySeconds),
-			Input:       testBuilderSubmitBlockRequest(builderPk, builderSk, consensusspec.DataVersionCapella),
+			Input:       testBuilderSubmitBlockRequest(builderPk, builderSk, spec.DataVersionCapella),
 			TestSuite: func(tc *test) func(*testing.T) {
 				return func(t *testing.T) {
 					t.Helper()

--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/attestantio/go-builder-client/api"
-	"github.com/attestantio/go-builder-client/api/deneb"
-	"github.com/attestantio/go-builder-client/spec"
-	consensusspec "github.com/attestantio/go-eth2-client/spec"
+	builderApi "github.com/attestantio/go-builder-client/api"
+	builderApiDeneb "github.com/attestantio/go-builder-client/api/deneb"
+	builderSpec "github.com/attestantio/go-builder-client/spec"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/flashbots/go-utils/cli"
 	"github.com/flashbots/mev-boost-relay/common"
@@ -123,7 +123,7 @@ func NewRedisCache(prefix, redisURI, readonlyURI string) (*RedisCache, error) {
 
 		prefixGetHeaderResponse:    fmt.Sprintf("%s/%s:cache-gethead-response", redisPrefix, prefix),
 		prefixExecPayloadCapella:   fmt.Sprintf("%s/%s:cache-execpayload-capella", redisPrefix, prefix),
-		prefixPayloadContentsDeneb: fmt.Sprintf("%s/%s:cache-payloadcontenst-deneb", redisPrefix, prefix),
+		prefixPayloadContentsDeneb: fmt.Sprintf("%s/%s:cache-payloadcontenst-builderApiDeneb", redisPrefix, prefix),
 		prefixBidTrace:             fmt.Sprintf("%s/%s:cache-bid-trace", redisPrefix, prefix),
 
 		prefixBlockBuilderLatestBids:      fmt.Sprintf("%s/%s:block-builder-latest-bid", redisPrefix, prefix),       // hashmap for slot+parentHash+proposerPubkey with builderPubkey as field
@@ -351,9 +351,9 @@ func (r *RedisCache) GetRelayConfig(field string) (string, error) {
 	return res, err
 }
 
-func (r *RedisCache) GetBestBid(slot uint64, parentHash, proposerPubkey string) (*spec.VersionedSignedBuilderBid, error) {
+func (r *RedisCache) GetBestBid(slot uint64, parentHash, proposerPubkey string) (*builderSpec.VersionedSignedBuilderBid, error) {
 	key := r.keyCacheGetHeaderResponse(slot, parentHash, proposerPubkey)
-	resp := new(spec.VersionedSignedBuilderBid)
+	resp := new(builderSpec.VersionedSignedBuilderBid)
 	err := r.GetObj(key, resp)
 	if errors.Is(err, redis.Nil) {
 		return nil, nil
@@ -361,16 +361,16 @@ func (r *RedisCache) GetBestBid(slot uint64, parentHash, proposerPubkey string) 
 	return resp, err
 }
 
-func (r *RedisCache) GetPayloadContents(slot uint64, proposerPubkey, blockHash string) (*api.VersionedSubmitBlindedBlockResponse, error) {
+func (r *RedisCache) GetPayloadContents(slot uint64, proposerPubkey, blockHash string) (*builderApi.VersionedSubmitBlindedBlockResponse, error) {
 	resp, err := r.GetPayloadContentsDeneb(slot, proposerPubkey, blockHash)
 	if errors.Is(err, redis.Nil) {
-		// can't find deneb payload, try find capella payload
+		// can't find builderApiDeneb payload, try find capella payload
 		return r.GetExecutionPayloadCapella(slot, proposerPubkey, blockHash)
 	}
 	return resp, err
 }
 
-func (r *RedisCache) SavePayloadContentsDeneb(ctx context.Context, tx redis.Pipeliner, slot uint64, proposerPubkey, blockHash string, execPayload *deneb.ExecutionPayloadAndBlobsBundle) (err error) {
+func (r *RedisCache) SavePayloadContentsDeneb(ctx context.Context, tx redis.Pipeliner, slot uint64, proposerPubkey, blockHash string, execPayload *builderApiDeneb.ExecutionPayloadAndBlobsBundle) (err error) {
 	key := r.keyPayloadContentsDeneb(slot, proposerPubkey, blockHash)
 	b, err := execPayload.MarshalSSZ()
 	if err != nil {
@@ -379,8 +379,8 @@ func (r *RedisCache) SavePayloadContentsDeneb(ctx context.Context, tx redis.Pipe
 	return tx.Set(ctx, key, b, expiryBidCache).Err()
 }
 
-func (r *RedisCache) GetPayloadContentsDeneb(slot uint64, proposerPubkey, blockHash string) (*api.VersionedSubmitBlindedBlockResponse, error) {
-	denebPayloadContents := new(deneb.ExecutionPayloadAndBlobsBundle)
+func (r *RedisCache) GetPayloadContentsDeneb(slot uint64, proposerPubkey, blockHash string) (*builderApi.VersionedSubmitBlindedBlockResponse, error) {
+	denebPayloadContents := new(builderApiDeneb.ExecutionPayloadAndBlobsBundle)
 
 	key := r.keyPayloadContentsDeneb(slot, proposerPubkey, blockHash)
 	val, err := r.client.Get(context.Background(), key).Result()
@@ -393,8 +393,8 @@ func (r *RedisCache) GetPayloadContentsDeneb(slot uint64, proposerPubkey, blockH
 		return nil, err
 	}
 
-	return &api.VersionedSubmitBlindedBlockResponse{
-		Version: consensusspec.DataVersionDeneb,
+	return &builderApi.VersionedSubmitBlindedBlockResponse{
+		Version: spec.DataVersionDeneb,
 		Deneb:   denebPayloadContents,
 	}, nil
 }
@@ -408,7 +408,7 @@ func (r *RedisCache) SaveExecutionPayloadCapella(ctx context.Context, tx redis.P
 	return tx.Set(ctx, key, b, expiryBidCache).Err()
 }
 
-func (r *RedisCache) GetExecutionPayloadCapella(slot uint64, proposerPubkey, blockHash string) (*api.VersionedSubmitBlindedBlockResponse, error) {
+func (r *RedisCache) GetExecutionPayloadCapella(slot uint64, proposerPubkey, blockHash string) (*builderApi.VersionedSubmitBlindedBlockResponse, error) {
 	capellaPayload := new(capella.ExecutionPayload)
 
 	key := r.keyExecPayloadCapella(slot, proposerPubkey, blockHash)
@@ -422,8 +422,8 @@ func (r *RedisCache) GetExecutionPayloadCapella(slot uint64, proposerPubkey, blo
 		return nil, err
 	}
 
-	return &api.VersionedSubmitBlindedBlockResponse{
-		Version: consensusspec.DataVersionCapella,
+	return &builderApi.VersionedSubmitBlindedBlockResponse{
+		Version: spec.DataVersionCapella,
 		Capella: capellaPayload,
 	}, nil
 }
@@ -454,7 +454,7 @@ func (r *RedisCache) GetBuilderLatestPayloadReceivedAt(ctx context.Context, tx r
 }
 
 // SaveBuilderBid saves the latest bid by a specific builder. TODO: use transaction to make these writes atomic
-func (r *RedisCache) SaveBuilderBid(ctx context.Context, tx redis.Pipeliner, slot uint64, parentHash, proposerPubkey, builderPubkey string, receivedAt time.Time, headerResp *spec.VersionedSignedBuilderBid) (err error) {
+func (r *RedisCache) SaveBuilderBid(ctx context.Context, tx redis.Pipeliner, slot uint64, parentHash, proposerPubkey, builderPubkey string, receivedAt time.Time, headerResp *builderSpec.VersionedSignedBuilderBid) (err error) {
 	// save the actual bid
 	keyLatestBid := r.keyLatestBidByBuilder(slot, parentHash, proposerPubkey, builderPubkey)
 	err = r.SetObjPipelined(ctx, tx, keyLatestBid, headerResp, expiryBidCache)
@@ -502,7 +502,7 @@ type SaveBidAndUpdateTopBidResponse struct {
 	TimeUpdateFloor  time.Duration
 }
 
-func (r *RedisCache) SaveBidAndUpdateTopBid(ctx context.Context, tx redis.Pipeliner, trace *common.BidTraceV2, payload *common.VersionedSubmitBlockRequest, getPayloadResponse *api.VersionedSubmitBlindedBlockResponse, getHeaderResponse *spec.VersionedSignedBuilderBid, reqReceivedAt time.Time, isCancellationEnabled bool, floorValue *big.Int) (state SaveBidAndUpdateTopBidResponse, err error) {
+func (r *RedisCache) SaveBidAndUpdateTopBid(ctx context.Context, tx redis.Pipeliner, trace *common.BidTraceV2, payload *common.VersionedSubmitBlockRequest, getPayloadResponse *builderApi.VersionedSubmitBlindedBlockResponse, getHeaderResponse *builderSpec.VersionedSignedBuilderBid, reqReceivedAt time.Time, isCancellationEnabled bool, floorValue *big.Int) (state SaveBidAndUpdateTopBidResponse, err error) {
 	var prevTime, nextTime time.Time
 	prevTime = time.Now()
 
@@ -548,17 +548,17 @@ func (r *RedisCache) SaveBidAndUpdateTopBid(ctx context.Context, tx redis.Pipeli
 	//
 	// 1. Save the execution payload
 	switch payload.Version {
-	case consensusspec.DataVersionCapella:
+	case spec.DataVersionCapella:
 		err = r.SaveExecutionPayloadCapella(ctx, tx, submission.Slot, submission.ParentHash.String(), submission.Proposer.String(), getPayloadResponse.Capella)
 		if err != nil {
 			return state, err
 		}
-	case consensusspec.DataVersionDeneb:
+	case spec.DataVersionDeneb:
 		err = r.SavePayloadContentsDeneb(ctx, tx, submission.Slot, submission.ParentHash.String(), submission.Proposer.String(), getPayloadResponse.Deneb)
 		if err != nil {
 			return state, err
 		}
-	case consensusspec.DataVersionUnknown, consensusspec.DataVersionPhase0, consensusspec.DataVersionAltair, consensusspec.DataVersionBellatrix:
+	case spec.DataVersionUnknown, spec.DataVersionPhase0, spec.DataVersionAltair, spec.DataVersionBellatrix:
 		return state, fmt.Errorf("unsupported payload version: %d", payload.Version) //nolint:goerr113
 	}
 

--- a/datastore/redis_test.go
+++ b/datastore/redis_test.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/attestantio/go-builder-client/api/capella"
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
-	"github.com/attestantio/go-builder-client/spec"
-	consensusspec "github.com/attestantio/go-eth2-client/spec"
+	builderApiCapella "github.com/attestantio/go-builder-client/api/capella"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
+	builderSpec "github.com/attestantio/go-builder-client/spec"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/flashbots/mev-boost-relay/common"
@@ -92,9 +92,9 @@ func TestRedisProposerDuties(t *testing.T) {
 	duties := []common.BuilderGetValidatorsResponseEntry{
 		{
 			Slot: 1,
-			Entry: &apiv1.SignedValidatorRegistration{
+			Entry: &builderApiV1.SignedValidatorRegistration{
 				Signature: phase0.BLSSignature{},
-				Message: &apiv1.ValidatorRegistration{
+				Message: &builderApiV1.ValidatorRegistration{
 					FeeRecipient: bellatrix.ExecutionAddress{0x02},
 					GasLimit:     5000,
 					Timestamp:    time.Unix(0xffffffff, 0),
@@ -121,11 +121,11 @@ func TestBuilderBids(t *testing.T) {
 		Slot:           2,
 		ParentHash:     parentHash,
 		ProposerPubkey: proposerPubkey,
-		Version:        consensusspec.DataVersionCapella,
+		Version:        spec.DataVersionCapella,
 	}
 
 	trace := &common.BidTraceV2{
-		BidTrace: apiv1.BidTrace{
+		BidTrace: builderApiV1.BidTrace{
 			Value: uint256.NewInt(123),
 		},
 	}
@@ -410,10 +410,10 @@ func TestGetBuilderLatestValue(t *testing.T) {
 	// Set a bid of 1 ETH.
 	newVal, err := uint256.FromDecimal("1000000000000000000")
 	require.NoError(t, err)
-	getHeaderResp := &spec.VersionedSignedBuilderBid{
-		Version: consensusspec.DataVersionCapella,
-		Capella: &capella.SignedBuilderBid{
-			Message: &capella.BuilderBid{
+	getHeaderResp := &builderSpec.VersionedSignedBuilderBid{
+		Version: spec.DataVersionCapella,
+		Capella: &builderApiCapella.SignedBuilderBid{
+			Message: &builderApiCapella.BuilderBid{
 				Value: newVal,
 			},
 		},

--- a/internal/investigations/validator-registration-signature-check/main.go
+++ b/internal/investigations/validator-registration-signature-check/main.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
 	"github.com/flashbots/go-boost-utils/bls"
 	"github.com/flashbots/go-boost-utils/ssz"
 	"github.com/flashbots/go-boost-utils/utils"
@@ -38,7 +38,7 @@ func main() {
 	Perr(err)
 
 	// Fill in validator registration details
-	validatorRegistration := apiv1.ValidatorRegistration{ //nolint:exhaustruct
+	validatorRegistration := builderApiV1.ValidatorRegistration{ //nolint:exhaustruct
 		GasLimit:  uint64(gasLimit),
 		Timestamp: time.Unix(timestamp, 0),
 	}

--- a/internal/investigations/validator-registration-signature-check/main_test.go
+++ b/internal/investigations/validator-registration-signature-check/main_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
 	"github.com/flashbots/go-boost-utils/ssz"
 	"github.com/flashbots/go-boost-utils/utils"
 	"github.com/flashbots/mev-boost-relay/common"
@@ -21,8 +21,8 @@ func TestValidatorRegistrationSignature(t *testing.T) {
 	signature := "0xaf12df007a0c78abb5575067e5f8b089cfcc6227e4a91db7dd8cf517fe86fb944ead859f0781277d9b78c672e4a18c5d06368b603374673cf2007966cece9540f3a1b3f6f9e1bf421d779c4e8010368e6aac134649c7a009210780d401a778a5"
 
 	// Constructing the object
-	payload := apiv1.SignedValidatorRegistration{
-		Message: &apiv1.ValidatorRegistration{
+	payload := builderApiV1.SignedValidatorRegistration{
+		Message: &builderApiV1.ValidatorRegistration{
 			GasLimit:  uint64(gasLimit),
 			Timestamp: time.Unix(timestamp, 0),
 		},

--- a/services/api/optimistic_test.go
+++ b/services/api/optimistic_test.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
-	consensuscapella "github.com/attestantio/go-eth2-client/spec/capella"
+	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/flashbots/go-boost-utils/bls"
 	"github.com/flashbots/go-boost-utils/utils"
@@ -44,7 +44,7 @@ var (
 
 func getTestBidTrace(pubkey phase0.BLSPubKey, value, slot uint64) *common.BidTraceV2 {
 	return &common.BidTraceV2{
-		BidTrace: apiv1.BidTrace{
+		BidTrace: builderApiV1.BidTrace{
 			Slot:                 slot,
 			BuilderPubkey:        pubkey,
 			ProposerFeeRecipient: feeRecipient,
@@ -79,8 +79,8 @@ func startTestBackend(t *testing.T) (*phase0.BLSPubKey, *bls.SecretKey, *testBac
 	backend.relay.genesisInfo.Data.GenesisTime = 0
 	backend.relay.proposerDutiesMap = map[uint64]*common.BuilderGetValidatorsResponseEntry{
 		slot: {
-			Entry: &apiv1.SignedValidatorRegistration{
-				Message: &apiv1.ValidatorRegistration{
+			Entry: &builderApiV1.SignedValidatorRegistration{
+				Message: &builderApiV1.ValidatorRegistration{
 					FeeRecipient: [20]byte(feeRecipient),
 					GasLimit:     5000,
 					Timestamp:    time.Unix(0xffffffff, 0),
@@ -468,7 +468,7 @@ func TestBuilderApiSubmitNewBlockOptimistic(t *testing.T) {
 
 			randaoHash, err := utils.HexToHash(randao)
 			require.NoError(t, err)
-			withRoot, err := ComputeWithdrawalsRoot([]*consensuscapella.Withdrawal{})
+			withRoot, err := ComputeWithdrawalsRoot([]*capella.Withdrawal{})
 			require.NoError(t, err)
 			backend.relay.payloadAttributes[emptyHash] = payloadAttributesHelper{
 				slot:            tc.slot,

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/NYTimes/gziphandler"
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/buger/jsonparser"
@@ -196,7 +196,7 @@ type RelayAPI struct {
 
 	blockSimRateLimiter IBlockSimRateLimiter
 
-	validatorRegC chan apiv1.SignedValidatorRegistration
+	validatorRegC chan builderApiV1.SignedValidatorRegistration
 
 	// used to wait on any active getPayload calls on shutdown
 	getPayloadCallsInFlight sync.WaitGroup
@@ -285,7 +285,7 @@ func NewRelayAPI(opts RelayAPIOpts) (api *RelayAPI, err error) {
 		proposerDutiesResponse: &[]byte{},
 		blockSimRateLimiter:    NewBlockSimulationRateLimiter(opts.BlockSimURL),
 
-		validatorRegC: make(chan apiv1.SignedValidatorRegistration, 450_000),
+		validatorRegC: make(chan builderApiV1.SignedValidatorRegistration, 450_000),
 	}
 
 	if os.Getenv("FORCE_GET_HEADER_204") == "1" {
@@ -917,7 +917,7 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 	}
 	req.Body.Close()
 
-	parseRegistration := func(value []byte) (reg *apiv1.SignedValidatorRegistration, err error) {
+	parseRegistration := func(value []byte) (reg *builderApiV1.SignedValidatorRegistration, err error) {
 		// Pubkey
 		_pubkey, err := jsonparser.GetUnsafeString(value, "message", "pubkey")
 		if err != nil {
@@ -977,8 +977,8 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 		}
 
 		// Construct and return full registration object
-		reg = &apiv1.SignedValidatorRegistration{
-			Message: &apiv1.ValidatorRegistration{
+		reg = &builderApiV1.SignedValidatorRegistration{
+			Message: &builderApiV1.ValidatorRegistration{
 				FeeRecipient: feeRecipient,
 				GasLimit:     gasLimit,
 				Timestamp:    time.Unix(timestamp, 0),
@@ -1547,7 +1547,7 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 				log.WithError(err).Error("error reading validator registration")
 			}
 		}
-		var signedRegistration *apiv1.SignedValidatorRegistration
+		var signedRegistration *builderApiV1.SignedValidatorRegistration
 		if registrationEntry != nil {
 			signedRegistration, err = registrationEntry.ToSignedValidatorRegistration()
 			if err != nil {

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	builderCapella "github.com/attestantio/go-builder-client/api/capella"
-	builderDeneb "github.com/attestantio/go-builder-client/api/deneb"
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
-	"github.com/attestantio/go-builder-client/spec"
-	consensusspec "github.com/attestantio/go-eth2-client/spec"
+	builderApiCapella "github.com/attestantio/go-builder-client/api/capella"
+	builderApiDeneb "github.com/attestantio/go-builder-client/api/deneb"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
+	builderSpec "github.com/attestantio/go-builder-client/spec"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/deneb"
@@ -196,7 +196,7 @@ func TestRegisterValidator(t *testing.T) {
 	t.Run("not a known validator", func(t *testing.T) {
 		backend := newTestBackend(t, 1)
 
-		rr := backend.request(http.MethodPost, path, []apiv1.SignedValidatorRegistration{common.ValidPayloadRegisterValidator})
+		rr := backend.request(http.MethodPost, path, []builderApiV1.SignedValidatorRegistration{common.ValidPayloadRegisterValidator})
 		require.Equal(t, http.StatusBadRequest, rr.Code)
 	})
 }
@@ -218,7 +218,7 @@ func TestGetHeader(t *testing.T) {
 	builderPubkey := "0xfa1ed37c3553d0ce1e9349b2c5063cf6e394d231c8d3e0df75e9462257c081543086109ffddaacc0aa76f33dc9661c83"
 	bidValue := uint256.NewInt(99)
 	trace := &common.BidTraceV2{
-		BidTrace: apiv1.BidTrace{
+		BidTrace: builderApiV1.BidTrace{
 			Value: bidValue,
 		},
 	}
@@ -231,7 +231,7 @@ func TestGetHeader(t *testing.T) {
 		Slot:           slot,
 		ParentHash:     parentHash,
 		ProposerPubkey: proposerPubkey,
-		Version:        consensusspec.DataVersionCapella,
+		Version:        spec.DataVersionCapella,
 	}
 	payload, getPayloadResp, getHeaderResp := common.CreateTestBlockSubmission(t, builderPubkey, bidValue, &opts)
 	_, err := backend.redis.SaveBidAndUpdateTopBid(context.Background(), backend.redis.NewPipeline(), trace, payload, getPayloadResp, getHeaderResp, time.Now(), false, nil)
@@ -240,12 +240,12 @@ func TestGetHeader(t *testing.T) {
 	// Check 1: regular capella request works and returns a bid
 	rr := backend.request(http.MethodGet, path, nil)
 	require.Equal(t, http.StatusOK, rr.Code)
-	resp := spec.VersionedSignedBuilderBid{}
+	resp := builderSpec.VersionedSignedBuilderBid{}
 	err = json.Unmarshal(rr.Body.Bytes(), &resp)
 	require.NoError(t, err)
 	value, err := resp.Value()
 	require.NoError(t, err)
-	require.Equal(t, consensusspec.DataVersionCapella, resp.Version)
+	require.Equal(t, spec.DataVersionCapella, resp.Version)
 	require.Equal(t, bidValue.String(), value.String())
 
 	// Create a deneb bid
@@ -254,7 +254,7 @@ func TestGetHeader(t *testing.T) {
 		Slot:           slot + 1,
 		ParentHash:     parentHash,
 		ProposerPubkey: proposerPubkey,
-		Version:        consensusspec.DataVersionDeneb,
+		Version:        spec.DataVersionDeneb,
 	}
 	payload, getPayloadResp, getHeaderResp = common.CreateTestBlockSubmission(t, builderPubkey, bidValue, &opts)
 	_, err = backend.redis.SaveBidAndUpdateTopBid(context.Background(), backend.redis.NewPipeline(), trace, payload, getPayloadResp, getHeaderResp, time.Now(), false, nil)
@@ -263,12 +263,12 @@ func TestGetHeader(t *testing.T) {
 	// Check 2: regular deneb request works and returns a bid
 	rr = backend.request(http.MethodGet, path, nil)
 	require.Equal(t, http.StatusOK, rr.Code)
-	resp = spec.VersionedSignedBuilderBid{}
+	resp = builderSpec.VersionedSignedBuilderBid{}
 	err = json.Unmarshal(rr.Body.Bytes(), &resp)
 	require.NoError(t, err)
 	value, err = resp.Value()
 	require.NoError(t, err)
-	require.Equal(t, consensusspec.DataVersionDeneb, resp.Version)
+	require.Equal(t, spec.DataVersionDeneb, resp.Version)
 	require.Equal(t, bidValue.String(), value.String())
 
 	// Check 3: Request returns 204 if sending a filtered user agent
@@ -338,7 +338,7 @@ func TestBuilderSubmitBlockSSZ(t *testing.T) {
 	requestPayloadJSONBytes := common.LoadGzippedBytes(t, "../../testdata/submitBlockPayloadCapella_Goerli.json.gz")
 
 	req := new(common.VersionedSubmitBlockRequest)
-	req.Capella = new(builderCapella.SubmitBlockRequest)
+	req.Capella = new(builderApiCapella.SubmitBlockRequest)
 	err := json.Unmarshal(requestPayloadJSONBytes, req.Capella)
 	require.NoError(t, err)
 
@@ -346,7 +346,7 @@ func TestBuilderSubmitBlockSSZ(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 352239, len(reqSSZ))
 
-	test := new(builderCapella.SubmitBlockRequest)
+	test := new(builderApiCapella.SubmitBlockRequest)
 	err = test.UnmarshalSSZ(reqSSZ)
 	require.NoError(t, err)
 }
@@ -374,8 +374,8 @@ func TestBuilderSubmitBlock(t *testing.T) {
 	backend.relay.proposerDutiesMap = make(map[uint64]*common.BuilderGetValidatorsResponseEntry)
 	backend.relay.proposerDutiesMap[headSlot+1] = &common.BuilderGetValidatorsResponseEntry{
 		Slot: headSlot,
-		Entry: &apiv1.SignedValidatorRegistration{
-			Message: &apiv1.ValidatorRegistration{
+		Entry: &builderApiV1.SignedValidatorRegistration{
+			Message: &builderApiV1.ValidatorRegistration{
 				FeeRecipient: feeRec,
 			},
 		},
@@ -392,7 +392,7 @@ func TestBuilderSubmitBlock(t *testing.T) {
 
 	// Prepare the request payload
 	req := new(common.VersionedSubmitBlockRequest)
-	req.Capella = new(builderCapella.SubmitBlockRequest)
+	req.Capella = new(builderApiCapella.SubmitBlockRequest)
 	requestPayloadJSONBytes := common.LoadGzippedBytes(t, payloadJSONFilename)
 	require.NoError(t, err)
 	err = json.Unmarshal(requestPayloadJSONBytes, req.Capella)
@@ -457,18 +457,18 @@ func TestCheckSubmissionFeeRecipient(t *testing.T) {
 		{
 			description: "success",
 			slotDuty: &common.BuilderGetValidatorsResponseEntry{
-				Entry: &apiv1.SignedValidatorRegistration{
-					Message: &apiv1.ValidatorRegistration{
+				Entry: &builderApiV1.SignedValidatorRegistration{
+					Message: &builderApiV1.ValidatorRegistration{
 						FeeRecipient: testAddress,
 						GasLimit:     testGasLimit,
 					},
 				},
 			},
 			payload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &builderCapella.SubmitBlockRequest{
-						Message: &apiv1.BidTrace{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
+						Message: &builderApiV1.BidTrace{
 							Slot:                 testSlot,
 							ProposerFeeRecipient: testAddress,
 						},
@@ -483,10 +483,10 @@ func TestCheckSubmissionFeeRecipient(t *testing.T) {
 			description: "failure_nil_slot_duty",
 			slotDuty:    nil,
 			payload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &builderCapella.SubmitBlockRequest{
-						Message: &apiv1.BidTrace{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
+						Message: &builderApiV1.BidTrace{
 							Slot: testSlot,
 						},
 						ExecutionPayload: &capella.ExecutionPayload{},
@@ -499,18 +499,18 @@ func TestCheckSubmissionFeeRecipient(t *testing.T) {
 		{
 			description: "failure_diff_fee_recipient",
 			slotDuty: &common.BuilderGetValidatorsResponseEntry{
-				Entry: &apiv1.SignedValidatorRegistration{
-					Message: &apiv1.ValidatorRegistration{
+				Entry: &builderApiV1.SignedValidatorRegistration{
+					Message: &builderApiV1.ValidatorRegistration{
 						FeeRecipient: testAddress,
 						GasLimit:     testGasLimit,
 					},
 				},
 			},
 			payload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &builderCapella.SubmitBlockRequest{
-						Message: &apiv1.BidTrace{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
+						Message: &builderApiV1.BidTrace{
 							Slot:                 testSlot,
 							ProposerFeeRecipient: testAddress2,
 						},
@@ -568,9 +568,9 @@ func TestCheckSubmissionPayloadAttrs(t *testing.T) {
 				},
 			},
 			payload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &builderCapella.SubmitBlockRequest{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
 						ExecutionPayload: &capella.ExecutionPayload{
 							PrevRandao: prevRandao,
 							Withdrawals: []*capella.Withdrawal{
@@ -579,7 +579,7 @@ func TestCheckSubmissionPayloadAttrs(t *testing.T) {
 								},
 							},
 						},
-						Message: &apiv1.BidTrace{
+						Message: &builderApiV1.BidTrace{
 							Slot:       testSlot,
 							ParentHash: parentHash,
 						},
@@ -594,10 +594,10 @@ func TestCheckSubmissionPayloadAttrs(t *testing.T) {
 				slot: testSlot,
 			},
 			payload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &builderCapella.SubmitBlockRequest{
-						Message: &apiv1.BidTrace{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
+						Message: &builderApiV1.BidTrace{
 							Slot: testSlot + 1, // submission for a future slot
 						},
 						ExecutionPayload: &capella.ExecutionPayload{},
@@ -615,10 +615,10 @@ func TestCheckSubmissionPayloadAttrs(t *testing.T) {
 				},
 			},
 			payload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &builderCapella.SubmitBlockRequest{
-						Message: &apiv1.BidTrace{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
+						Message: &builderApiV1.BidTrace{
 							Slot:       testSlot,
 							ParentHash: parentHash,
 						},
@@ -639,10 +639,10 @@ func TestCheckSubmissionPayloadAttrs(t *testing.T) {
 				},
 			},
 			payload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &builderCapella.SubmitBlockRequest{
-						Message: &apiv1.BidTrace{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
+						Message: &builderApiV1.BidTrace{
 							Slot:       testSlot,
 							ParentHash: parentHash,
 						},
@@ -666,9 +666,9 @@ func TestCheckSubmissionPayloadAttrs(t *testing.T) {
 				},
 			},
 			payload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &builderCapella.SubmitBlockRequest{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
 						ExecutionPayload: &capella.ExecutionPayload{
 							PrevRandao: [32]byte(prevRandao),
 							Withdrawals: []*capella.Withdrawal{
@@ -677,7 +677,7 @@ func TestCheckSubmissionPayloadAttrs(t *testing.T) {
 								},
 							},
 						},
-						Message: &apiv1.BidTrace{
+						Message: &builderApiV1.BidTrace{
 							Slot:       testSlot,
 							ParentHash: parentHash,
 						},
@@ -715,13 +715,13 @@ func TestCheckSubmissionSlotDetails(t *testing.T) {
 		{
 			description: "success",
 			payload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &builderCapella.SubmitBlockRequest{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
 						ExecutionPayload: &capella.ExecutionPayload{
 							Timestamp: testSlot * common.SecondsPerSlot,
 						},
-						Message: &apiv1.BidTrace{
+						Message: &builderApiV1.BidTrace{
 							Slot: testSlot,
 						},
 					},
@@ -732,13 +732,13 @@ func TestCheckSubmissionSlotDetails(t *testing.T) {
 		{
 			description: "non_capella_slot",
 			payload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &builderCapella.SubmitBlockRequest{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
 						ExecutionPayload: &capella.ExecutionPayload{
 							Timestamp: testSlot * common.SecondsPerSlot,
 						},
-						Message: &apiv1.BidTrace{
+						Message: &builderApiV1.BidTrace{
 							Slot: testSlot + 32,
 						},
 					},
@@ -749,13 +749,13 @@ func TestCheckSubmissionSlotDetails(t *testing.T) {
 		{
 			description: "non_deneb_slot",
 			payload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionDeneb,
-					Deneb: &builderDeneb.SubmitBlockRequest{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionDeneb,
+					Deneb: &builderApiDeneb.SubmitBlockRequest{
 						ExecutionPayload: &deneb.ExecutionPayload{
 							Timestamp: testSlot * common.SecondsPerSlot,
 						},
-						Message: &apiv1.BidTrace{
+						Message: &builderApiV1.BidTrace{
 							Slot: testSlot,
 						},
 					},
@@ -766,10 +766,10 @@ func TestCheckSubmissionSlotDetails(t *testing.T) {
 		{
 			description: "failure_past_slot",
 			payload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &builderCapella.SubmitBlockRequest{
-						Message: &apiv1.BidTrace{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
+						Message: &builderApiV1.BidTrace{
 							Slot: testSlot - 1, // use old slot to cause error
 						},
 						ExecutionPayload: &capella.ExecutionPayload{},
@@ -781,13 +781,13 @@ func TestCheckSubmissionSlotDetails(t *testing.T) {
 		{
 			description: "failure_wrong_timestamp",
 			payload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &builderCapella.SubmitBlockRequest{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
 						ExecutionPayload: &capella.ExecutionPayload{
 							Timestamp: testSlot*common.SecondsPerSlot - 1, // use wrong timestamp to cause error
 						},
-						Message: &apiv1.BidTrace{
+						Message: &builderApiV1.BidTrace{
 							Slot: testSlot,
 						},
 					},
@@ -879,7 +879,7 @@ func TestCheckProposerSignature(t *testing.T) {
 	t.Run("Unsupported version", func(t *testing.T) {
 		_, _, backend := startTestBackend(t)
 		payload := new(common.VersionedSignedBlindedBlockRequest)
-		payload.Version = consensusspec.DataVersionBellatrix
+		payload.Version = spec.DataVersionBellatrix
 		ok, err := backend.relay.checkProposerSignature(payload, []byte{})
 		require.Error(t, err, "unsupported consensus data version")
 		require.False(t, ok)

--- a/services/api/types_test.go
+++ b/services/api/types_test.go
@@ -3,14 +3,14 @@ package api
 import (
 	"testing"
 
-	"github.com/attestantio/go-builder-client/api/capella"
-	"github.com/attestantio/go-builder-client/api/deneb"
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
-	"github.com/attestantio/go-builder-client/spec"
-	consensusspec "github.com/attestantio/go-eth2-client/spec"
+	builderApiCapella "github.com/attestantio/go-builder-client/api/capella"
+	builderApiDeneb "github.com/attestantio/go-builder-client/api/deneb"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
+	builderSpec "github.com/attestantio/go-builder-client/spec"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
-	capellaspec "github.com/attestantio/go-eth2-client/spec/capella"
-	denebspec "github.com/attestantio/go-eth2-client/spec/deneb"
+	"github.com/attestantio/go-eth2-client/spec/capella"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/flashbots/go-boost-utils/bls"
 	"github.com/flashbots/go-boost-utils/ssz"
@@ -35,10 +35,10 @@ func TestBuilderBlockRequestToSignedBuilderBid(t *testing.T) {
 		{
 			name: "Capella",
 			reqPayload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionCapella,
-					Capella: &capella.SubmitBlockRequest{
-						ExecutionPayload: &capellaspec.ExecutionPayload{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionCapella,
+					Capella: &builderApiCapella.SubmitBlockRequest{
+						ExecutionPayload: &capella.ExecutionPayload{
 							ParentHash:    phase0.Hash32{0x01},
 							FeeRecipient:  bellatrix.ExecutionAddress{0x02},
 							StateRoot:     phase0.Root{0x03},
@@ -54,7 +54,7 @@ func TestBuilderBlockRequestToSignedBuilderBid(t *testing.T) {
 							BlockHash:     phase0.Hash32{0x09},
 							Transactions:  []bellatrix.Transaction{},
 						},
-						Message: &apiv1.BidTrace{
+						Message: &builderApiV1.BidTrace{
 							Slot:                 1,
 							ParentHash:           phase0.Hash32{0x01},
 							BlockHash:            phase0.Hash32{0x09},
@@ -73,10 +73,10 @@ func TestBuilderBlockRequestToSignedBuilderBid(t *testing.T) {
 		{
 			name: "Deneb",
 			reqPayload: &common.VersionedSubmitBlockRequest{
-				VersionedSubmitBlockRequest: spec.VersionedSubmitBlockRequest{
-					Version: consensusspec.DataVersionDeneb,
-					Deneb: &deneb.SubmitBlockRequest{
-						ExecutionPayload: &denebspec.ExecutionPayload{
+				VersionedSubmitBlockRequest: builderSpec.VersionedSubmitBlockRequest{
+					Version: spec.DataVersionDeneb,
+					Deneb: &builderApiDeneb.SubmitBlockRequest{
+						ExecutionPayload: &deneb.ExecutionPayload{
 							ParentHash:    phase0.Hash32{0x01},
 							FeeRecipient:  bellatrix.ExecutionAddress{0x02},
 							StateRoot:     phase0.Root{0x03},
@@ -92,12 +92,12 @@ func TestBuilderBlockRequestToSignedBuilderBid(t *testing.T) {
 							BlockHash:     phase0.Hash32{0x09},
 							Transactions:  []bellatrix.Transaction{},
 						},
-						BlobsBundle: &deneb.BlobsBundle{
-							Commitments: []denebspec.KzgCommitment{},
-							Proofs:      []denebspec.KzgProof{},
-							Blobs:       []denebspec.Blob{},
+						BlobsBundle: &builderApiDeneb.BlobsBundle{
+							Commitments: []deneb.KzgCommitment{},
+							Proofs:      []deneb.KzgProof{},
+							Blobs:       []deneb.Blob{},
 						},
-						Message: &apiv1.BidTrace{
+						Message: &builderApiV1.BidTrace{
 							Slot:                 1,
 							ParentHash:           phase0.Hash32{0x01},
 							BlockHash:            phase0.Hash32{0x09},

--- a/services/api/utils.go
+++ b/services/api/utils.go
@@ -3,12 +3,12 @@ package api
 import (
 	"fmt"
 
-	"github.com/attestantio/go-builder-client/api"
+	builderApi "github.com/attestantio/go-builder-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	utilcapella "github.com/attestantio/go-eth2-client/util/capella"
-	utildeneb "github.com/attestantio/go-eth2-client/util/deneb"
+	eth2UtilCapella "github.com/attestantio/go-eth2-client/util/capella"
+	eth2UtilDeneb "github.com/attestantio/go-eth2-client/util/deneb"
 	"github.com/flashbots/go-boost-utils/bls"
 	"github.com/flashbots/go-boost-utils/utils"
 	"github.com/flashbots/mev-boost-relay/common"
@@ -46,16 +46,16 @@ func ComputeWithdrawalsRoot(w []*capella.Withdrawal) (phase0.Root, error) {
 	if w == nil {
 		return phase0.Root{}, ErrNoWithdrawals
 	}
-	withdrawals := utilcapella.ExecutionPayloadWithdrawals{Withdrawals: w}
+	withdrawals := eth2UtilCapella.ExecutionPayloadWithdrawals{Withdrawals: w}
 	return withdrawals.HashTreeRoot()
 }
 
-func EqBlindedBlockContentsToBlockContents(bb *common.VersionedSignedBlindedBlockRequest, payload *api.VersionedSubmitBlindedBlockResponse) error {
+func EqBlindedBlockContentsToBlockContents(bb *common.VersionedSignedBlindedBlockRequest, payload *builderApi.VersionedSubmitBlindedBlockResponse) error {
 	if bb.Version != payload.Version {
 		return errors.Wrap(ErrPayloadMismatch, fmt.Sprintf("beacon block version %d does not match payload version %d", bb.Version, payload.Version))
 	}
 
-	versionedPayload := &api.VersionedExecutionPayload{ //nolint:exhaustivestruct
+	versionedPayload := &builderApi.VersionedExecutionPayload{ //nolint:exhaustivestruct
 		Version: payload.Version,
 	}
 	switch bb.Version {
@@ -118,7 +118,7 @@ func EqBlindedBlockContentsToBlockContents(bb *common.VersionedSignedBlindedBloc
 			if blindedSidecar.Message.KzgProof != payload.Deneb.BlobsBundle.Proofs[i] {
 				return errors.Wrap(ErrBlobMismatch, fmt.Sprintf("mismatched KZG proof at index %d", i))
 			}
-			blobRootHelper := utildeneb.BeaconBlockBlob{Blob: payload.Deneb.BlobsBundle.Blobs[i]}
+			blobRootHelper := eth2UtilDeneb.BeaconBlockBlob{Blob: payload.Deneb.BlobsBundle.Blobs[i]}
 			blobRoot, err := blobRootHelper.HashTreeRoot()
 			if err != nil {
 				return errors.New(fmt.Sprintf("failed to compute blob root at index %d", i))

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	apiv1 "github.com/attestantio/go-builder-client/api/v1"
+	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
 	"github.com/flashbots/mev-boost-relay/beaconclient"
 	"github.com/flashbots/mev-boost-relay/common"
 	"github.com/flashbots/mev-boost-relay/database"
@@ -204,7 +204,7 @@ func (hk *Housekeeper) updateProposerDuties(headSlot uint64) {
 	}
 
 	// Convert db entries to signed validator registration type
-	signedValidatorRegistrations := make(map[string]*apiv1.SignedValidatorRegistration)
+	signedValidatorRegistrations := make(map[string]*builderApiV1.SignedValidatorRegistration)
 	for _, regEntry := range validatorRegistrationEntries {
 		signedEntry, err := regEntry.ToSignedValidatorRegistration()
 		if err != nil {


### PR DESCRIPTION
## 📝 Summary

Rename imports for github.com/attestantio/* to be more consistent.

See the mev-boost PR (in the references section) for more details. This PR follows the same conventions.

## ⛱ Motivation and Context

This has been a small pet-peeve of mine for a while. Due to a lot of overlapping package names, we were required to rename some imports. This wasn't very consistent. This PR aims to make things consistent.

## 📚 References

* https://github.com/flashbots/mev-boost/pull/560
* https://github.com/flashbots/mev-boost-relay/pull/509

---

## ✅ I have run these commands

* [ ] `make lint` (see other PR)
* [ ] `make test-race` (see other PR)
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
