### PR TITLE
BLS key script improvement: allow hex string input

### DIFF
--- a/scripts/create-bls-keypair/main.go
+++ b/scripts/create-bls-keypair/main.go
@@ -1,5 +1,7 @@
 package main
 
+// See also https://github.com/dvush/bls-vanity for creating vanity BLS keys!
+
 import (
 	"fmt"
 	"log"

--- a/scripts/create-bls-keypair/main.go
+++ b/scripts/create-bls-keypair/main.go
@@ -4,20 +4,45 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/flashbots/go-boost-utils/bls"
 )
 
 func main() {
-	sk, _, err := bls.GenerateNewKeypair()
-	if err != nil {
-		log.Fatal(err.Error())
-	}
+	sk := GenSecretKey()
+	// sk := SecretKeyFromHexString("0x")
 
+	// Convert secret key to public key
 	blsPubkey, err := bls.PublicKeyFromSecretKey(sk)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
 
+	// Print secret key and public key
 	fmt.Printf("secret key: 0x%x\n", bls.SecretKeyToBytes(sk))
 	fmt.Printf("public key: 0x%x\n", bls.PublicKeyToBytes(blsPubkey))
+}
+
+// GenSecretKey generates a random secret key
+func GenSecretKey() *bls.SecretKey {
+	sk, _, err := bls.GenerateNewKeypair()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	return sk
+}
+
+// SecretKeyFromHexString converts a hex string to a BLS secret key
+func SecretKeyFromHexString(secretKeyHex string) *bls.SecretKey {
+	skBytes, err := hexutil.Decode(secretKeyHex)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	blsSecretKey, err := bls.SecretKeyFromBytes(skBytes[:])
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	return blsSecretKey
 }


### PR DESCRIPTION
## 📝 Summary

`scripts/create-bls-keypair`: allow hex string as input

just used as a helper, not part of the relay logic

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
