### PR TITLE
Save simulated block value to database

### DIFF
--- a/common/types_spec.go
+++ b/common/types_spec.go
@@ -19,6 +19,7 @@ import (
 	"github.com/flashbots/go-boost-utils/bls"
 	"github.com/flashbots/go-boost-utils/ssz"
 	"github.com/flashbots/go-boost-utils/utils"
+	"github.com/holiman/uint256"
 	"github.com/pkg/errors"
 )
 
@@ -274,6 +275,10 @@ func (r *BuilderBlockValidationRequest) MarshalJSON() ([]byte, error) {
 	default:
 		return nil, errors.Wrap(ErrInvalidVersion, fmt.Sprintf("%s is not supported", r.Version))
 	}
+}
+
+type BuilderBlockValidationResponse struct {
+	BlockValue *uint256.Int `json:"block_value"` // true block value calculated from simulation
 }
 
 type VersionedSubmitBlockRequest struct {

--- a/database/database.go
+++ b/database/database.go
@@ -3,6 +3,7 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -219,7 +220,10 @@ func (s *DatabaseService) SaveBuilderBlockSubmission(payload *common.VersionedSu
 		SimSuccess:   wasSimulated && validationError == nil,
 		SimError:     simErrStr,
 		SimReqError:  requestErrStr,
-		BlockValue:   NewNullString(blockValueStr),
+		BlockValue: sql.NullString{
+			String: blockValueStr,
+			Valid:  blockValue != nil,
+		},
 
 		Signature: submission.Signature.String(),
 

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -29,6 +29,8 @@ const (
 	slot                 = uint64(42)
 	collateral           = 1000
 	collateralStr        = "1000"
+	blockValue           = 1234
+	blockValueStr        = "1234"
 	builderID            = "builder0x69"
 	randao               = "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
 	optimisticSubmission = true
@@ -88,7 +90,7 @@ func insertTestBuilder(t *testing.T, db IDatabaseService) string {
 			Value:                uint256.NewInt(collateral),
 		},
 	}, spec.DataVersionDeneb)
-	entry, err := db.SaveBuilderBlockSubmission(req, nil, nil, time.Now(), time.Now().Add(time.Second), true, true, profile, optimisticSubmission, nil)
+	entry, err := db.SaveBuilderBlockSubmission(req, nil, nil, time.Now(), time.Now().Add(time.Second), true, true, profile, optimisticSubmission, uint256.NewInt(blockValue))
 	require.NoError(t, err)
 	err = db.UpsertBlockBuilderEntryAfterSubmission(entry, false)
 	require.NoError(t, err)
@@ -450,6 +452,7 @@ func TestGetBuilderSubmissions(t *testing.T) {
 	require.Equal(t, pubkey, e.BuilderPubkey)
 	require.Equal(t, feeRecipient.String(), e.ProposerFeeRecipient)
 	require.Equal(t, strconv.Itoa(collateral), e.Value)
+	require.Equal(t, NewNullString(blockValueStr), e.BlockValue)
 }
 
 func TestUpsertTooLateGetPayload(t *testing.T) {

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -88,7 +88,7 @@ func insertTestBuilder(t *testing.T, db IDatabaseService) string {
 			Value:                uint256.NewInt(collateral),
 		},
 	}, spec.DataVersionDeneb)
-	entry, err := db.SaveBuilderBlockSubmission(req, nil, nil, time.Now(), time.Now().Add(time.Second), true, true, profile, optimisticSubmission)
+	entry, err := db.SaveBuilderBlockSubmission(req, nil, nil, time.Now(), time.Now().Add(time.Second), true, true, profile, optimisticSubmission, nil)
 	require.NoError(t, err)
 	err = db.UpsertBlockBuilderEntryAfterSubmission(entry, false)
 	require.NoError(t, err)

--- a/database/migrations/011_bid_add_simulated_block_value.go
+++ b/database/migrations/011_bid_add_simulated_block_value.go
@@ -1,0 +1,17 @@
+package migrations
+
+import (
+	"github.com/flashbots/mev-boost-relay/database/vars"
+	migrate "github.com/rubenv/sql-migrate"
+)
+
+var Migration011AddSimulatedBlockValue = &migrate.Migration{
+	Id: "011-add-simulated-block-value",
+	Up: []string{`
+		ALTER TABLE ` + vars.TableBuilderBlockSubmission + ` ADD block_value NUMERIC(48, 0);
+	`},
+	Down: []string{},
+
+	DisableTransactionUp:   true,
+	DisableTransactionDown: true,
+}

