### PR TITLE
Only commit to saving payload once the response has been found

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1278,6 +1278,38 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 	var getPayloadResp *common.VersionedExecutionPayload
 	var msNeededForPublishing uint64
 
+	// Get the response - from Redis, Memcache or DB
+	getPayloadResp, err = api.datastore.GetGetPayloadResponse(log, payload.Slot(), proposerPubkey.String(), payload.BlockHash())
+	if err != nil || getPayloadResp == nil {
+		log.WithError(err).Warn("failed getting execution payload (1/2)")
+		time.Sleep(time.Duration(timeoutGetPayloadRetryMs) * time.Millisecond)
+
+		// Try again
+		getPayloadResp, err = api.datastore.GetGetPayloadResponse(log, payload.Slot(), proposerPubkey.String(), payload.BlockHash())
+		if err != nil || getPayloadResp == nil {
+			// Still not found! Error out now.
+			if errors.Is(err, datastore.ErrExecutionPayloadNotFound) {
+				// Couldn't find the execution payload, maybe it never was submitted to our relay! Check that now
+				_, err := api.db.GetBlockSubmissionEntry(payload.Slot(), proposerPubkey.String(), payload.BlockHash())
+				if errors.Is(err, sql.ErrNoRows) {
+					log.Warn("failed getting execution payload (2/2) - payload not found, block was never submitted to this relay")
+					api.RespondError(w, http.StatusBadRequest, "no execution payload for this request - block was never seen by this relay")
+				} else if err != nil {
+					log.WithError(err).Error("failed getting execution payload (2/2) - payload not found, and error on checking bids")
+				} else {
+					log.Error("failed getting execution payload (2/2) - payload not found, but found bid in database")
+				}
+			} else { // some other error
+				log.WithError(err).Error("failed getting execution payload (2/2) - error")
+			}
+			api.RespondError(w, http.StatusBadRequest, "no execution payload for this request")
+			return
+		}
+	}
+
+	// Now we know this relay also has the payload
+	log = log.WithField("timestampAfterLoadResponse", time.Now().UTC().UnixMilli())
+
 	// Save information about delivered payload
 	defer func() {
 		bidTrace, err := api.redis.GetBidTrace(payload.Slot(), proposerPubkey.String(), payload.BlockHash())
@@ -1353,39 +1385,6 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 			}).WithError(err).Error("unable to update builder demotion with refund justification")
 		}
 	}()
-
-	// Get the response - from Redis, Memcache or DB
-	// note that recent mev-boost versions only send getPayload to relays that provided the bid
-	getPayloadResp, err = api.datastore.GetGetPayloadResponse(log, payload.Slot(), proposerPubkey.String(), payload.BlockHash())
-	if err != nil || getPayloadResp == nil {
-		log.WithError(err).Warn("failed getting execution payload (1/2)")
-		time.Sleep(time.Duration(timeoutGetPayloadRetryMs) * time.Millisecond)
-
-		// Try again
-		getPayloadResp, err = api.datastore.GetGetPayloadResponse(log, payload.Slot(), proposerPubkey.String(), payload.BlockHash())
-		if err != nil || getPayloadResp == nil {
-			// Still not found! Error out now.
-			if errors.Is(err, datastore.ErrExecutionPayloadNotFound) {
-				// Couldn't find the execution payload, maybe it never was submitted to our relay! Check that now
-				_, err := api.db.GetBlockSubmissionEntry(payload.Slot(), proposerPubkey.String(), payload.BlockHash())
-				if errors.Is(err, sql.ErrNoRows) {
-					log.Warn("failed getting execution payload (2/2) - payload not found, block was never submitted to this relay")
-					api.RespondError(w, http.StatusBadRequest, "no execution payload for this request - block was never seen by this relay")
-				} else if err != nil {
-					log.WithError(err).Error("failed getting execution payload (2/2) - payload not found, and error on checking bids")
-				} else {
-					log.Error("failed getting execution payload (2/2) - payload not found, but found bid in database")
-				}
-			} else { // some other error
-				log.WithError(err).Error("failed getting execution payload (2/2) - error")
-			}
-			api.RespondError(w, http.StatusBadRequest, "no execution payload for this request")
-			return
-		}
-	}
-
-	// Now we know this relay also has the payload
-	log = log.WithField("timestampAfterLoadResponse", time.Now().UTC().UnixMilli())
 
 	// Check whether getPayload has already been called -- TODO: do we need to allow multiple submissions of one blinded block?
 	err = api.redis.CheckAndSetLastSlotAndHashDelivered(payload.Slot(), payload.BlockHash())


### PR DESCRIPTION
## 📝 Summary

In #512 `handleGetPayload` was changed to save execution payloads even if the publication was unsuccessful. However, the function commits to saving the payload before it has performed its check to see if the payload in question is available. This PR swaps the order of these operations, so that it does not try to save a payload that cannot be found.

## ⛱ Motivation and Context

Currently, `handleGetPayload` commits to saving the requested execution payload (via `defer func()`) immediately after the header signature is verified, in order to ensure that data is stored long-term. Next, the function checks if the payload response is available in the datastore. If it is *not* available (the relay had never seen the payload, and the proposer is querying all relays anyway), that situation will be caught here and the function will exit relatively gracefully with a descriptive warning.

After that, the deferred code is run, regardless of whether the response was found. If the corresponding bid was never received, the code will fail its first check, producing an error that appears to be serious at first glance:

```level=error msg="failed to get bidTrace for delivered payload from redis"```

This PR changes the order of operations: the function only attempts to save the execution payload if the payload is actually available to be saved. The main benefit is in removal of confusing false-positive errors, though it additionally removes one redis read from the case where the payload is unavailable. This does not affect the desired behavior in #512: the payload will be saved regardless of whether publication was successful.

---

## ✅ I have run these commands

* [✅] `make lint`
* [✅] `make test-race`
* [✅] `go mod tidy`
* [✅] I have seen and agree to `CONTRIBUTING.md`
