### PR TITLE
Use public key of builder for headers.

### DIFF
--- a/common/test_utils.go
+++ b/common/test_utils.go
@@ -125,7 +125,6 @@ func TestBuilderSubmitBlockRequest(sk *bls.SecretKey, bid *BidTraceV2WithBlobFie
 
 type CreateTestBlockSubmissionOpts struct {
 	relaySk bls.SecretKey
-	relayPk phase0.BLSPubKey
 	domain  phase0.Domain
 
 	Version        spec.DataVersion
@@ -140,7 +139,6 @@ func CreateTestBlockSubmission(t *testing.T, builderPubkey string, value *uint25
 
 	slot := uint64(0)
 	relaySk := bls.SecretKey{}
-	relayPk := phase0.BLSPubKey{}
 	domain := phase0.Domain{}
 	proposerPk := phase0.BLSPubKey{}
 	parentHash := phase0.Hash32{}
@@ -148,7 +146,6 @@ func CreateTestBlockSubmission(t *testing.T, builderPubkey string, value *uint25
 
 	if opts != nil {
 		relaySk = opts.relaySk
-		relayPk = opts.relayPk
 		domain = opts.domain
 		slot = opts.Slot
 
@@ -207,7 +204,7 @@ func CreateTestBlockSubmission(t *testing.T, builderPubkey string, value *uint25
 		}
 	}
 
-	getHeaderResponse, err = BuildGetHeaderResponse(payload, &relaySk, &relayPk, domain)
+	getHeaderResponse, err = BuildGetHeaderResponse(payload, &relaySk, domain)
 	require.NoError(t, err)
 
 	getPayloadResponse, err = BuildGetPayloadResponse(payload)

--- a/common/types_spec.go
+++ b/common/types_spec.go
@@ -36,7 +36,7 @@ type HTTPErrorResp struct {
 
 var NilResponse = struct{}{}
 
-func BuildGetHeaderResponse(payload *VersionedSubmitBlockRequest, sk *bls.SecretKey, pubkey *phase0.BLSPubKey, domain phase0.Domain) (*builderSpec.VersionedSignedBuilderBid, error) {
+func BuildGetHeaderResponse(payload *VersionedSubmitBlockRequest, sk *bls.SecretKey, domain phase0.Domain) (*builderSpec.VersionedSignedBuilderBid, error) {
 	if payload == nil {
 		return nil, ErrMissingRequest
 	}
@@ -53,7 +53,7 @@ func BuildGetHeaderResponse(payload *VersionedSubmitBlockRequest, sk *bls.Secret
 		if err != nil {
 			return nil, err
 		}
-		signedBuilderBid, err := BuilderBlockRequestToSignedBuilderBid(payload, header, sk, pubkey, domain)
+		signedBuilderBid, err := BuilderBlockRequestToSignedBuilderBid(payload, header, sk, domain)
 		if err != nil {
 			return nil, err
 		}
@@ -67,7 +67,7 @@ func BuildGetHeaderResponse(payload *VersionedSubmitBlockRequest, sk *bls.Secret
 		if err != nil {
 			return nil, err
 		}
-		signedBuilderBid, err := BuilderBlockRequestToSignedBuilderBid(payload, header, sk, pubkey, domain)
+		signedBuilderBid, err := BuilderBlockRequestToSignedBuilderBid(payload, header, sk, domain)
 		if err != nil {
 			return nil, err
 		}
@@ -103,7 +103,7 @@ func BuildGetPayloadResponse(payload *VersionedSubmitBlockRequest) (*builderApi.
 	return nil, ErrEmptyPayload
 }
 
-func BuilderBlockRequestToSignedBuilderBid(payload *VersionedSubmitBlockRequest, header *builderApi.VersionedExecutionPayloadHeader, sk *bls.SecretKey, pubkey *phase0.BLSPubKey, domain phase0.Domain) (*builderSpec.VersionedSignedBuilderBid, error) {
+func BuilderBlockRequestToSignedBuilderBid(payload *VersionedSubmitBlockRequest, header *builderApi.VersionedExecutionPayloadHeader, sk *bls.SecretKey, domain phase0.Domain) (*builderSpec.VersionedSignedBuilderBid, error) {
 	value, err := payload.Value()
 	if err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ func BuilderBlockRequestToSignedBuilderBid(payload *VersionedSubmitBlockRequest,
 		builderBid := builderApiCapella.BuilderBid{
 			Value:  value,
 			Header: header.Capella,
-			Pubkey: *pubkey,
+			Pubkey: payload.Capella.Message.BuilderPubkey,
 		}
 
 		sig, err := ssz.SignMessage(&builderBid, domain, sk)
@@ -134,7 +134,7 @@ func BuilderBlockRequestToSignedBuilderBid(payload *VersionedSubmitBlockRequest,
 			Header:             header.Deneb,
 			BlobKZGCommitments: payload.Deneb.BlobsBundle.Commitments,
 			Value:              value,
-			Pubkey:             *pubkey,
+			Pubkey:             payload.Deneb.Message.BuilderPubkey,
 		}
 
 		sig, err := ssz.SignMessage(&builderBid, domain, sk)

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1841,7 +1841,7 @@ type redisUpdateBidOpts struct {
 
 func (api *RelayAPI) updateRedisBid(opts redisUpdateBidOpts) (*datastore.SaveBidAndUpdateTopBidResponse, *builderApi.VersionedSubmitBlindedBlockResponse, bool) {
 	// Prepare the response data
-	getHeaderResponse, err := common.BuildGetHeaderResponse(opts.payload, api.blsSk, api.publicKey, api.opts.EthNetDetails.DomainBuilder)
+	getHeaderResponse, err := common.BuildGetHeaderResponse(opts.payload, api.blsSk, api.opts.EthNetDetails.DomainBuilder)
 	if err != nil {
 		opts.log.WithError(err).Error("could not sign builder bid")
 		api.RespondError(opts.w, http.StatusBadRequest, err.Error())

--- a/services/api/types_test.go
+++ b/services/api/types_test.go
@@ -122,13 +122,7 @@ func TestBuilderBlockRequestToSignedBuilderBid(t *testing.T) {
 			sk, _, err := bls.GenerateNewKeypair()
 			require.NoError(t, err)
 
-			pubkey, err := bls.PublicKeyFromSecretKey(sk)
-			require.NoError(t, err)
-
-			publicKey, err := utils.BlsPublicKeyToPublicKey(pubkey)
-			require.NoError(t, err)
-
-			signedBuilderBid, err := common.BuildGetHeaderResponse(tc.reqPayload, sk, &publicKey, ssz.DomainBuilder)
+			signedBuilderBid, err := common.BuildGetHeaderResponse(tc.reqPayload, sk, ssz.DomainBuilder)
 			require.NoError(t, err)
 
 			bidValue, err := signedBuilderBid.Value()


### PR DESCRIPTION
## 📝 Summary

Fix for #660.

## ⛱ Motivation and Context

This fixes a bug with the data returned by headers.

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
