### PR TITLE
Redis waitgroup for optimistic block sync

### DIFF
--- a/datastore/redis.go
+++ b/datastore/redis.go
@@ -146,6 +146,7 @@ func NewRedisCache(prefix, redisURI, readonlyURI string) (*RedisCache, error) {
 		keyBlockBuilderStatus: fmt.Sprintf("%s/%s:block-builder-status", redisPrefix, prefix),
 		keyLastSlotDelivered:  fmt.Sprintf("%s/%s:last-slot-delivered", redisPrefix, prefix),
 		keyLastHashDelivered:  fmt.Sprintf("%s/%s:last-hash-delivered", redisPrefix, prefix),
+		currentSlot:           0,
 	}, nil
 }
 
@@ -814,7 +815,7 @@ func (r *RedisCache) SetFloorBidValue(slot uint64, parentHash, proposerPubkey, v
 func (r *RedisCache) BeginProcessingSlot(ctx context.Context, slot uint64) (err error) {
 	// Should never process more than one slot at a time
 	if r.currentSlot != 0 {
-		return fmt.Errorf("already processing slot %d", r.currentSlot)
+		return fmt.Errorf("already processing slot %d", r.currentSlot) //nolint:goerr113
 	}
 
 	keyProcessingSlot := r.keyProcessingSlot(slot)

--- a/services/api/optimistic_test.go
+++ b/services/api/optimistic_test.go
@@ -358,7 +358,7 @@ func TestPrepareBuildersForSlot(t *testing.T) {
 	pkStr := pubkey.String()
 	// Clear cache.
 	backend.relay.blockBuildersCache = map[string]*blockBuilderCacheEntry{}
-	backend.relay.prepareBuildersForSlot(slot + 1)
+	backend.relay.prepareBuildersForSlot(slot+1, slot)
 	entry, ok := backend.relay.blockBuildersCache[pkStr]
 	require.True(t, ok)
 	require.Equal(t, true, entry.status.IsHighPrio)

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -516,7 +516,7 @@ func (api *RelayAPI) IsReady() bool {
 // - Stop returning bids
 // - Set ready /readyz to negative status
 // - Wait a bit to allow removal of service from load balancer and draining of requests
-// - If in the middle of proccessing optimistic blocks, wait for those to finish and release redis lock
+// - If in the middle of processing optimistic blocks, wait for those to finish and release redis lock
 func (api *RelayAPI) StopServer() (err error) {
 	// avoid running this twice. setting srvShutdown to true makes /readyz switch to negative status
 	if wasStopping := api.srvShutdown.Swap(true); wasStopping {
@@ -541,7 +541,10 @@ func (api *RelayAPI) StopServer() (err error) {
 
 	// wait for optimistic blocks
 	api.optimisticBlocksWG.Wait()
-	api.redis.EndProcessingSlot(context.Background())
+	err = api.redis.EndProcessingSlot(context.Background())
+	if err != nil {
+		api.log.WithError(err).Error("failed to update redis optimistic processing slot")
+	}
 
 	// shutdown
 	return api.srv.Shutdown(context.Background())
@@ -834,13 +837,19 @@ func (api *RelayAPI) updateProposerDuties(headSlot uint64) {
 	api.log.Infof("proposer duties updated: %s", strings.Join(_duties, ", "))
 }
 
-func (api *RelayAPI) prepareBuildersForSlot(headSlot uint64, prevHeadSlot uint64) {
+func (api *RelayAPI) prepareBuildersForSlot(headSlot, prevHeadSlot uint64) {
 	// First wait for this process to finish processing optimistic blocks
 	api.optimisticBlocksWG.Wait()
 
 	// Now we release our lock and wait for all other builder processes to wrap up
-	api.redis.EndProcessingSlot(context.Background())
-	api.redis.WaitForSlotComplete(context.Background(), prevHeadSlot + 1)
+	err := api.redis.EndProcessingSlot(context.Background())
+	if err != nil {
+		api.log.WithError(err).Error("failed to update redis optimistic processing slot")
+	}
+	err = api.redis.WaitForSlotComplete(context.Background(), prevHeadSlot+1)
+	if err != nil {
+		api.log.WithError(err).Error("failed to get redis optimistic processing slot")
+	}
 
 	// Prevent race with StopServer, make sure we don't lock up redis if the server is shutting down
 	if api.srvShutdown.Load() {
@@ -849,7 +858,10 @@ func (api *RelayAPI) prepareBuildersForSlot(headSlot uint64, prevHeadSlot uint64
 
 	// Update the optimistic slot and signal processing of the next slot
 	api.optimisticSlot.Store(headSlot + 1)
-	api.redis.BeginProcessingSlot(context.Background(), headSlot + 1)
+	err = api.redis.BeginProcessingSlot(context.Background(), headSlot+1)
+	if err != nil {
+		api.log.WithError(err).Error("failed to update redis optimistic processing slot")
+	}
 
 	builders, err := api.db.GetBlockBuilders()
 	if err != nil {
@@ -1404,7 +1416,10 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 		}
 
 		// Wait until optimistic blocks are complete using the redis waitgroup
-		api.redis.WaitForSlotComplete(context.Background(), uint64(slot))
+		err = api.redis.WaitForSlotComplete(context.Background(), uint64(slot))
+		if err != nil {
+			api.log.WithError(err).Error("failed to get redis optimistic processing slot")
+		}
 
 		// Check if there is a demotion for the winning block.
 		_, err = api.db.GetBuilderDemotion(bidTrace)


### PR DESCRIPTION
## 📝 Summary

This change implements a counter in redis which monitors the number of builder API processes currently handling validation of optimistic blocks for a given slot. Each slot has a separate key in redis, though as before only one slot is optimistically processed at a time. When a builder process begins optimistic validation, it INCR's the value, and once it is complete it DECR's the value. These are atomic redis operations so no mutex is needed. Functions can block by waiting on this value to reach 0, at which point all optimistic blocks for the slot have been validated.

This has been tested on Aestus's goerli relay, using builders marked for optimistic submissions and intentionally triggering demotions by disabling the block priority queue (causing all validation calls to timeout after the default 10s).

Caveats:

- These redis reads/writes occur whether or not the relay has optimistic submissions enabled (but they are not in the critical path)
- Blocking works by querying redis once every 50 ms. Slightly awkward, could be exposed as a configurable parameter, but not aware of a better solution.

## ⛱ Motivation and Context

See #534 . This is a revised version of the code originally linked there.

## 📚 References

Test log entries from a, Aestus Goerli block proposal, *reverse chronological*, newest at the top. Shows three builder API processes working on validations (each which take 10s). There's a lot going on here, but it does demonstrate correct behavior and I'm happy to walk through it elsewhere.
[sync.txt](https://github.com/flashbots/mev-boost-relay/files/12821539/sync.txt)

---

## ✅ I have run these commands

* [✅] `make lint`
* [✅] `make test-race`
* [✅] `go mod tidy`
* [✅] I have seen and agree to `CONTRIBUTING.md`
