### PR TITLE
website custom data origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `LINK_ETHERSCAN` - url for etherscan (default: `https://etherscan.io`)
 * `LISTEN_ADDR` - listen address for webserver (default: `localhost:9060`)
 * `RELAY_URL` - full url for the relay (https://pubkey@host)
-* `SHOW_CONFIG_DETAILS` - log configuration details
+* `SHOW_CONFIG_DETAILS` - when set to "1", logs configuration details
 
 ## Updating the website
 

--- a/README.md
+++ b/README.md
@@ -160,9 +160,18 @@ redis-cli DEL boost-relay/sepolia:validators-registration boost-relay/sepolia:va
 * `RUN_INTEGRATION_TESTS` - when set to "1" enables integration tests, currently used for testing Memcached using comma separated list of endpoints specified by `MEMCACHED_URIS`
 * `TEST_DB_DSN` - specifies connection string using Data Source Name (DSN) for Postgres (default: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable)
 
-#### Redis tuning
+#### Redis Tuning
 
 * `REDIS_CONNECTION_POOL_SIZE`, `REDIS_MIN_IDLE_CONNECTIONS`, `REDIS_READ_TIMEOUT_SEC`, `REDIS_POOL_TIMEOUT_SEC`, `REDIS_WRITE_TIMEOUT_SEC` (see also [the code here](https://github.com/flashbots/mev-boost-relay/blob/e39cd38010de26bf9a51d1a3e77fc235ea87b12f/datastore/redis.go#L35-L41))
+
+#### Website
+
+* `LINK_BEACONCHAIN` - url for beaconcha.in (default: `https://beaconcha.in`)
+* `LINK_DATA_API` - origin url for data api (https://domain:port)
+* `LINK_ETHERSCAN` - url for etherscan (default: `https://etherscan.io`)
+* `LISTEN_ADDR` - listen address for webserver (default: `localhost:9060`)
+* `RELAY_URL` - full url for the relay (https://pubkey@host)
+* `SHOW_CONFIG_DETAILS` - log configuration details
 
 ## Updating the website
 

--- a/cmd/website.go
+++ b/cmd/website.go
@@ -17,7 +17,7 @@ var (
 	websiteDefaultShowConfigDetails = os.Getenv("SHOW_CONFIG_DETAILS") == "1"
 	websiteDefaultLinkBeaconchain   = common.GetEnv("LINK_BEACONCHAIN", "https://beaconcha.in")
 	websiteDefaultLinkEtherscan     = common.GetEnv("LINK_ETHERSCAN", "https://etherscan.io")
-	websiteDefaultLinkDataAPI       = common.GetEnv("LINK_API", "")
+	websiteDefaultLinkDataAPI       = common.GetEnv("LINK_DATA_API", "")
 	websiteDefaultRelayURL          = common.GetEnv("RELAY_URL", "")
 
 	websiteListenAddr        string

--- a/cmd/website.go
+++ b/cmd/website.go
@@ -17,6 +17,7 @@ var (
 	websiteDefaultShowConfigDetails = os.Getenv("SHOW_CONFIG_DETAILS") == "1"
 	websiteDefaultLinkBeaconchain   = common.GetEnv("LINK_BEACONCHAIN", "https://beaconcha.in")
 	websiteDefaultLinkEtherscan     = common.GetEnv("LINK_ETHERSCAN", "https://etherscan.io")
+	websiteDefaultLinkDataAPI       = common.GetEnv("LINK_API", "")
 	websiteDefaultRelayURL          = common.GetEnv("RELAY_URL", "")
 
 	websiteListenAddr        string
@@ -25,6 +26,7 @@ var (
 
 	websiteLinkBeaconchain string
 	websiteLinkEtherscan   string
+	websiteLinkDataAPI     string
 	websiteRelayURL        string
 )
 
@@ -43,6 +45,7 @@ func init() {
 	websiteCmd.Flags().BoolVar(&websiteShowConfigDetails, "show-config-details", websiteDefaultShowConfigDetails, "show config details")
 	websiteCmd.Flags().StringVar(&websiteLinkBeaconchain, "link-beaconchain", websiteDefaultLinkBeaconchain, "url for beaconcha.in")
 	websiteCmd.Flags().StringVar(&websiteLinkEtherscan, "link-etherscan", websiteDefaultLinkEtherscan, "url for etherscan")
+	websiteCmd.Flags().StringVar(&websiteLinkDataAPI, "link-dataapi", websiteDefaultLinkDataAPI, "origin url for data api (https://domain:port)")
 	websiteCmd.Flags().StringVar(&websiteRelayURL, "relay-url", websiteDefaultRelayURL, "full url for the relay (https://pubkey@host)")
 }
 
@@ -110,6 +113,7 @@ var websiteCmd = &cobra.Command{
 			ShowConfigDetails: websiteShowConfigDetails,
 			LinkBeaconchain:   websiteLinkBeaconchain,
 			LinkEtherscan:     websiteLinkEtherscan,
+			LinkDataAPI:       websiteLinkDataAPI,
 			RelayURL:          websiteRelayURL,
 		}
 

--- a/cmd/website.go
+++ b/cmd/website.go
@@ -45,7 +45,7 @@ func init() {
 	websiteCmd.Flags().BoolVar(&websiteShowConfigDetails, "show-config-details", websiteDefaultShowConfigDetails, "show config details")
 	websiteCmd.Flags().StringVar(&websiteLinkBeaconchain, "link-beaconchain", websiteDefaultLinkBeaconchain, "url for beaconcha.in")
 	websiteCmd.Flags().StringVar(&websiteLinkEtherscan, "link-etherscan", websiteDefaultLinkEtherscan, "url for etherscan")
-	websiteCmd.Flags().StringVar(&websiteLinkDataAPI, "link-dataapi", websiteDefaultLinkDataAPI, "origin url for data api (https://domain:port)")
+	websiteCmd.Flags().StringVar(&websiteLinkDataAPI, "link-data-api", websiteDefaultLinkDataAPI, "origin url for data api (https://domain:port)")
 	websiteCmd.Flags().StringVar(&websiteRelayURL, "relay-url", websiteDefaultRelayURL, "full url for the relay (https://pubkey@host)")
 }
 

--- a/services/website/html.go
+++ b/services/website/html.go
@@ -40,6 +40,7 @@ type StatusHTMLData struct { //nolint:musttag
 	ShowConfigDetails bool
 	LinkBeaconchain   string
 	LinkEtherscan     string
+	LinkDataAPI       string
 	RelayURL          string
 }
 

--- a/services/website/website.go
+++ b/services/website/website.go
@@ -42,6 +42,7 @@ type WebserverOpts struct {
 	ShowConfigDetails bool
 	LinkBeaconchain   string
 	LinkEtherscan     string
+	LinkDataAPI       string
 	RelayURL          string
 }
 
@@ -110,6 +111,7 @@ func NewWebserver(opts *WebserverOpts) (*Webserver, error) {
 		ShowConfigDetails:           opts.ShowConfigDetails,
 		LinkBeaconchain:             opts.LinkBeaconchain,
 		LinkEtherscan:               opts.LinkEtherscan,
+		LinkDataAPI:                 opts.LinkDataAPI,
 		RelayURL:                    opts.RelayURL,
 	}
 

--- a/services/website/website.html
+++ b/services/website/website.html
@@ -248,11 +248,12 @@
                 <tbody>
                     {{$linkBeaconchain := .LinkBeaconchain}}
                     {{$linkEtherscan := .LinkEtherscan}}
+                    {{$linkDataAPI := .LinkDataAPI}}
                     {{ range .Payloads }}
                     <tr>
                         <td>{{.Epoch | prettyInt}}</td>
                         <td>
-                            <a href="{{.LinkDataAPI}}/relay/v1/data/bidtraces/proposer_payload_delivered?slot={{.Slot}}">{{.Slot | prettyInt}}</a>
+                            <a href="{{$linkDataAPI}}/relay/v1/data/bidtraces/proposer_payload_delivered?slot={{.Slot}}">{{.Slot | prettyInt}}</a>
                         </td>
                         <td>{{.BlockNumber | prettyInt}}</td>
                         <td>{{.Value | weiToEth}}</td>

--- a/services/website/website.html
+++ b/services/website/website.html
@@ -252,7 +252,7 @@
                     <tr>
                         <td>{{.Epoch | prettyInt}}</td>
                         <td>
-                            <a href="/relay/v1/data/bidtraces/proposer_payload_delivered?slot={{.Slot}}">{{.Slot | prettyInt}}</a>
+                            <a href="{{.LinkDataAPI}}/relay/v1/data/bidtraces/proposer_payload_delivered?slot={{.Slot}}">{{.Slot | prettyInt}}</a>
                         </td>
                         <td>{{.BlockNumber | prettyInt}}</td>
                         <td>{{.Value | weiToEth}}</td>
@@ -279,7 +279,7 @@
                 <p>{{.NumPayloadsDelivered | prettyInt}} payloads delivered</p>
                 <p>
                     <small>
-                        <a href="/relay/v1/data/bidtraces/proposer_payload_delivered?limit=10">Data API</a> &middot; <a href="https://flashbots-boost-relay-public.s3.us-east-2.amazonaws.com/index.html">Bulk Data</a> &middot; <a href="https://flashbots.notion.site/Relay-API-Spec-5fb0819366954962bc02e81cb33840f5#417abe417dde45caaff3dc15aaae65dd">Docs</a>
+                        <a href="{{.LinkDataAPI}}/relay/v1/data/bidtraces/proposer_payload_delivered?limit=10">Data API</a> &middot; <a href="https://flashbots-boost-relay-public.s3.us-east-2.amazonaws.com/index.html">Bulk Data</a> &middot; <a href="https://flashbots.notion.site/Relay-API-Spec-5fb0819366954962bc02e81cb33840f5#417abe417dde45caaff3dc15aaae65dd">Docs</a>
                     </small>
                 </p>
             </center>


### PR DESCRIPTION
## 📝 Summary

adds the ability to control, via environment variable, the origin of the data api hyperlinks in the website service. 

## ⛱ Motivation and Context

allows operators to run the data api on a different endpoint or port from the website service.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
