### PR TITLE
feat(Dockerfile): switch to scratch base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build go mod download
 ADD . .
 RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux go build -trimpath -ldflags "-s -X cmd.Version=$VERSION -X main.Version=$VERSION -linkmode external -extldflags '-static'" -v -o mev-boost-relay .
 
-FROM alpine
-RUN apk add --no-cache libstdc++ libc6-compat
+FROM scratch
 WORKDIR /app
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /build/mev-boost-relay /app/mev-boost-relay


### PR DESCRIPTION
## 📝 Summary

This MR switches the base Docker image from Alpine to `scratch`, reducing the image size and eliminating unnecessary dependencies.

Again, not changing logic so I didn't open an issue. Let me know if I should. I am making an assumption (explained below) that we don't need this because of the way that we are compiling the binary. I did a simple test of running locally and it works, but I might be missing something.

## ⛱ Motivation and Context

### Why Use Scratch?

1. **Reduced Size**: A `scratch` image is an empty layer, meaning it doesn't carry any extra libraries, making the image extremely small in size. Decrease from `32MB` -> `22MB` 
2. **Reduced Dependencies**: No need for extra packages or libraries, making the image lighter and less complex.
3. **Security Advantages**: 
    - **Reduced Surface for Attacks**: Eliminates potential risks tied to any libraries or packages that Alpine might bring in.
        - **Example**: The absence of a shell in `scratch` means shell-based attacks are not applicable.
    - **No Outdated Libraries**: No risk of having vulnerable or outdated libraries as we are building from `scratch`.
    - Dependabot handles updates, ensuring that all package versions are maintained in the `go.mod` file.

### Why Don't We Need Alpine and Libraries?

`Assumption:` During the `go build ...`, we use `-linkmode external -extldflags '-static'`. These flags instruct the compiler to statically link all dependencies into the binary. As a result, the `mev-boost-relay` binary should be fully self-contained and not dependent on any shared libraries 🤞.  This makes the transition to `scratch` seamless while making the image more secure and less prone to vulnerabilities.

## 📚 References

- [Docker's official documentation on scratch images](https://docs.docker.com/develop/develop-images/baseimages/#create-a-simple-parent-image-using-scratch)

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
