### PR TITLE
chore: bump go version 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.21 as builder
+FROM golang:1.22 AS builder
 ARG VERSION
 WORKDIR /build
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flashbots/mev-boost-relay
 
-go 1.21
+go 1.22
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1


### PR DESCRIPTION
## 📝 Summary
Bumps go version to 1.22.

## ⛱ Motivation and Context
To ensure compatibility with up to date version of Go.

## 📚 References
[Go 1.22 Release Notes](https://golang.org/doc/go1.22)

## ✅ I have run these commands

* [X] `make lint`
* [X] `make test-race`
* [X] `go mod tidy`
* [X] I have seen and agree to `CONTRIBUTING.md`
