### PR TITLE
docs: Rectify typographical inaccuracies

### DIFF
--- a/docs/docs/20220822-audit.md
+++ b/docs/docs/20220822-audit.md
@@ -49,7 +49,7 @@ When the `api.headSlot ` value is modified in the [`service.go file`]([api.headS
 
 Data races lead to unexpected behavior and potential crashes.
 
-Consider making use of a sincronization library to allow atomic modifications.
+Consider making use of a synchronization library to allow atomic modifications.
 
 #### Incorrect Redis keys
 

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -652,7 +652,7 @@ func (api *RelayAPI) demoteBuilder(pubkey string, req *common.VersionedSubmitBlo
 	}
 }
 
-// processOptimisticBlock is called on a new goroutine when a optimistic block
+// processOptimisticBlock is called on a new goroutine when an optimistic block
 // needs to be simulated.
 func (api *RelayAPI) processOptimisticBlock(opts blockSimOptions, simResultC chan *blockSimResult) {
 	api.optimisticBlocksInFlight.Add(1)


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.