### PR TITLE
Create ssz type: SubmitBlockRequestV2Optimistic

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -13,9 +13,10 @@ import (
 	"github.com/attestantio/go-builder-client/spec"
 	apiv1capella "github.com/attestantio/go-eth2-client/api/v1/capella"
 	consensusspec "github.com/attestantio/go-eth2-client/spec"
-	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	consensusbellatrix "github.com/attestantio/go-eth2-client/spec/bellatrix"
 	consensuscapella "github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	ssz "github.com/ferranbt/fastssz"
 	boostTypes "github.com/flashbots/go-boost-utils/types"
 )
 
@@ -692,7 +693,7 @@ func BoostBidToBidTrace(bidTrace *boostTypes.BidTrace) *apiv1.BidTrace {
 		BuilderPubkey:        phase0.BLSPubKey(bidTrace.BuilderPubkey),
 		Slot:                 bidTrace.Slot,
 		ProposerPubkey:       phase0.BLSPubKey(bidTrace.ProposerPubkey),
-		ProposerFeeRecipient: bellatrix.ExecutionAddress(bidTrace.ProposerFeeRecipient),
+		ProposerFeeRecipient: consensusbellatrix.ExecutionAddress(bidTrace.ProposerFeeRecipient),
 		BlockHash:            phase0.Hash32(bidTrace.BlockHash),
 		Value:                U256StrToUint256(bidTrace.Value),
 		ParentHash:           phase0.Hash32(bidTrace.ParentHash),
@@ -801,4 +802,271 @@ func (b *BuilderSubmitBlockRequest) Withdrawals() []*consensuscapella.Withdrawal
 		return b.Capella.ExecutionPayload.Withdrawals
 	}
 	return nil
