### PR TITLE
Update website.html

### DIFF
--- a/services/website/website.html
+++ b/services/website/website.html
@@ -187,11 +187,11 @@
                     <table class="pure-table pure-table-horizontal">
                         <tbody>
                             <tr title="Currently active or pending validators on Ethereum PoS">
-                                <td>Validators total</td>
+                                <td>Validators active or in queue</td>
                                 <td>{{ .ValidatorsTotal | prettyInt }}</td>
                             </tr>
                             <tr title="Validators who have sent a registration at least once">
-                                <td>Validators registered</td>
+                                <td>Validators registered (all time)</td>
                                 <td>{{ .ValidatorsRegistered| prettyInt }}</td>
                             </tr>
                             <tr title="Last slot delivered through this relay">


### PR DESCRIPTION
Edited descriptions for validators stats

## 📝 Summary

A tiny edit to the titles used to describe the validator stats. 

## ⛱ Motivation and Context

Without the tooltip (for example on mobile) it may cause confusion for users that compare "validator total" with "validator registered". Especially if "validator registered" exceeds "validator total". This change aims to make this a bit more clear.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* ❌ `make lint`
* ❌ `make test-race`
* ❌ `go mod tidy`
* ✅ I have seen and agree to `CONTRIBUTING.md`
