### PR TITLE
Clean up logging when payload attributes are unknown

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1617,9 +1617,11 @@ func (api *RelayAPI) checkSubmissionPayloadAttrs(w http.ResponseWriter, log *log
 	attrs, ok := api.payloadAttributes[submission.BidTrace.ParentHash.String()]
 	api.payloadAttributesLock.RUnlock()
 	if !ok || submission.BidTrace.Slot != attrs.slot {
-		log.Info(ok)
-		log.Info("payload", submission.BidTrace.Slot, "attrs", attrs.slot)
-		log.Warn("payload attributes not (yet) known")
+		log.WithFields(logrus.Fields{
+			"attributesFound": ok,
+			"payloadSlot":     submission.BidTrace.Slot,
+			"attrsSlot":       attrs.slot,
+		}).Warn("payload attributes not (yet) known")
 		api.RespondError(w, http.StatusBadRequest, "payload attributes not (yet) known")
 		return attrs, false
 	}


### PR DESCRIPTION
## 📝 Summary

`checkSubmissionPayloadAttrs()` has some recent logging additions which print additional variables, but do not use the standard format of `log.WithFields(...).Warn("msg")`. This means that every time we would get a "payload attributes not (yet) known" warning, a few extra lines are printed with confusing messages (e.g. msg="true", msg="payload951687attrs951685") and a lot of duplicated info. This just cleans up logging a little.

I figure these were added for some quick debugging; the other option is to remove the `log.Info()` lines entirely. I noticed this a while back but need to figure out how to properly use GitHub's reviewing functionality.

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [✅] `make lint`
* [✅] `make test-race`
* [✅] `go mod tidy`
* [✅] I have seen and agree to `CONTRIBUTING.md`
