### PR TITLE
New http client for every beacon request

### DIFF
--- a/beaconclient/util.go
+++ b/beaconclient/util.go
@@ -55,11 +55,9 @@ func fetchBeacon(method, url string, payload []byte, dst any, timeout *time.Dura
 	}
 	req.Header.Set("accept", "application/json")
 
-	client := http.DefaultClient
+	client := &http.Client{}
 	if timeout != nil && timeout.Seconds() > 0 {
-		client = &http.Client{ //nolint:exhaustruct
-			Timeout: *timeout,
-		}
+		client.Timeout = *timeout
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/beaconclient/util.go
+++ b/beaconclient/util.go
@@ -56,7 +56,7 @@ func fetchBeacon(method, url string, payload []byte, dst any, timeout *time.Dura
 	req.Header.Set("accept", "application/json")
 
 	client := &http.Client{}
-	if timeout != nil && timeout.Seconds() > 0 {
+	if timeout != nil && timeout.Milliseconds() > 0 {
 		client.Timeout = *timeout
 	}
 	resp, err := client.Do(req)


### PR DESCRIPTION
## 📝 Summary

Use new HTTP client for every beacon node request to improve latency instead of reusing the same connection.

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
