### PR TITLE
Handle no deneb fork schedule from beacon client

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -185,8 +185,8 @@ type RelayAPI struct {
 
 	headSlot     uberatomic.Uint64
 	genesisInfo  *beaconclient.GetGenesisResponse
-	capellaEpoch uint64
-	denebEpoch   uint64
+	capellaEpoch int64
+	denebEpoch   int64
 
 	proposerDutiesLock       sync.RWMutex
 	proposerDutiesResponse   *[]byte // raw http response
@@ -411,23 +411,28 @@ func (api *RelayAPI) StartServer() (err error) {
 	if err != nil {
 		return err
 	}
-	var foundCapellaEpoch, foundDenebEpoch bool
+
+	api.denebEpoch = -1
+	api.capellaEpoch = -1
 	for _, fork := range forkSchedule.Data {
 		log.Infof("forkSchedule: version=%s / epoch=%d", fork.CurrentVersion, fork.Epoch)
 		switch fork.CurrentVersion {
 		case api.opts.EthNetDetails.CapellaForkVersionHex:
-			foundCapellaEpoch = true
-			api.capellaEpoch = fork.Epoch
+			api.capellaEpoch = int64(fork.Epoch)
 		case api.opts.EthNetDetails.DenebForkVersionHex:
-			foundDenebEpoch = true
-			api.denebEpoch = fork.Epoch
+			api.denebEpoch = int64(fork.Epoch)
 		}
 	}
 
+	if api.denebEpoch == -1 {
+		// log warning that deneb epoch was not found in CL fork schedule, suggest CL upgrade
+		log.Warn("deneb epoch not found in fork schedule, you may need to upgrade the beacon client")
+	}
+
 	// Print fork version information
-	if foundDenebEpoch && hasReachedFork(currentSlot, api.denebEpoch) {
+	if hasReachedFork(currentSlot, api.denebEpoch) {
 		log.Infof("deneb fork detected (currentEpoch: %d / denebEpoch: %d)", common.SlotToEpoch(currentSlot), api.denebEpoch)
-	} else if foundCapellaEpoch && hasReachedFork(currentSlot, api.capellaEpoch) {
+	} else if hasReachedFork(currentSlot, api.capellaEpoch) {
 		log.Infof("capella fork detected (currentEpoch: %d / capellaEpoch: %d)", common.SlotToEpoch(currentSlot), api.capellaEpoch)
 	}
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -426,7 +426,7 @@ func (api *RelayAPI) StartServer() (err error) {
 
 	if api.denebEpoch == -1 {
 		// log warning that deneb epoch was not found in CL fork schedule, suggest CL upgrade
-		log.Warn("deneb epoch not found in fork schedule, you may need to upgrade the beacon client")
+		log.Info("Deneb epoch not found in fork schedule")
 	}
 
 	// Print fork version information

--- a/services/api/utils.go
+++ b/services/api/utils.go
@@ -121,9 +121,12 @@ func checkBLSPublicKeyHex(pkHex string) error {
 	return err
 }
 
-func hasReachedFork(slot, forkEpoch uint64) bool {
+func hasReachedFork(slot uint64, forkEpoch int64) bool {
+	if forkEpoch < 0 {
+		return false
+	}
 	currentEpoch := slot / common.SlotsPerEpoch
-	return currentEpoch >= forkEpoch
+	return currentEpoch >= uint64(forkEpoch)
 }
 
 func verifyBlockSignature(block *common.VersionedSignedBlindedBeaconBlock, domain phase0.Domain, pubKey []byte) (bool, error) {


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
This PR handles the case where the deneb schedule is not found and only processes capella payloads. It defaults the epoch to -1 (as forks can occur on epoch = 0 on devnets).

## ⛱ Motivation and Context

As the deneb mainnet fork schedule has not been announced yet, the current relay behaviour on the deneb branch would:
1. Default to `denebEpoch = 0`
2. Return true for `hasReachedFork(currentSlot, api.denebEpoch)`
3. Reject capella payloads as it thinks it has reached the deneb fork

this change would default to return false for `hasReachedFork(currentSlot, api.denebEpoch)` if the fork schedule was not found.

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
