### PR TITLE
blocksim - increase http client transport settings

### DIFF
--- a/services/api/blocksim_ratelimiter.go
+++ b/services/api/blocksim_ratelimiter.go
@@ -48,6 +48,12 @@ func NewBlockSimulationRateLimiter(blockSimURL string) *BlockSimulationRateLimit
 		blockSimURL: blockSimURL,
 		client: http.Client{ //nolint:exhaustruct
 			Timeout: simRequestTimeout,
+			Transport: &http.Transport{
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 100,
+				MaxConnsPerHost:     100,
+				IdleConnTimeout:     90 * time.Second,
+			},
 		},
 	}
 }


### PR DESCRIPTION
## 📝 Summary

Improve HTTP client transport settings for forwarding blocks to simulation 

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
