### PR TITLE
Allow fork epochs to be 0

### DIFF
--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -429,7 +429,8 @@ func TestBuilderSubmitBlock(t *testing.T) {
 
 	// Setup the test relay backend
 	backend.relay.headSlot.Store(headSlot)
-	backend.relay.capellaEpoch = 1
+	backend.relay.capellaEpoch = 0
+	backend.relay.denebEpoch = 1
 	backend.relay.proposerDutiesMap = make(map[uint64]*common.BuilderGetValidatorsResponseEntry)
 	backend.relay.proposerDutiesMap[headSlot+1] = &common.BuilderGetValidatorsResponseEntry{
 		Slot: headSlot,
@@ -719,7 +720,6 @@ func TestCheckSubmissionPayloadAttrs(t *testing.T) {
 			backend.relay.payloadAttributesLock.RLock()
 			backend.relay.payloadAttributes[testParentHash] = tc.attrs
 			backend.relay.payloadAttributesLock.RUnlock()
-			backend.relay.capellaEpoch = 1
 
 			w := httptest.NewRecorder()
 			logger := logrus.New()

--- a/services/api/utils.go
+++ b/services/api/utils.go
@@ -104,9 +104,6 @@ func checkBLSPublicKeyHex(pkHex string) error {
 }
 
 func hasReachedFork(slot, forkEpoch uint64) bool {
-	if forkEpoch == 0 {
-		return false
-	}
 	currentEpoch := slot / common.SlotsPerEpoch
 	return currentEpoch >= forkEpoch
 }


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Allows fork epochs from the validator to be 0. 

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This allows for devnet testing in which capella epoch = 0. This will speed up kurtosis testing to reduce the wait time for capella epoch.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
