### PR TITLE
fix registerValidator content type detection

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1018,7 +1018,12 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 	}
 
 	// Get the request content type
-	proposerContentType := req.Header.Get(HeaderContentType)
+	proposerContentType, _, err := getHeaderContentType(req.Header)
+	if err != nil {
+		api.log.WithError(err).Error("failed to parse proposer content type")
+		api.RespondError(w, http.StatusUnsupportedMediaType, err.Error())
+		return
+	}
 	log = log.WithField("proposerContentType", proposerContentType)
 
 	// Read the encoded validator registrations

--- a/services/api/utils.go
+++ b/services/api/utils.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"fmt"
+	"mime"
+	"net/http"
 
 	builderApi "github.com/attestantio/go-builder-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
@@ -183,4 +185,21 @@ func verifyBlockSignature(block *common.VersionedSignedBlindedBeaconBlock, domai
 
 func getPayloadAttributesKey(parentHash string, slot uint64) string {
 	return fmt.Sprintf("%s-%d", parentHash, slot)
+}
+
+// getHeaderContentType parses the Content-Type header and returns the media type and parameters.
+// It returns an empty mediaType string and nil parameters if the header is not set or empty.
+func getHeaderContentType(header http.Header) (mediatype string, params map[string]string, err error) {
+	contentType := header.Get(HeaderContentType)
+	if contentType == "" {
+		return "", nil, nil
+	}
+
+	// Parse the content type
+	contentType, params, err = mime.ParseMediaType(contentType)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "failed to parse Content-Type header")
+	}
+
+	return contentType, params, nil
 }

--- a/services/api/utils_test.go
+++ b/services/api/utils_test.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHeaderContentType(t *testing.T) {
+	for _, tc := range []struct {
+		header   http.Header
+		expected string
+	}{
+		{
+			header:   http.Header{"Content-Type": []string{"application/json"}},
+			expected: ApplicationJSON,
+		},
+		{
+			header:   http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
+			expected: ApplicationJSON,
+		},
+		{
+			header:   http.Header{"Content-Type": []string{""}},
+			expected: "",
+		},
+	} {
+		t.Run(tc.expected, func(t *testing.T) {
+			contentType, _, err := getHeaderContentType(tc.header)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, contentType)
+		})
+	}
+}


### PR DESCRIPTION
## 📝 Summary

Fixes detection of content type on registerValidator, now also supports additional params, i.e.:

```
application/json; charset=utf-8
``` 

See also https://github.com/flashbots/mev-boost/issues/766#issuecomment-2809586758

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
