### PR TITLE
optimistic v2 slowpath

### DIFF
--- a/services/api/optimistic_test.go
+++ b/services/api/optimistic_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -691,7 +690,7 @@ func TestBuilderApiOptimisticV2SlowPath(t *testing.T) {
 		},
 		{
 			description:    "failure_empty_payload",
-			simError:       errors.New("test err"),
+			simError:       errFake,
 			expectDemotion: true,
 		},
 	}

--- a/services/api/optimistic_test.go
+++ b/services/api/optimistic_test.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -12,6 +14,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/attestantio/go-builder-client/api/capella"
 	v1 "github.com/attestantio/go-builder-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	consensuscapella "github.com/attestantio/go-eth2-client/spec/capella"
@@ -637,6 +640,84 @@ func TestBuilderApiSubmitNewBlockOptimisticV2_full(t *testing.T) {
 			// Check http code.
 			rr := backend.requestBytes(http.MethodPost, pathSubmitNewBlockV2, outBytes, map[string]string{})
 			require.Equal(t, uint64(rr.Code), tc.httpCode)
+		})
+	}
+}
+
+func TestBuilderApiOptimisticV2SlowPath_fail_ssz_decode_header(t *testing.T) {
+	pubkey, _ := generateKeyPair(t)
+	backend := startTestBackend(t, pubkey)
+	outBytes := make([]byte, 944) // 944 bytes is min required to try ssz decoding.
+	outBytes[0] = 0xaa
+
+	r := bytes.NewReader(outBytes)
+
+	backend.relay.optimisticV2SlowPath(r, v2SlowPathOpts{
+		payload: &common.BuilderSubmitBlockRequest{
+			Capella: &capella.SubmitBlockRequest{
+				Message: &v1.BidTrace{
+					BuilderPubkey: *pubkey,
+				},
+			},
+		},
+	})
+
+	// Check that demotion occurred.
+	mockDB, ok := backend.relay.db.(*database.MockDB)
+	require.True(t, ok)
+	require.Equal(t, mockDB.Demotions[pubkey.String()], true)
+}
+
+func TestBuilderApiOptimisticV2SlowPath(t *testing.T) {
+	pubkey, secretkey := generateKeyPair(t)
+
+	testReq := common.TestBuilderSubmitBlockRequestV2(secretkey, getTestBidTrace(*pubkey, 10))
+	testPayload := &common.BuilderSubmitBlockRequest{
+		Capella: &capella.SubmitBlockRequest{
+			Message: &v1.BidTrace{
+				BuilderPubkey: *pubkey,
+			},
+			ExecutionPayload: &consensuscapella.ExecutionPayload{},
+		},
+	}
+
+	testCases := []struct {
+		description    string
+		simError       error
+		expectDemotion bool
+	}{
+		{
+			description: "success",
+		},
+		{
+			description:    "failure_empty_payload",
+			simError:       errors.New("test err"),
+			expectDemotion: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			backend := startTestBackend(t, pubkey)
+			backend.relay.blockSimRateLimiter = &MockBlockSimulationRateLimiter{
+				simulationError: tc.simError,
+			}
+
+			submissionBytes, err := testReq.MarshalSSZ()
+			require.NoError(t, err)
+
+			r := bytes.NewReader(submissionBytes)
+
+			opts := v2SlowPathOpts{
+				payload: testPayload,
+				entry:   &blockBuilderCacheEntry{},
+			}
+			backend.relay.optimisticV2SlowPath(r, opts)
+
+			// Check demotion status.
+			mockDB, ok := backend.relay.db.(*database.MockDB)
+			require.True(t, ok)
+			require.Equal(t, mockDB.Demotions[pubkey.String()], tc.expectDemotion)
 		})
 	}
 }


### PR DESCRIPTION
## 📝 Summary

Completion of the v2 code. This is diffed off https://github.com/flashbots/mev-boost-relay/pull/524 to make the review clearer.

This follows up on the series: https://github.com/flashbots/mev-boost-relay/pull/479, https://github.com/flashbots/mev-boost-relay/pull/491, https://github.com/flashbots/mev-boost-relay/pull/494, https://github.com/flashbots/mev-boost-relay/pull/498, https://github.com/flashbots/mev-boost-relay/pull/513, https://github.com/flashbots/mev-boost-relay/pull/514, https://github.com/flashbots/mev-boost-relay/pull/518, https://github.com/flashbots/mev-boost-relay/pull/524 which aim at reducing the diff and productionizing https://github.com/flashbots/mev-boost-relay/pull/466.

## ⛱ Motivation and Context

This PR implements the slow path of the v2 code, which parses the full transactions and withdrawals, saves the payload, and runs the simulation.

## 📚 References

https://notes.ethereum.org/@mikeneuder/optimistic-v2

https://github.com/michaelneuder/optimistic-relay-documentation/blob/main/towards-epbs.md#optimistic-relay-v2-header-only-parsing


---

## ✅ I have run these commands

* [x] `make lint`
* [ ] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
