### PR TITLE
Avoid race condition on conditional variable

### DIFF
--- a/services/api/blocksim_ratelimiter.go
+++ b/services/api/blocksim_ratelimiter.go
@@ -55,7 +55,7 @@ func NewBlockSimulationRateLimiter(blockSimURL string) *BlockSimulationRateLimit
 func (b *BlockSimulationRateLimiter) Send(context context.Context, payload *common.BuilderBlockValidationRequest, isHighPrio, fastTrack bool) (requestErr, validationErr error) {
 	b.cv.L.Lock()
 	cnt := atomic.AddInt64(&b.counter, 1)
-	if maxConcurrentBlocks > 0 && cnt > maxConcurrentBlocks {
+	for maxConcurrentBlocks > 0 && cnt > maxConcurrentBlocks {
 		b.cv.Wait()
 	}
 	b.cv.L.Unlock()


### PR DESCRIPTION
cannot assume that the if condition is true when Wait returns. always best to check in a while loop to avoid race condition.