### PR TITLE
Add more profiling logging in submit block

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -42,6 +42,7 @@ type BuilderStatus struct {
 // field corresponds to the number of microseconds in each stage. The `Total`
 // field is the number of microseconds taken for entire flow.
 type Profile struct {
+	PayloadLoad uint64
 	Decode      uint64
 	Prechecks   uint64
 	Simulation  uint64


### PR DESCRIPTION
## 📝 Summary

Some timestamp logs were not very helpful, added some more granular profiling logging

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