--- a/database/migrations/migration.go
+++ b/database/migrations/migration.go
@@ -17,5 +17,6 @@ var Migrations = migrate.MemoryMigrationSource{
 		Migration008Optimistic,
 		Migration009BlockBuilderRemoveReference,
 		Migration010PayloadAddBlobFields,
+		Migration011AddSimulatedBlockValue,
 	},
 }

--- a/database/mockdb.go
+++ b/database/mockdb.go
@@ -7,6 +7,7 @@ import (
 
 	builderApiV1 "github.com/attestantio/go-builder-client/api/v1"
 	"github.com/flashbots/mev-boost-relay/common"
+	"github.com/holiman/uint256"
 )
 
 type MockDB struct {
@@ -36,7 +37,7 @@ func (db MockDB) GetLatestValidatorRegistrations(timestampOnly bool) ([]*Validat
 	return nil, nil
 }
 
-func (db MockDB) SaveBuilderBlockSubmission(payload *common.VersionedSubmitBlockRequest, requestError, validationError error, receivedAt, eligibleAt time.Time, wasSimulated, saveExecPayload bool, profile common.Profile, optimisticSubmission bool) (entry *BuilderBlockSubmissionEntry, err error) {
+func (db MockDB) SaveBuilderBlockSubmission(payload *common.VersionedSubmitBlockRequest, requestError, validationError error, receivedAt, eligibleAt time.Time, wasSimulated, saveExecPayload bool, profile common.Profile, optimisticSubmission bool, blockValue *uint256.Int) (entry *BuilderBlockSubmissionEntry, err error) {
 	return nil, nil
 }
 

--- a/database/types.go
+++ b/database/types.go
@@ -135,11 +135,11 @@ type BuilderBlockSubmissionEntry struct {
 	ExecutionPayloadID sql.NullInt64 `db:"execution_payload_id"`
 
 	// Sim Result
-	WasSimulated bool   `db:"was_simulated"`
-	SimSuccess   bool   `db:"sim_success"`
-	SimError     string `db:"sim_error"`
-	SimReqError  string `db:"sim_req_error"`
-	BlockValue   string `db:"block_value"`
+	WasSimulated bool           `db:"was_simulated"`
+	SimSuccess   bool           `db:"sim_success"`
+	SimError     string         `db:"sim_error"`
+	SimReqError  string         `db:"sim_req_error"`
+	BlockValue   sql.NullString `db:"block_value"`
 
 	// BidTrace data
 	Signature string `db:"signature"`

--- a/database/types.go
+++ b/database/types.go
@@ -139,6 +139,7 @@ type BuilderBlockSubmissionEntry struct {
 	SimSuccess   bool   `db:"sim_success"`
 	SimError     string `db:"sim_error"`
 	SimReqError  string `db:"sim_req_error"`
+	BlockValue   string `db:"block_value"`
 
 	// BidTrace data
 	Signature string `db:"signature"`

--- a/services/api/mock_blocksim_ratelimiter.go
+++ b/services/api/mock_blocksim_ratelimiter.go
@@ -10,8 +10,8 @@ type MockBlockSimulationRateLimiter struct {
 	simulationError error
 }
 
-func (m *MockBlockSimulationRateLimiter) Send(context context.Context, payload *common.BuilderBlockValidationRequest, isHighPrio, fastTrack bool) (error, error) {
-	return nil, m.simulationError
+func (m *MockBlockSimulationRateLimiter) Send(context context.Context, payload *common.BuilderBlockValidationRequest, isHighPrio, fastTrack bool) (*common.BuilderBlockValidationResponse, error, error) {
+	return nil, nil, m.simulationError
 }
 
 func (m *MockBlockSimulationRateLimiter) CurrentCounter() int64 {

--- a/services/api/optimistic_test.go
+++ b/services/api/optimistic_test.go
@@ -200,7 +200,7 @@ func TestSimulateBlock(t *testing.T) {
 			backend.relay.blockSimRateLimiter = &MockBlockSimulationRateLimiter{
 				simulationError: tc.simulationError,
 			}
-			_, simErr := backend.relay.simulateBlock(context.Background(), blockSimOptions{
+			_, _, simErr := backend.relay.simulateBlock(context.Background(), blockSimOptions{
 				isHighPrio: true,
 				log:        backend.relay.log,
 				builder: &blockBuilderCacheEntry{

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -2084,7 +2084,10 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 
 		submissionEntry, err := api.db.SaveBuilderBlockSubmission(payload, simResult.requestErr, simResult.validationErr, receivedAt, eligibleAt, simResult.wasSimulated, savePayloadToDatabase, pf, simResult.optimisticSubmission, simResult.blockValue)
 		if err != nil {
-			log.WithError(err).WithField("payload", payload).Error("saving builder block submission to database failed")
+			log.WithError(err).WithFields(logrus.Fields{
+				"payload":   payload,
+				"simResult": simResult,
+			}).Error("saving builder block submission to database failed")
 			return
 		}
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -164,6 +164,7 @@ type blockBuilderCacheEntry struct {
 
 type blockSimResult struct {
 	wasSimulated         bool
+	blockValue           *uint256.Int
 	optimisticSubmission bool
 	requestErr           error
 	validationErr        error
@@ -577,9 +578,9 @@ func (api *RelayAPI) startValidatorRegistrationDBProcessor() {
 }
 
 // simulateBlock sends a request for a block simulation to blockSimRateLimiter.
-func (api *RelayAPI) simulateBlock(ctx context.Context, opts blockSimOptions) (requestErr, validationErr error) {
+func (api *RelayAPI) simulateBlock(ctx context.Context, opts blockSimOptions) (blockValue *uint256.Int, requestErr, validationErr error) {
 	t := time.Now()
-	requestErr, validationErr = api.blockSimRateLimiter.Send(ctx, opts.req, opts.isHighPrio, opts.fastTrack)
+	response, requestErr, validationErr := api.blockSimRateLimiter.Send(ctx, opts.req, opts.isHighPrio, opts.fastTrack)
 	log := opts.log.WithFields(logrus.Fields{
 		"durationMs": time.Since(t).Milliseconds(),
 		"numWaiting": api.blockSimRateLimiter.CurrentCounter(),
@@ -590,18 +591,23 @@ func (api *RelayAPI) simulateBlock(ctx context.Context, opts blockSimOptions) (r
 			ignoreError := validationErr.Error() == ErrBlockAlreadyKnown || validationErr.Error() == ErrBlockRequiresReorg || strings.Contains(validationErr.Error(), ErrMissingTrieNode)
 			if ignoreError {
 				log.WithError(validationErr).Warn("block validation failed with ignorable error")
-				return nil, nil
+				return nil, nil, nil
 			}
 		}
 		log.WithError(validationErr).Warn("block validation failed")
-		return nil, validationErr
+		return nil, nil, validationErr
 	}
 	if requestErr != nil {
 		log.WithError(requestErr).Warn("block validation failed: request error")
-		return requestErr, nil
+		return nil, requestErr, nil
 	}
+
 	log.Info("block validation successful")
-	return nil, nil
+	if response == nil {
+		log.Warn("block validation response is nil")
+		return nil, nil, nil
+	}
+	return response.BlockValue, nil, nil
 }
 
 func (api *RelayAPI) demoteBuilder(pubkey string, req *common.VersionedSubmitBlockRequest, simError error) {
@@ -666,8 +672,8 @@ func (api *RelayAPI) processOptimisticBlock(opts blockSimOptions, simResultC cha
 		// it for logging, it is not atomic to avoid the performance impact.
 		"optBlocksInFlight": api.optimisticBlocksInFlight,
 	}).Infof("simulating optimistic block with hash: %v", submission.BidTrace.BlockHash.String())
-	reqErr, simErr := api.simulateBlock(ctx, opts)
-	simResultC <- &blockSimResult{reqErr == nil, true, reqErr, simErr}
+	blockValue, reqErr, simErr := api.simulateBlock(ctx, opts)
+	simResultC <- &blockSimResult{reqErr == nil, blockValue, true, reqErr, simErr}
 	if reqErr != nil || simErr != nil {
 		// Mark builder as non-optimistic.
 		opts.builder.status.IsOptimistic = false
@@ -1786,7 +1792,7 @@ func (api *RelayAPI) checkFloorBidValue(opts bidFloorOpts) (*big.Int, bool) {
 	isBidBelowFloor := floorBidValue != nil && opts.submission.BidTrace.Value.ToBig().Cmp(floorBidValue) == -1
 	isBidAtOrBelowFloor := floorBidValue != nil && opts.submission.BidTrace.Value.ToBig().Cmp(floorBidValue) < 1
 	if opts.cancellationsEnabled && isBidBelowFloor { // with cancellations: if below floor -> delete previous bid
-		opts.simResultC <- &blockSimResult{false, false, nil, nil}
+		opts.simResultC <- &blockSimResult{false, nil, false, nil, nil}
 		opts.log.Info("submission below floor bid value, with cancellation")
 		err := api.redis.DelBuilderBid(context.Background(), opts.tx, opts.submission.BidTrace.Slot, opts.submission.BidTrace.ParentHash.String(), opts.submission.BidTrace.ProposerPubkey.String(), opts.submission.BidTrace.BuilderPubkey.String())
 		if err != nil {
@@ -1797,7 +1803,7 @@ func (api *RelayAPI) checkFloorBidValue(opts bidFloorOpts) (*big.Int, bool) {
 		api.Respond(opts.w, http.StatusAccepted, "accepted bid below floor, skipped validation")
 		return nil, false
 	} else if !opts.cancellationsEnabled && isBidAtOrBelowFloor { // without cancellations: if at or below floor -> ignore
-		opts.simResultC <- &blockSimResult{false, false, nil, nil}
+		opts.simResultC <- &blockSimResult{false, nil, false, nil, nil}
 		opts.log.Info("submission at or below floor bid value, without cancellation")
 		api.RespondMsg(opts.w, http.StatusAccepted, "accepted bid below floor, skipped validation")
 		return nil, false
@@ -2073,10 +2079,10 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		case simResult = <-simResultC:
 		case <-time.After(10 * time.Second):
 			log.Warn("timed out waiting for simulation result")
-			simResult = &blockSimResult{false, false, nil, nil}
+			simResult = &blockSimResult{false, nil, false, nil, nil}
 		}
 
-		submissionEntry, err := api.db.SaveBuilderBlockSubmission(payload, simResult.requestErr, simResult.validationErr, receivedAt, eligibleAt, simResult.wasSimulated, savePayloadToDatabase, pf, simResult.optimisticSubmission)
+		submissionEntry, err := api.db.SaveBuilderBlockSubmission(payload, simResult.requestErr, simResult.validationErr, receivedAt, eligibleAt, simResult.wasSimulated, savePayloadToDatabase, pf, simResult.optimisticSubmission, simResult.blockValue)
 		if err != nil {
 			log.WithError(err).WithField("payload", payload).Error("saving builder block submission to database failed")
 			return
@@ -2143,8 +2149,8 @@ func (api *RelayAPI) handleSubmitNewBlock(w http.ResponseWriter, req *http.Reque
 		go api.processOptimisticBlock(opts, simResultC)
 	} else {
 		// Simulate block (synchronously).
-		requestErr, validationErr := api.simulateBlock(context.Background(), opts) // success/error logging happens inside
-		simResultC <- &blockSimResult{requestErr == nil, false, requestErr, validationErr}
+		blockValue, requestErr, validationErr := api.simulateBlock(context.Background(), opts) // success/error logging happens inside
+		simResultC <- &blockSimResult{requestErr == nil, blockValue, false, requestErr, validationErr}
 		validationDurationMs := time.Since(timeBeforeValidation).Milliseconds()
 		log = log.WithFields(logrus.Fields{
 			"timestampAfterValidation": time.Now().UTC().UnixMilli(),


### PR DESCRIPTION
## 📝 Summary

Adds "block value" reflecting the simulated block value (as opposed to the block's bid value) to the block validation api. This is then saved to the relay db, but it is not exposed in the data api.

## ⛱ Motivation and Context

Improve transparency and data collection by saving a bid's true block value after simulation. This allows more visibility into builder subsidies in blocks.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
