### PR TITLE
change specific error log to info because it's expected nowadays

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1282,7 +1282,7 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 	defer func() {
 		bidTrace, err := api.redis.GetBidTrace(payload.Slot(), proposerPubkey.String(), payload.BlockHash())
 		if err != nil {
-			log.WithError(err).Error("failed to get bidTrace for delivered payload from redis")
+			log.WithError(err).Info("failed to get bidTrace for delivered payload from redis")
 			return
 		}
 


### PR DESCRIPTION
## 📝 Summary

This error is logges often, because it will happen if mev-boost does a getPayload request for a bid from other relays.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
