### PR TITLE
fix perfsprint linter

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,7 +53,7 @@ jobs:
         run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.6
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.0
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.1
 
       - name: Lint
         run: make lint

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -83,7 +83,7 @@ type PayloadAttributes struct {
 }
 
 func (c *ProdBeaconInstance) SubscribeToHeadEvents(slotC chan HeadEventData) {
-	eventsURL := fmt.Sprintf("%s/eth/v1/events?topics=head", c.beaconURI)
+	eventsURL := c.beaconURI + "/eth/v1/events?topics=head"
 	log := c.log.WithField("url", eventsURL)
 	log.Info("subscribing to head events")
 
@@ -109,7 +109,7 @@ func (c *ProdBeaconInstance) SubscribeToHeadEvents(slotC chan HeadEventData) {
 }
 
 func (c *ProdBeaconInstance) SubscribeToPayloadAttributesEvents(payloadAttributesC chan PayloadAttributesEvent) {
-	eventsURL := fmt.Sprintf("%s/eth/v1/events?topics=payload_attributes", c.beaconURI)
+	eventsURL := c.beaconURI + "/eth/v1/events?topics=payload_attributes"
 	log := c.log.WithField("url", eventsURL)
 	log.Info("subscribing to payload_attributes events")
 
@@ -235,7 +235,7 @@ type GetHeaderResponseMessage struct {
 
 // GetHeader returns the latest header - https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockHeader
 func (c *ProdBeaconInstance) GetHeader() (*GetHeaderResponse, error) {
-	uri := fmt.Sprintf("%s/eth/v1/beacon/headers/head", c.beaconURI)
+	uri := c.beaconURI + "/eth/v1/beacon/headers/head"
 	resp := new(GetHeaderResponse)
 	_, err := fetchBeacon(http.MethodGet, uri, nil, resp, nil, http.Header{}, false)
 	return resp, err
@@ -260,7 +260,7 @@ func (c *ProdBeaconInstance) GetPublishURI() string {
 func (c *ProdBeaconInstance) PublishBlock(block *common.VersionedSignedProposal, broadcastMode BroadcastMode) (code int, err error) {
 	var uri string
 	if c.ffUseV1PublishBlockEndpoint {
-		uri = fmt.Sprintf("%s/eth/v1/beacon/blocks", c.beaconPublishURI)
+		uri = c.beaconPublishURI + "/eth/v1/beacon/blocks"
 	} else {
 		uri = fmt.Sprintf("%s/eth/v2/beacon/blocks?broadcast_validation=%s", c.beaconPublishURI, broadcastMode)
 	}
@@ -311,7 +311,7 @@ type GetGenesisResponseData struct {
 
 // GetGenesis returns the genesis info - https://ethereum.github.io/beacon-APIs/#/Beacon/getGenesis
 func (c *ProdBeaconInstance) GetGenesis() (*GetGenesisResponse, error) {
-	uri := fmt.Sprintf("%s/eth/v1/beacon/genesis", c.beaconURI)
+	uri := c.beaconURI + "/eth/v1/beacon/genesis"
 	resp := new(GetGenesisResponse)
 	_, err := fetchBeacon(http.MethodGet, uri, nil, resp, nil, http.Header{}, false)
 	return resp, err
@@ -328,7 +328,7 @@ type GetSpecResponse struct {
 
 // GetSpec - https://ethereum.github.io/beacon-APIs/#/Config/getSpec
 func (c *ProdBeaconInstance) GetSpec() (spec *GetSpecResponse, err error) {
-	uri := fmt.Sprintf("%s/eth/v1/config/spec", c.beaconURI)
+	uri := c.beaconURI + "/eth/v1/config/spec"
 	resp := new(GetSpecResponse)
 	_, err = fetchBeacon(http.MethodGet, uri, nil, resp, nil, http.Header{}, false)
 	return resp, err
@@ -344,7 +344,7 @@ type GetForkScheduleResponse struct {
 
 // GetForkSchedule - https://ethereum.github.io/beacon-APIs/#/Config/getForkSchedule
 func (c *ProdBeaconInstance) GetForkSchedule() (spec *GetForkScheduleResponse, err error) {
-	uri := fmt.Sprintf("%s/eth/v1/config/fork_schedule", c.beaconURI)
+	uri := c.beaconURI + "/eth/v1/config/fork_schedule"
 	resp := new(GetForkScheduleResponse)
 	_, err = fetchBeacon(http.MethodGet, uri, nil, resp, nil, http.Header{}, false)
 	return resp, err

--- a/common/ssz_test.go
+++ b/common/ssz_test.go
@@ -3,7 +3,6 @@ package common
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"os"
 	"testing"
 
@@ -36,7 +35,7 @@ func TestSSZBuilderSubmission(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			// json matches marshalled SSZ
-			jsonBytes := LoadGzippedBytes(t, fmt.Sprintf("%s.json.gz", testCase.filepath))
+			jsonBytes := LoadGzippedBytes(t, testCase.filepath+".json.gz")
 
 			submitBlockData := new(VersionedSubmitBlockRequest)
 			err := json.Unmarshal(jsonBytes, &submitBlockData)
@@ -46,7 +45,7 @@ func TestSSZBuilderSubmission(t *testing.T) {
 			marshalledSszBytes, err := submitBlockData.MarshalSSZ()
 			require.NoError(t, err)
 
-			sszBytes := LoadGzippedBytes(t, fmt.Sprintf("%s.ssz.gz", testCase.filepath))
+			sszBytes := LoadGzippedBytes(t, testCase.filepath+".ssz.gz")
 			require.Equal(t, sszBytes, marshalledSszBytes)
 
 			htr, err := submitBlockData.HashTreeRoot()
@@ -91,7 +90,7 @@ func TestSSZGetHeaderResponse(t *testing.T) {
 			// json -> marshalled ssz -> matches expected ssz
 			payload := new(builderSpec.VersionedSignedBuilderBid)
 
-			jsonBytes, err := os.ReadFile(fmt.Sprintf("%s.json", testCase.filepath))
+			jsonBytes, err := os.ReadFile(testCase.filepath + ".json")
 			require.NoError(t, err)
 
 			err = json.Unmarshal(jsonBytes, &payload)
@@ -109,7 +108,7 @@ func TestSSZGetHeaderResponse(t *testing.T) {
 				require.Fail(t, "unknown version")
 			}
 
-			sszExpectedBytes, err := os.ReadFile(fmt.Sprintf("%s.ssz", testCase.filepath))
+			sszExpectedBytes, err := os.ReadFile(testCase.filepath + ".ssz")
 			require.NoError(t, err)
 			require.Equal(t, sszExpectedBytes, ssz)
 

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -2,7 +2,7 @@ package database
 
 import (
 	"database/sql"
-	"fmt"
+	"errors"
 	"os"
 	"strconv"
 	"testing"
@@ -46,7 +46,7 @@ var (
 		RedisUpdate: 45,
 		Total:       46,
 	}
-	errFoo = fmt.Errorf("fake simulation error")
+	errFoo = errors.New("fake simulation error")
 )
 
 func createValidatorRegistration(pubKey string) ValidatorRegistrationEntry {

--- a/services/api/optimistic_test.go
+++ b/services/api/optimistic_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -39,7 +39,7 @@ const (
 
 var (
 	feeRecipient = bellatrix.ExecutionAddress{0x02}
-	errFake      = fmt.Errorf("foo error")
+	errFake      = errors.New("foo error")
 )
 
 func getTestBidTrace(pubkey phase0.BLSPubKey, value, slot uint64) *common.BidTraceV2WithBlobFields {
@@ -166,12 +166,12 @@ func TestSimulateBlock(t *testing.T) {
 		{
 			description:     "block_already_known_capella",
 			version:         spec.DataVersionCapella,
-			simulationError: fmt.Errorf(ErrBlockAlreadyKnown), //nolint:goerr113
+			simulationError: errors.New(ErrBlockAlreadyKnown), //nolint:goerr113
 		},
 		{
 			description:     "missing_trie_node_capella",
 			version:         spec.DataVersionCapella,
-			simulationError: fmt.Errorf(ErrMissingTrieNode + "23e21f94cd97b3b27ae5c758277639dd387a6e3da5923c5485f24ec6c71e16b8 (path ) <nil>"), //nolint:goerr113
+			simulationError: errors.New(ErrMissingTrieNode + "23e21f94cd97b3b27ae5c758277639dd387a6e3da5923c5485f24ec6c71e16b8 (path ) <nil>"), //nolint:goerr113
 		},
 		{
 			description: "success_deneb",
@@ -186,12 +186,12 @@ func TestSimulateBlock(t *testing.T) {
 		{
 			description:     "block_already_known_deneb",
 			version:         spec.DataVersionDeneb,
-			simulationError: fmt.Errorf(ErrBlockAlreadyKnown), //nolint:goerr113
+			simulationError: errors.New(ErrBlockAlreadyKnown), //nolint:goerr113
 		},
 		{
 			description:     "missing_trie_node_deneb",
 			version:         spec.DataVersionDeneb,
-			simulationError: fmt.Errorf(ErrMissingTrieNode + "23e21f94cd97b3b27ae5c758277639dd387a6e3da5923c5485f24ec6c71e16b8 (path ) <nil>"), //nolint:goerr113
+			simulationError: errors.New(ErrMissingTrieNode + "23e21f94cd97b3b27ae5c758277639dd387a6e3da5923c5485f24ec6c71e16b8 (path ) <nil>"), //nolint:goerr113
 		},
 	}
 	for _, tc := range cases {

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1078,7 +1078,7 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 			if api.ffRegValContinueOnInvalidSig {
 				return
 			} else {
-				handleError(regLog, http.StatusBadRequest, fmt.Sprintf("failed to verify validator signature for %s", signedValidatorRegistration.Message.Pubkey.String()))
+				handleError(regLog, http.StatusBadRequest, fmt.Sprintf("failed to verify validator signature for %s", signedValidatorRegistration.Message.Pubkey.String())) //nolint:perfsprint
 				return
 			}
 		}


### PR DESCRIPTION
## 📝 Summary

Update to comply with perfsprint linter, which is auto-enabled in latest golangci-lint

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
