### PR TITLE
Add channel to notify externally of new validators

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -172,6 +172,14 @@ func (ds *Datastore) NumRegisteredValidators() (uint64, error) {
 	return ds.db.NumRegisteredValidators()
 }
 
+func (ds *Datastore) SetKnownValidator(pubkeyHex common.PubkeyHex, index uint64) {
+	ds.knownValidatorsLock.Lock()
+	defer ds.knownValidatorsLock.Unlock()
+
+	ds.knownValidatorsByPubkey[pubkeyHex] = index
+	ds.knownValidatorsByIndex[index] = pubkeyHex
+}
+
 // SaveValidatorRegistration saves a validator registration into both Redis and the database
 func (ds *Datastore) SaveValidatorRegistration(entry builderApiV1.SignedValidatorRegistration) error {
 	// First save in the database


### PR DESCRIPTION
## 📝 Summary

This PR adds a new channel that sends async updates for new validators.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
