### PR TITLE
Fix notification end of api call instead of per validator

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1122,12 +1122,6 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 		default:
 			regLog.Error("validator registration channel full")
 		}
-
-		// notify of a new validator
-		select {
-		case api.validatorUpdateCh <- struct{}{}:
-		default:
-		}
 	})
 
 	log = log.WithFields(logrus.Fields{
@@ -1143,6 +1137,12 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 	if err != nil {
 		handleError(log, http.StatusBadRequest, "error in traversing json")
 		return
+	}
+
+	// notify that new registrations are available
+	select {
+	case api.validatorUpdateCh <- struct{}{}:
+	default:
 	}
 
 	log.Info("validator registrations call processed")


### PR DESCRIPTION
## 📝 Summary

Perform the notification at the end of the call instead of per validator.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
