### PR TITLE
Decouple logic and periodic scheduling from internal tasks

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -107,10 +107,10 @@ func (ds *Datastore) RefreshKnownValidators(log *logrus.Entry, beaconClient beac
 		time.Sleep(6 * time.Second)
 	}
 
-	ds.RefreshKnownValidatorsBySlot(log, beaconClient, slot)
+	ds.RefreshKnownValidatorsWithoutChecks(log, beaconClient, slot)
 }
 
-func (ds *Datastore) RefreshKnownValidatorsBySlot(log *logrus.Entry, beaconClient beaconclient.IMultiBeaconClient, slot uint64) {
+func (ds *Datastore) RefreshKnownValidatorsWithoutChecks(log *logrus.Entry, beaconClient beaconclient.IMultiBeaconClient, slot uint64) {
 	log.Info("Querying validators from beacon node... (this may take a while)")
 	timeStartFetching := time.Now()
 	validators, err := beaconClient.GetStateValidators(beaconclient.StateIDHead) // head is fastest

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -107,6 +107,10 @@ func (ds *Datastore) RefreshKnownValidators(log *logrus.Entry, beaconClient beac
 		time.Sleep(6 * time.Second)
 	}
 
+	ds.RefreshKnownValidatorsBySlot(log, beaconClient, slot)
+}
+
+func (ds *Datastore) RefreshKnownValidatorsBySlot(log *logrus.Entry, beaconClient beaconclient.IMultiBeaconClient, slot uint64) {
 	log.Info("Querying validators from beacon node... (this may take a while)")
 	timeStartFetching := time.Now()
 	validators, err := beaconClient.GetStateValidators(beaconclient.StateIDHead) // head is fastest

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -810,10 +810,10 @@ func (api *RelayAPI) updateProposerDuties(headSlot uint64) {
 		return
 	}
 
-	api.UpdateProposerDutiesBySlot(headSlot)
+	api.UpdateProposerDutiesWithoutChecks(headSlot)
 }
 
-func (api *RelayAPI) UpdateProposerDutiesBySlot(headSlot uint64) {
+func (api *RelayAPI) UpdateProposerDutiesWithoutChecks(headSlot uint64) {
 	// Load upcoming proposer duties from Redis
 	duties, err := api.redis.GetProposerDuties()
 	if err != nil {

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -810,6 +810,10 @@ func (api *RelayAPI) updateProposerDuties(headSlot uint64) {
 		return
 	}
 
+	api.UpdateProposerDutiesBySlot(headSlot)
+}
+
+func (api *RelayAPI) UpdateProposerDutiesBySlot(headSlot uint64) {
 	// Load upcoming proposer duties from Redis
 	duties, err := api.redis.GetProposerDuties()
 	if err != nil {

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -168,6 +168,10 @@ func (hk *Housekeeper) updateProposerDuties(headSlot uint64) {
 		return
 	}
 
+	hk.UpdateProposerDutiesBySlot(headSlot)
+}
+
+func (hk *Housekeeper) UpdateProposerDutiesBySlot(headSlot uint64) {
 	epoch := headSlot / common.SlotsPerEpoch
 
 	log := hk.log.WithFields(logrus.Fields{

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -168,10 +168,10 @@ func (hk *Housekeeper) updateProposerDuties(headSlot uint64) {
 		return
 	}
 
-	hk.UpdateProposerDutiesBySlot(headSlot)
+	hk.UpdateProposerDutiesWithoutChecks(headSlot)
 }
 
-func (hk *Housekeeper) UpdateProposerDutiesBySlot(headSlot uint64) {
+func (hk *Housekeeper) UpdateProposerDutiesWithoutChecks(headSlot uint64) {
 	epoch := headSlot / common.SlotsPerEpoch
 
 	log := hk.log.WithFields(logrus.Fields{


### PR DESCRIPTION
## 📝 Summary

This PR decouples some internal logic in Housekeeper and API in two functions, one with the core logic and another one that decides whether the core logic is executed or not given the slot.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
