### PR TITLE
Add feature flags for backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `FORCE_GET_HEADER_204` - force 204 as getHeader response
 * `ENABLE_IGNORABLE_VALIDATION_ERRORS` - enable ignorable validation errors
 * `USE_V2_PUBLISH_BLOCK_ENDPOINT` - uses the v2 publish block endpoint on the beacon node
-* `REQUIRE_DENEB_FORK_SCHEDULE` - enforces validation for beacon node to return a deneb fork schedule
 
 #### Development Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `FORCE_GET_HEADER_204` - force 204 as getHeader response
 * `ENABLE_IGNORABLE_VALIDATION_ERRORS` - enable ignorable validation errors
 * `USE_V2_PUBLISH_BLOCK_ENDPOINT` - uses the v2 publish block endpoint on the beacon node
-* `FORCE_DENEB_FORK_SCHEDULE` - forces validation for beacon node to return a deneb fork schedule
+* `CHECK_DENEB_FORK_SCHEDULE` - enforces validation for beacon node to return a deneb fork schedule
 
 #### Development Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `DISABLE_LOWPRIO_BUILDERS` - reject block submissions by low-prio builders
 * `FORCE_GET_HEADER_204` - force 204 as getHeader response
 * `ENABLE_IGNORABLE_VALIDATION_ERRORS` - enable ignorable validation errors
+* `USE_V2_PUBLISH_BLOCK_ENDPOINT` - uses the v2 publish block endpoint on the beacon node
+* `FORCE_DENEB_FORK_SCHEDULE` - forces validation for beacon node to return a deneb fork schedule
 
 #### Development Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `FORCE_GET_HEADER_204` - force 204 as getHeader response
 * `ENABLE_IGNORABLE_VALIDATION_ERRORS` - enable ignorable validation errors
 * `USE_V2_PUBLISH_BLOCK_ENDPOINT` - uses the v2 publish block endpoint on the beacon node
-* `CHECK_DENEB_FORK_SCHEDULE` - enforces validation for beacon node to return a deneb fork schedule
+* `REQUIRE_DENEB_FORK_SCHEDULE` - enforces validation for beacon node to return a deneb fork schedule
 
 #### Development Environment Variables
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -423,13 +423,13 @@ func (api *RelayAPI) StartServer() (err error) {
 	}
 
 	// feature flags
-	ffCheckDenebForkSchedule := false // compatibility with older CL clients missing deneb fork schedule
-	if os.Getenv("CHECK_DENEB_FORK_SCHEDULE") != "" {
-		log.Warn("env: CHECK_DENEB_FORK_SCHEDULE: checking validation for deneb fork schedule")
-		ffCheckDenebForkSchedule = true
+	ffRequireDenebForkSchedule := false // compatibility with older CL clients missing deneb fork schedule
+	if os.Getenv("REQUIRE_DENEB_FORK_SCHEDULE") != "" {
+		log.Warn("env: REQUIRE_DENEB_FORK_SCHEDULE: checking validation for deneb fork schedule")
+		ffRequireDenebForkSchedule = true
 	}
 
-	if ffCheckDenebForkSchedule {
+	if ffRequireDenebForkSchedule {
 		if !foundCapellaEpoch || !foundDenebEpoch {
 			return ErrMissingForkVersions
 		}
@@ -440,7 +440,7 @@ func (api *RelayAPI) StartServer() (err error) {
 	}
 
 	// Print fork version information
-	if ffCheckDenebForkSchedule && hasReachedFork(currentSlot, api.denebEpoch) {
+	if foundDenebEpoch && hasReachedFork(currentSlot, api.denebEpoch) {
 		log.Infof("deneb fork detected (currentEpoch: %d / denebEpoch: %d)", common.SlotToEpoch(currentSlot), api.denebEpoch)
 	} else if hasReachedFork(currentSlot, api.capellaEpoch) {
 		log.Infof("capella fork detected (currentEpoch: %d / capellaEpoch: %d)", common.SlotToEpoch(currentSlot), api.capellaEpoch)

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -53,8 +53,6 @@ var (
 	ErrRelayPubkeyMismatch        = errors.New("relay pubkey does not match existing one")
 	ErrServerAlreadyStarted       = errors.New("server was already started")
 	ErrBuilderAPIWithoutSecretKey = errors.New("cannot start builder API without secret key")
-	ErrMismatchedForkVersions     = errors.New("can not find matching fork versions as retrieved from beacon node")
-	ErrMissingForkVersions        = errors.New("invalid fork version from beacon node")
 )
 
 var (
@@ -422,27 +420,10 @@ func (api *RelayAPI) StartServer() (err error) {
 		}
 	}
 
-	// feature flags
-	ffRequireDenebForkSchedule := false // compatibility with older CL clients missing deneb fork schedule
-	if os.Getenv("REQUIRE_DENEB_FORK_SCHEDULE") != "" {
-		log.Warn("env: REQUIRE_DENEB_FORK_SCHEDULE: checking validation for deneb fork schedule")
-		ffRequireDenebForkSchedule = true
-	}
-
-	if ffRequireDenebForkSchedule {
-		if !foundCapellaEpoch || !foundDenebEpoch {
-			return ErrMissingForkVersions
-		}
-	} else {
-		if !foundCapellaEpoch {
-			return ErrMissingForkVersions
-		}
-	}
-
 	// Print fork version information
 	if foundDenebEpoch && hasReachedFork(currentSlot, api.denebEpoch) {
 		log.Infof("deneb fork detected (currentEpoch: %d / denebEpoch: %d)", common.SlotToEpoch(currentSlot), api.denebEpoch)
-	} else if hasReachedFork(currentSlot, api.capellaEpoch) {
+	} else if foundCapellaEpoch && hasReachedFork(currentSlot, api.capellaEpoch) {
 		log.Infof("capella fork detected (currentEpoch: %d / capellaEpoch: %d)", common.SlotToEpoch(currentSlot), api.capellaEpoch)
 	}
 


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Adds two feature flags to maintain backwards compatibility with older CL clients. 

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
New features were recently added which breaks compatibility with older clients. This PR adds feature flags allowing toggling via env vars to switch between the features:

* `USE_V2_PUBLISH_BLOCK_ENDPOINT` - this toggles using the v2 endpoint on CL clients to publish blocks. This endpoint includes equivocation checks to prevent equivocation attacks. The latest prysm and lighthouse releases has not been tested thoroughly for the v2 endpoint, so the default for this flag is using the v1 endpoint.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