+}
+
+/*
+SubmitBlockRequestV2Optimistic is the v2 request from the builder to submit
+a block. The message must be SSZ encoded. The first three fields are at most
+944 bytes, which fit into a single 1500 MTU ethernet packet. The
+`UnmarshalSSZHeaderOnly` function just parses the first three fields,
+which is sufficient data to set the bid of the builder. The `Transactions`
+and `Withdrawals` fields are required to construct the full SignedBeaconBlock
+and are parsed asynchronously.
+
+Header only layout:
+[000-236) = Message   (236 bytes)
+[236-240) = offset1   (  4 bytes)
+[240-336) = Signature ( 96 bytes)
+[336-340) = offset2   (  4 bytes)
+[340-344) = offset3   (  4 bytes)
+[344-944) = EPH       (600 bytes)
+*/
+type SubmitBlockRequestV2Optimistic struct {
+	Message                *apiv1.BidTrace
+	ExecutionPayloadHeader *consensuscapella.ExecutionPayloadHeader
+	Signature              phase0.BLSSignature              `ssz-size:"96"`
+	Transactions           []consensusbellatrix.Transaction `ssz-max:"1048576,1073741824" ssz-size:"?,?"`
+	Withdrawals            []*consensuscapella.Withdrawal   `ssz-max:"16"`
+}
+
+// MarshalSSZ ssz marshals the SubmitBlockRequestV2Optimistic object
+func (s *SubmitBlockRequestV2Optimistic) MarshalSSZ() ([]byte, error) {
+	return ssz.MarshalSSZ(s)
+}
+
+// UnmarshalSSZ ssz unmarshals the SubmitBlockRequestV2Optimistic object
+func (s *SubmitBlockRequestV2Optimistic) UnmarshalSSZ(buf []byte) error {
+	var err error
+	size := uint64(len(buf))
+	if size < 344 {
+		return ssz.ErrSize
+	}
+
+	tail := buf
+	var o1, o3, o4 uint64
+
+	// Field (0) 'Message'
+	if s.Message == nil {
+		s.Message = new(apiv1.BidTrace)
+	}
+	if err = s.Message.UnmarshalSSZ(buf[0:236]); err != nil {
+		return err
+	}
+
+	// Offset (1) 'ExecutionPayloadHeader'
+	if o1 = ssz.ReadOffset(buf[236:240]); o1 > size {
+		return ssz.ErrOffset
+	}
+
+	if o1 < 344 {
+		return ssz.ErrInvalidVariableOffset
+	}
+
+	// Field (2) 'Signature'
+	copy(s.Signature[:], buf[240:336])
+
+	// Offset (3) 'Transactions'
+	if o3 = ssz.ReadOffset(buf[336:340]); o3 > size || o1 > o3 {
+		return ssz.ErrOffset
+	}
+
+	// Offset (4) 'Withdrawals'
+	if o4 = ssz.ReadOffset(buf[340:344]); o4 > size || o3 > o4 {
+		return ssz.ErrOffset
+	}
+
+	// Field (1) 'ExecutionPayloadHeader'
+	{
+		buf = tail[o1:o3]
+		if s.ExecutionPayloadHeader == nil {
+			s.ExecutionPayloadHeader = new(consensuscapella.ExecutionPayloadHeader)
+		}
+		if err = s.ExecutionPayloadHeader.UnmarshalSSZ(buf); err != nil {
+			return err
+		}
+	}
+
+	// Field (3) 'Transactions'
+	{
+		buf = tail[o3:o4]
+		num, err := ssz.DecodeDynamicLength(buf, 1073741824)
+		if err != nil {
+			return err
+		}
+		s.Transactions = make([]consensusbellatrix.Transaction, num)
+		err = ssz.UnmarshalDynamic(buf, num, func(indx int, buf []byte) (err error) {
+			if len(buf) > 1073741824 {
+				return ssz.ErrBytesLength
+			}
+			if cap(s.Transactions[indx]) == 0 {
+				s.Transactions[indx] = consensusbellatrix.Transaction(make([]byte, 0, len(buf)))
+			}
+			s.Transactions[indx] = append(s.Transactions[indx], buf...)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// Field (4) 'Withdrawals'
+	{
+		buf = tail[o4:]
+		num, err := ssz.DivideInt2(len(buf), 44, 16)
+		if err != nil {
+			return err
+		}
+		s.Withdrawals = make([]*consensuscapella.Withdrawal, num)
+		for ii := 0; ii < num; ii++ {
+			if s.Withdrawals[ii] == nil {
+				s.Withdrawals[ii] = new(consensuscapella.Withdrawal)
+			}
+			if err = s.Withdrawals[ii].UnmarshalSSZ(buf[ii*44 : (ii+1)*44]); err != nil {
+				return err
+			}
+		}
+	}
+	return err
+}
+
+// UnmarshalSSZHeaderOnly ssz unmarshals the first 3 fields of the SubmitBlockRequestV2Optimistic object
+func (s *SubmitBlockRequestV2Optimistic) UnmarshalSSZHeaderOnly(buf []byte) error {
+	var err error
+	size := uint64(len(buf))
+	if size < 344 {
+		return ssz.ErrSize
+	}
+
+	tail := buf
+	var o1, o3 uint64
+
+	// Field (0) 'Message'
+	if s.Message == nil {
+		s.Message = new(apiv1.BidTrace)
+	}
+	if err = s.Message.UnmarshalSSZ(buf[0:236]); err != nil {
+		return err
+	}
+
+	// Offset (1) 'ExecutionPayloadHeader'
+	if o1 = ssz.ReadOffset(buf[236:240]); o1 > size {
+		return ssz.ErrOffset
+	}
+
+	if o1 < 344 {
+		return ssz.ErrInvalidVariableOffset
+	}
+
+	// Field (2) 'Signature'
+	copy(s.Signature[:], buf[240:336])
+
+	// Offset (3) 'Transactions'
+	if o3 = ssz.ReadOffset(buf[336:340]); o3 > size || o1 > o3 {
+		return ssz.ErrOffset
+	}
+
+	// Field (1) 'ExecutionPayloadHeader'
+	{
+		buf = tail[o1:o3]
+		if s.ExecutionPayloadHeader == nil {
+			s.ExecutionPayloadHeader = new(consensuscapella.ExecutionPayloadHeader)
+		}
+		if err = s.ExecutionPayloadHeader.UnmarshalSSZ(buf); err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+// MarshalSSZTo ssz marshals the SubmitBlockRequestV2Optimistic object to a target array
+func (s *SubmitBlockRequestV2Optimistic) MarshalSSZTo(buf []byte) (dst []byte, err error) {
+	dst = buf
+	offset := int(344)
+
+	// Field (0) 'Message'
+	if s.Message == nil {
+		s.Message = new(apiv1.BidTrace)
+	}
+	if dst, err = s.Message.MarshalSSZTo(dst); err != nil {
+		return
+	}
+
+	// Offset (1) 'ExecutionPayloadHeader'
+	dst = ssz.WriteOffset(dst, offset)
+	if s.ExecutionPayloadHeader == nil {
+		s.ExecutionPayloadHeader = new(consensuscapella.ExecutionPayloadHeader)
+	}
+	offset += s.ExecutionPayloadHeader.SizeSSZ()
+
+	// Field (2) 'Signature'
+	dst = append(dst, s.Signature[:]...)
+
+	// Offset (3) 'Transactions'
+	dst = ssz.WriteOffset(dst, offset)
+	for ii := 0; ii < len(s.Transactions); ii++ {
+		offset += 4
+		offset += len(s.Transactions[ii])
+	}
+
+	// Offset (4) 'Withdrawals'
+	dst = ssz.WriteOffset(dst, offset)
+
+	// Field (1) 'ExecutionPayloadHeader'
+	if dst, err = s.ExecutionPayloadHeader.MarshalSSZTo(dst); err != nil {
+		return
+	}
+
+	// Field (3) 'Transactions'
+	if size := len(s.Transactions); size > 1073741824 {
+		err = ssz.ErrListTooBigFn("SubmitBlockRequestV2Optimistic.Transactions", size, 1073741824)
+		return
+	}
+	{
+		offset = 4 * len(s.Transactions)
+		for ii := 0; ii < len(s.Transactions); ii++ {
+			dst = ssz.WriteOffset(dst, offset)
+			offset += len(s.Transactions[ii])
+		}
+	}
+	for ii := 0; ii < len(s.Transactions); ii++ {
+		if size := len(s.Transactions[ii]); size > 1073741824 {
+			err = ssz.ErrBytesLengthFn("SubmitBlockRequestV2Optimistic.Transactions[ii]", size, 1073741824)
+			return
+		}
+		dst = append(dst, s.Transactions[ii]...)
+	}
+
+	// Field (4) 'Withdrawals'
+	if size := len(s.Withdrawals); size > 16 {
+		err = ssz.ErrListTooBigFn("SubmitBlockRequestV2Optimistic.Withdrawals", size, 16)
+		return
+	}
+	for ii := 0; ii < len(s.Withdrawals); ii++ {
+		if dst, err = s.Withdrawals[ii].MarshalSSZTo(dst); err != nil {
+			return
+		}
+	}
+	return dst, nil
+}
+
+// SizeSSZ returns the ssz encoded size in bytes for the SubmitBlockRequestV2Optimistic object
+func (s *SubmitBlockRequestV2Optimistic) SizeSSZ() (size int) {
+	size = 344
+
+	// Field (1) 'ExecutionPayloadHeader'
+	if s.ExecutionPayloadHeader == nil {
+		s.ExecutionPayloadHeader = new(consensuscapella.ExecutionPayloadHeader)
+	}
+	size += s.ExecutionPayloadHeader.SizeSSZ()
+
+	// Field (3) 'Transactions'
+	for ii := 0; ii < len(s.Transactions); ii++ {
+		size += 4
+		size += len(s.Transactions[ii])
+	}
+
+	// Field (4) 'Withdrawals'
+	size += len(s.Withdrawals) * 44
+
+	return
 }

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -1,14 +1,89 @@
 package common
 
 import (
+	"encoding/hex"
 	"testing"
 
+	v1 "github.com/attestantio/go-builder-client/api/v1"
 	consensusspec "github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	boostTypes "github.com/flashbots/go-boost-utils/types"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
+
+func makeTestSubmitBlockRequestV2Optimistic(t *testing.T) *SubmitBlockRequestV2Optimistic {
+	t.Helper()
+	testParentHash, err := hex.DecodeString("ec51bd499a3fa0270f1446fbf05ff0b61157cfe4ec719bb4c3e834e339ee9c5c")
+	require.Nil(t, err)
+	testBlockHash, err := hex.DecodeString("3f5b5aaa800a3d25c3f75e72dc45da89fdd58168f1358a9f94aac8b029361a0a")
+	require.Nil(t, err)
+	testRandao, err := hex.DecodeString("8cf6b7fbfbaf80da001fe769fd02e9b8dbfa0a646d9cf51b5d7137dd4f8103cc")
+	require.Nil(t, err)
+	testRoot, err := hex.DecodeString("7554727cee6d976a1dfdad80b392b37c87f0651ff5b01f6a0b3402bcfce92077")
+	require.Nil(t, err)
+	testBuilderPubkey, err := hex.DecodeString("ae7bde4839fa905b7d8125fd84cfdcd0c32cd74e1be3fa24263d71b520fc78113326ce0a90b95d73f19e6d8150a2f73b")
+	require.Nil(t, err)
+	testProposerPubkey, err := hex.DecodeString("bb8e223239fa905b7d8125fd84cfdcd0c32cd74e1be3fa24263d71b520fc78113326ce0a90b95d73f19e6d8150a2f73b")
+	require.Nil(t, err)
+	testAddress, err := hex.DecodeString("95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5")
+	require.Nil(t, err)
+	testSignature, err := hex.DecodeString("b06311be19c92307c06070578af9ad147c9c6ea902439eac19f785f3dca478c354b79a0af9b09839c3d06c1ccf2185b0162f4d4fbf981220f77586b52ed9ae8a8acfc953baaa30dee15e1b112913c6cbe02c780d7b5363a4af16563fe55c2e88")
+	require.Nil(t, err)
+	testValue := new(uint256.Int)
+	err = testValue.SetFromDecimal("100")
+	require.Nil(t, err)
+
+	return &SubmitBlockRequestV2Optimistic{
+		Message: &v1.BidTrace{
+			Slot:                 31,
+			ParentHash:           phase0.Hash32(testParentHash),
+			BlockHash:            phase0.Hash32(testBlockHash),
+			BuilderPubkey:        phase0.BLSPubKey(testBuilderPubkey),
+			ProposerPubkey:       phase0.BLSPubKey(testProposerPubkey),
+			ProposerFeeRecipient: bellatrix.ExecutionAddress(testAddress),
+			GasLimit:             30_000_000,
+			GasUsed:              15_000_000,
+			Value:                testValue,
+		},
+		ExecutionPayloadHeader: &capella.ExecutionPayloadHeader{
+			ParentHash:       phase0.Hash32(testParentHash),
+			FeeRecipient:     bellatrix.ExecutionAddress(testAddress),
+			StateRoot:        [32]byte(testBlockHash),
+			ReceiptsRoot:     [32]byte(testBlockHash),
+			LogsBloom:        [256]byte{0xaa, 0xbb, 0xcc},
+			PrevRandao:       [32]byte(testRandao),
+			BlockNumber:      30,
+			GasLimit:         30_000_000,
+			GasUsed:          15_000_000,
+			Timestamp:        168318215,
+			ExtraData:        make([]byte, 32),
+			BaseFeePerGas:    [32]byte{0xaa, 0xbb},
+			BlockHash:        phase0.Hash32(testBlockHash),
+			TransactionsRoot: phase0.Root(testRoot),
+			WithdrawalsRoot:  phase0.Root(testRoot),
+		},
+		Signature: phase0.BLSSignature(testSignature),
+		Transactions: []bellatrix.Transaction{
+			[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09},
+			[]byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19},
+			[]byte{0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29},
+			[]byte{0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39},
+			[]byte{0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49},
+			[]byte{0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59},
+		},
+		Withdrawals: []*capella.Withdrawal{
+			{
+				Index:          capella.WithdrawalIndex(120),
+				ValidatorIndex: phase0.ValidatorIndex(121),
+				Address:        bellatrix.ExecutionAddress(testAddress),
+				Amount:         phase0.Gwei(102412521125125),
+			},
+		},
+	}
+}
 
 func TestBoostBidToBidTrace(t *testing.T) {
 	bidTrace := boostTypes.BidTrace{
@@ -36,4 +111,45 @@ func TestDataVersion(t *testing.T) {
 	require.Equal(t, ForkVersionStringBellatrix, consensusspec.DataVersionBellatrix.String())
 	require.Equal(t, ForkVersionStringCapella, consensusspec.DataVersionCapella.String())
 	require.Equal(t, ForkVersionStringDeneb, consensusspec.DataVersionDeneb.String())
+}
+
+func compareV2RequestEquality(t *testing.T, src, targ *SubmitBlockRequestV2Optimistic) {
+	require.Equal(t, src.Message.String(), targ.Message.String())
+	require.Equal(t, src.ExecutionPayloadHeader.String(), targ.ExecutionPayloadHeader.String())
+	require.Equal(t, src.Signature, targ.Signature)
+	for i := 0; i < len(src.Transactions); i++ {
+		require.Equal(t, src.Transactions[i], targ.Transactions[i])
+	}
+	for i := 0; i < len(src.Withdrawals); i++ {
+		require.Equal(t, src.Withdrawals[i].String(), targ.Withdrawals[i].String())
+	}
+}
+
+func TestSubmitBlockRequestV2Optimistic(t *testing.T) {
+	obj := makeTestSubmitBlockRequestV2Optimistic(t)
+
+	// Encode the object.
+	sszObj, err := obj.MarshalSSZ()
+	require.Nil(t, err)
+	require.Equal(t, obj.SizeSSZ(), len(sszObj))
+
+	// Unmarshall the full object.
+	unmarshalled := new(SubmitBlockRequestV2Optimistic)
+	err = unmarshalled.UnmarshalSSZ(sszObj)
+	require.Nil(t, err)
+
+	compareV2RequestEquality(t, obj, unmarshalled)
+
+	// Clear out non-header data.
+	obj.Transactions = []bellatrix.Transaction{}
+	obj.Withdrawals = []*capella.Withdrawal{}
+
+	// Unmarshall just the header.
+	unmarshalledHeader := new(SubmitBlockRequestV2Optimistic)
+	unmarshalledHeader.UnmarshalSSZHeaderOnly(sszObj)
+
+	compareV2RequestEquality(t, obj, unmarshalledHeader)
+
+	// Make sure size is correct (must have 32 bytes of ExtraData).
+	require.Equal(t, unmarshalledHeader.SizeSSZ(), 944)
 }

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -114,6 +114,7 @@ func TestDataVersion(t *testing.T) {
 }
 
 func compareV2RequestEquality(t *testing.T, src, targ *SubmitBlockRequestV2Optimistic) {
+	t.Helper()
 	require.Equal(t, src.Message.String(), targ.Message.String())
 	require.Equal(t, src.ExecutionPayloadHeader.String(), targ.ExecutionPayloadHeader.String())
 	require.Equal(t, src.Signature, targ.Signature)
@@ -146,7 +147,8 @@ func TestSubmitBlockRequestV2Optimistic(t *testing.T) {
 
 	// Unmarshal just the header.
 	unmarshalHeader := new(SubmitBlockRequestV2Optimistic)
-	unmarshalHeader.UnmarshalSSZHeaderOnly(sszObj)
+	err = unmarshalHeader.UnmarshalSSZHeaderOnly(sszObj)
+	require.Nil(t, err)
 
 	compareV2RequestEquality(t, obj, unmarshalHeader)
 

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -133,23 +133,23 @@ func TestSubmitBlockRequestV2Optimistic(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, obj.SizeSSZ(), len(sszObj))
 
-	// Unmarshall the full object.
-	unmarshalled := new(SubmitBlockRequestV2Optimistic)
-	err = unmarshalled.UnmarshalSSZ(sszObj)
+	// Unmarshal the full object.
+	unmarshal := new(SubmitBlockRequestV2Optimistic)
+	err = unmarshal.UnmarshalSSZ(sszObj)
 	require.Nil(t, err)
 
-	compareV2RequestEquality(t, obj, unmarshalled)
+	compareV2RequestEquality(t, obj, unmarshal)
 
 	// Clear out non-header data.
 	obj.Transactions = []bellatrix.Transaction{}
 	obj.Withdrawals = []*capella.Withdrawal{}
 
-	// Unmarshall just the header.
-	unmarshalledHeader := new(SubmitBlockRequestV2Optimistic)
-	unmarshalledHeader.UnmarshalSSZHeaderOnly(sszObj)
+	// Unmarshal just the header.
+	unmarshalHeader := new(SubmitBlockRequestV2Optimistic)
+	unmarshalHeader.UnmarshalSSZHeaderOnly(sszObj)
 
-	compareV2RequestEquality(t, obj, unmarshalledHeader)
+	compareV2RequestEquality(t, obj, unmarshalHeader)
 
 	// Make sure size is correct (must have 32 bytes of ExtraData).
-	require.Equal(t, unmarshalledHeader.SizeSSZ(), 944)
+	require.Equal(t, unmarshalHeader.SizeSSZ(), 944)
 }

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/ferranbt/fastssz v0.1.3 // indirect
+	github.com/ferranbt/fastssz v0.1.3
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect


### PR DESCRIPTION
## 📝 Summary

Creating the type and SSZ encoding needed for the v2 optimistic builder submissions. 

This type implements the standard SSZ interface

```
MarshalSSZ
UnmarshalSSZ
MarshalSSZTo
SizeSSZ
```

We also define a custom decode that only parses the header part of the bid `UnmarshalSSZHeaderOnly`. 

This follows up on the series: https://github.com/flashbots/mev-boost-relay/pull/479, https://github.com/flashbots/mev-boost-relay/pull/491, https://github.com/flashbots/mev-boost-relay/pull/494, https://github.com/flashbots/mev-boost-relay/pull/498, https://github.com/flashbots/mev-boost-relay/pull/513, https://github.com/flashbots/mev-boost-relay/pull/514, which aim at reducing the diff and productionizing https://github.com/flashbots/mev-boost-relay/pull/466.


## ⛱ Motivation and Context

SubmitBlockRequestV2Optimistic is the v2 request from the builder to submit a block. The message must be SSZ encoded. The first three fields are at most 944 bytes, which fit into a single 1500 MTU ethernet packet. The `UnmarshalSSZHeaderOnly` function just parses the first three fields, which is sufficient data to set the bid of the builder. The `Transactions` and `Withdrawals` fields are required to construct the full SignedBeaconBlock and are parsed asynchronously.

```
Header only layout:
[000-236) = Message   (236 bytes)
[236-240) = offset1   (  4 bytes)
[240-336) = Signature ( 96 bytes)
[336-340) = offset2   (  4 bytes)
[340-344) = offset3   (  4 bytes)
[344-944) = EPH       (600 bytes)
```

## 📚 References

https://notes.ethereum.org/@mikeneuder/optimistic-v2

https://github.com/michaelneuder/optimistic-relay-documentation/blob/main/towards-epbs.md#optimistic-relay-v2-header-only-parsing

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
