### PR TITLE
fix USE_V1_PUBLISH_BLOCK_ENDPOINT flag

### DIFF
--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -244,9 +244,9 @@ func (c *ProdBeaconInstance) GetURI() string {
 func (c *ProdBeaconInstance) PublishBlock(block *common.VersionedSignedProposal, broadcastMode BroadcastMode) (code int, err error) {
 	var uri string
 	if c.ffUseV1PublishBlockEndpoint {
-		uri = fmt.Sprintf("%s/eth/v2/beacon/blocks?broadcast_validation=%s", c.beaconURI, broadcastMode)
-	} else {
 		uri = fmt.Sprintf("%s/eth/v1/beacon/blocks", c.beaconURI)
+	} else {
+		uri = fmt.Sprintf("%s/eth/v2/beacon/blocks?broadcast_validation=%s", c.beaconURI, broadcastMode)
 	}
 	headers := http.Header{}
 	headers.Add("Eth-Consensus-Version", common.ForkVersionStringCapella) // optional in v1, required in v2

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -249,7 +249,7 @@ func (c *ProdBeaconInstance) PublishBlock(block *common.VersionedSignedProposal,
 		uri = fmt.Sprintf("%s/eth/v2/beacon/blocks?broadcast_validation=%s", c.beaconURI, broadcastMode)
 	}
 	headers := http.Header{}
-	headers.Add("Eth-Consensus-Version", common.ForkVersionStringCapella) // optional in v1, required in v2
+	headers.Add("Eth-Consensus-Version", strings.ToLower(block.Version.String())) // optional in v1, required in v2
 	return fetchBeacon(http.MethodPost, uri, block, nil, nil, headers, false)
 }
 

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/capella"


### PR DESCRIPTION
## 📝 Summary

USE_V1_PUBLISH_BLOCK_ENDPOINT was accidentally using the v2 publish endpoint when set instead of v1, and vice versa.

## ⛱ Motivation and Context



## 📚 References

fixes #581 

---

## ✅ I have run these commands
(used the web editor)
* [ ] `make lint`
* [ ] `make test-race`
* [ ] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
