### PR TITLE
Add builder demotion metrics

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -22,6 +22,8 @@ var (
 	GetPayloadLatencyHistogram   otelapi.Float64Histogram
 	PublishBlockLatencyHistogram otelapi.Float64Histogram
 
+	BuilderDemotionCount otelapi.Int64Counter
+
 	latencyBoundaries = otelapi.WithExplicitBucketBoundaries(func() []float64 {
 		base := math.Exp(math.Log(12.0) / 15.0)
 		res := make([]float64, 0, 31)
@@ -37,6 +39,7 @@ func Setup(ctx context.Context) error {
 		setupMeter, // must come first
 		setupGetPayloadLatency,
 		setupPublishBlockLatency,
+		setupBuilderDemotionCount,
 	} {
 		if err := setup(ctx); err != nil {
 			return err
@@ -93,6 +96,18 @@ func setupPublishBlockLatency(ctx context.Context) error {
 		latencyBoundaries,
 	)
 	PublishBlockLatencyHistogram = latency
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func setupBuilderDemotionCount(ctx context.Context) error {
+	counter, err := meter.Int64Counter(
+		"builder_demotion_count",
+		otelapi.WithDescription("number of times a builder has been demoted"),
+	)
+	BuilderDemotionCount = counter
 	if err != nil {
 		return err
 	}

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -458,6 +458,9 @@ func (api *RelayAPI) StartServer() (err error) {
 
 	// start block-builder API specific things
 	if api.opts.BlockBuilderAPI {
+		// Initialize metrics
+		metrics.BuilderDemotionCount.Add(context.Background(), 0)
+
 		// Get current proposer duties blocking before starting, to have them ready
 		api.updateProposerDuties(syncStatus.HeadSlot)
 
@@ -600,6 +603,11 @@ func (api *RelayAPI) simulateBlock(ctx context.Context, opts blockSimOptions) (r
 }
 
 func (api *RelayAPI) demoteBuilder(pubkey string, req *common.VersionedSubmitBlockRequest, simError error) {
+	metrics.BuilderDemotionCount.Add(
+		context.Background(),
+		1,
+	)
+
 	builderEntry, ok := api.blockBuildersCache[pubkey]
 	if !ok {
 		api.log.Warnf("builder %v not in the builder cache", pubkey)


### PR DESCRIPTION
## 📝 Summary

Adds metrics and observability to builder demotions.

## ⛱ Motivation and Context

Allows monitoring and alerting for builder demotions

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
