### PR TITLE
Add logging and validation improvements

### DIFF
--- a/beaconclient/multi_beacon_client.go
+++ b/beaconclient/multi_beacon_client.go
@@ -294,7 +294,7 @@ func (c *MultiBeaconClient) PublishBlock(block *common.VersionedSignedProposal) 
 		} else if res.code == 202 {
 			// Should the block fail full validation, a separate success response code (202) is used to indicate that the block was successfully broadcast but failed integration.
 			// https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/publishBlock
-			log.WithField("statusCode", res.code).WithError(res.err).Error("block failed validation but was still broadcast")
+			log.WithField("statusCode", res.code).WithError(res.err).Warn("block failed validation but was still broadcast")
 			lastErrPublishResp = res
 			continue
 		}
@@ -305,6 +305,9 @@ func (c *MultiBeaconClient) PublishBlock(block *common.VersionedSignedProposal) 
 		return res.code, nil
 	}
 
+	if lastErrPublishResp.err == nil {
+		return lastErrPublishResp.code, nil
+	}
 	log.Error("failed to publish block on any CL node")
 	return lastErrPublishResp.code, fmt.Errorf("last error: %w", lastErrPublishResp.err)
 }

--- a/beaconclient/multi_beacon_client.go
+++ b/beaconclient/multi_beacon_client.go
@@ -294,7 +294,7 @@ func (c *MultiBeaconClient) PublishBlock(block *common.VersionedSignedProposal) 
 		} else if res.code == 202 {
 			// Should the block fail full validation, a separate success response code (202) is used to indicate that the block was successfully broadcast but failed integration.
 			// https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/publishBlock
-			log.WithField("statusCode", res.code).WithError(res.err).Warn("block failed validation but was still broadcast")
+			log.WithField("statusCode", res.code).WithError(res.err).Warn("CL client failed block integration, but block was successfully broadcast")
 			lastErrPublishResp = res
 			continue
 		}

--- a/database/types.go
+++ b/database/types.go
@@ -31,22 +31,21 @@ func NewNullTime(t time.Time) sql.NullTime {
 }
 
 type GetPayloadsFilters struct {
-	Slot           uint64
-	Cursor         uint64
+	Slot           int64
+	Cursor         int64
 	Limit          uint64
 	BlockHash      string
-	BlockNumber    uint64
+	BlockNumber    int64
 	ProposerPubkey string
 	BuilderPubkey  string
 	OrderByValue   int8
 }
 
 type GetBuilderSubmissionsFilters struct {
-	Slot        uint64
-	Limit       uint64
-	BlockHash   string
-	BlockNumber uint64
-	// Cursor      uint64
+	Slot          int64
+	Limit         int64
+	BlockHash     string
+	BlockNumber   int64
 	BuilderPubkey string
 }
 


### PR DESCRIPTION
## 📝 Summary

Some logging improvements and validation:
* Logging error only if the bid was eligible and payload was not found. `failed getting execution payload (2/2) - payload not found, but found bid in database` - this error log occurred often due to race conditions in which a submission passed `checkFloorBidValue` earlier in the request and was simulated. However a higher value bid was simulated and updated in redis before the block submission finished simulation, resulting in a bid below the floor when `SaveBidAndUpdateTopBid` is reached. The bid is saved but the payload was not.
* Demote the 202 response code to a warning. This response code was returned from lighthouse when a duplicate block was gossiped, see https://github.com/sigp/lighthouse/pull/4655
* Changes the data api parameters to int64. `bigint` in postgres is represented as a int64 value which was not properly validated in the request parameters and uint64 values could be inputted.


## ⛱ Motivation and Context

Reduces error logging noise in the relay.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
