### PR TITLE
Draft: log timestamps in RFC3339Nano

### DIFF
--- a/common/logging.go
+++ b/common/logging.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"os"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -11,10 +12,13 @@ func LogSetup(json bool, logLevel string) *logrus.Entry {
 	log.Logger.SetOutput(os.Stdout)
 
 	if json {
-		log.Logger.SetFormatter(&logrus.JSONFormatter{})
+		log.Logger.SetFormatter(&logrus.JSONFormatter{
+			TimestampFormat: time.RFC3339Nano,
+		})
 	} else {
 		log.Logger.SetFormatter(&logrus.TextFormatter{
-			FullTimestamp: true,
+			TimestampFormat: time.RFC3339Nano,
+			FullTimestamp:   true,
 		})
 	}
 


### PR DESCRIPTION
## 📝 Summary

- Changes the timestamp format to human-readable RFC3339.
- Increases the precision to nanosecond from second.

## ⛱ Motivation and Context

Current log precision is on the second level. On a high volume relay bids are in the hundreds per second, meaning logs, in the thousands, will share the same timestamp and lose their ordering. This would return ordering, and as a bonus make timestamps human-readable.

## 📚 References

---

## ✅ I have run these commands

* [ ] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
