### PR TITLE
Use SSZ encoding for block validation

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -19,10 +19,11 @@ import (
 )
 
 var (
-	apiDefaultListenAddr = common.GetEnv("LISTEN_ADDR", "localhost:9062")
-	apiDefaultBlockSim   = common.GetEnv("BLOCKSIM_URI", "http://localhost:8545")
-	apiDefaultSecretKey  = common.GetEnv("SECRET_KEY", "")
-	apiDefaultLogTag     = os.Getenv("LOG_TAG")
+	apiDefaultListenAddr   = common.GetEnv("LISTEN_ADDR", "localhost:9062")
+	apiDefaultBlockSim     = common.GetEnv("BLOCKSIM_URI", "http://localhost:8545")
+	apiDefaultBlockSimHTTP = common.GetEnv("BLOCKSIM_HTTP_URI", "http://localhost:28546")
+	apiDefaultSecretKey    = common.GetEnv("SECRET_KEY", "")
+	apiDefaultLogTag       = os.Getenv("LOG_TAG")
 
 	apiDefaultPprofEnabled       = os.Getenv("PPROF") == "1"
 	apiDefaultInternalAPIEnabled = os.Getenv("ENABLE_INTERNAL_API") == "1"
@@ -32,16 +33,17 @@ var (
 	apiDefaultDataAPIEnabled     = os.Getenv("DISABLE_DATA_API") != "1"
 	apiDefaultProposerAPIEnabled = os.Getenv("DISABLE_PROPOSER_API") != "1"
 
-	apiListenAddr   string
-	apiPprofEnabled bool
-	apiSecretKey    string
-	apiBlockSimURL  string
-	apiDebug        bool
-	apiBuilderAPI   bool
-	apiDataAPI      bool
-	apiInternalAPI  bool
-	apiProposerAPI  bool
-	apiLogTag       string
+	apiListenAddr      string
+	apiPprofEnabled    bool
+	apiSecretKey       string
+	apiBlockSimURL     string
+	apiBlockSimHTTPURL string
+	apiDebug           bool
+	apiBuilderAPI      bool
+	apiDataAPI         bool
+	apiInternalAPI     bool
+	apiProposerAPI     bool
+	apiLogTag          string
 )
 
 func init() {
@@ -60,6 +62,7 @@ func init() {
 		"Enable memcached, typically used as secondary backup to Redis for redundancy")
 	apiCmd.Flags().StringVar(&apiSecretKey, "secret-key", apiDefaultSecretKey, "secret key for signing bids")
 	apiCmd.Flags().StringVar(&apiBlockSimURL, "blocksim", apiDefaultBlockSim, "URL for block simulator")
+	apiCmd.Flags().StringVar(&apiBlockSimHTTPURL, "blocksim-http", apiDefaultBlockSimHTTP, "HTTP URL for block simulator")
 	apiCmd.Flags().StringVar(&network, "network", defaultNetwork, "Which network to use")
 
 	apiCmd.Flags().BoolVar(&apiPprofEnabled, "pprof", apiDefaultPprofEnabled, "enable pprof API")
@@ -145,15 +148,16 @@ var apiCmd = &cobra.Command{
 		}
 
 		opts := api.RelayAPIOpts{
-			Log:           log,
-			ListenAddr:    apiListenAddr,
-			BeaconClient:  beaconClient,
-			Datastore:     ds,
-			Redis:         redis,
-			Memcached:     mem,
-			DB:            db,
-			EthNetDetails: *networkInfo,
-			BlockSimURL:   apiBlockSimURL,
+			Log:             log,
+			ListenAddr:      apiListenAddr,
+			BeaconClient:    beaconClient,
+			Datastore:       ds,
+			Redis:           redis,
+			Memcached:       mem,
+			DB:              db,
+			EthNetDetails:   *networkInfo,
+			BlockSimURL:     apiBlockSimURL,
+			BlockSimHTTPURL: apiBlockSimHTTPURL,
 
 			BlockBuilderAPI: apiBuilderAPI,
 			DataAPI:         apiDataAPI,

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -114,8 +114,9 @@ var (
 type RelayAPIOpts struct {
 	Log *logrus.Entry
 
-	ListenAddr  string
-	BlockSimURL string
+	ListenAddr      string
+	BlockSimURL     string
+	BlockSimHTTPURL string
 
 	BeaconClient beaconclient.IMultiBeaconClient
 	Datastore    *datastore.Datastore
@@ -283,7 +284,7 @@ func NewRelayAPI(opts RelayAPIOpts) (api *RelayAPI, err error) {
 		payloadAttributes: make(map[string]payloadAttributesHelper),
 
 		proposerDutiesResponse: &[]byte{},
-		blockSimRateLimiter:    NewBlockSimulationRateLimiter(opts.BlockSimURL),
+		blockSimRateLimiter:    NewBlockSimulationRateLimiter(opts.BlockSimURL, opts.BlockSimHTTPURL),
 
 		validatorRegC: make(chan builderApiV1.SignedValidatorRegistration, 450_000),
 	}


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Uses SSZ to send block validation payloads to the validation node. Instead of JSON RPC, a new HTTP endpoint is needed to post SSZ payloads, implemented like in https://github.com/flashbots/builder/pull/152. 

## ⛱ Motivation and Context

Improve block submission latency at the relay.
<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
