### PR TITLE
Try fixing registerValidator cache misses

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -192,9 +192,7 @@ func (ds *Datastore) SaveValidatorRegistration(entry builderApiV1.SignedValidato
 		return errors.Wrap(err, "failed saving validator registration to database")
 	}
 
-	// then save in redis
-	pk := common.NewPubkeyHex(entry.Message.Pubkey.String())
-	err = ds.redis.SetValidatorRegistrationTimestampIfNewer(pk, uint64(entry.Message.Timestamp.Unix())) //nolint:gosec
+	err = ds.redis.SetValidatorRegistrationData(entry.Message)
 	if err != nil {
 		return errors.Wrap(err, "failed saving validator registration to redis")
 	}

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1057,7 +1057,7 @@ func (api *RelayAPI) handleRegisterValidator(w http.ResponseWriter, req *http.Re
 		})
 
 		// Add validator pubkey to logs
-		pkHex := common.PubkeyHex(signedValidatorRegistration.Message.Pubkey.String())
+		pkHex := common.NewPubkeyHex(signedValidatorRegistration.Message.Pubkey.String())
 		regLog = regLog.WithFields(logrus.Fields{
 			"pubkey":       pkHex,
 			"signature":    signedValidatorRegistration.Signature.String(),

--- a/services/housekeeper/housekeeper.go
+++ b/services/housekeeper/housekeeper.go
@@ -260,7 +260,15 @@ func (hk *Housekeeper) updateValidatorRegistrationsInRedis() {
 	timeStarted := time.Now()
 
 	for _, reg := range regs {
-		err = hk.redis.SetValidatorRegistrationTimestampIfNewer(common.NewPubkeyHex(reg.Pubkey), reg.Timestamp)
+		// convert DB data to original struct
+		data, err := reg.ToSignedValidatorRegistration()
+		if err != nil {
+			hk.log.WithError(err).Error("failed to convert validator registration entry to signed validator registration")
+			continue
+		}
+
+		// save to Redis
+		err = hk.redis.SetValidatorRegistrationData(data.Message)
 		if err != nil {
 			hk.log.WithError(err).Error("failed to set validator registration")
 			continue


### PR DESCRIPTION
Improvement to registerValidator caching (and some cleanup)

CL clients often send registerValidator requests with new timestamps, which made the old codebase always validate the signature. Validating BLS signature is CPU intensive, which can botteleneck and degrade overall stability.

The updated registerValidator logic is this:
- Instead of caching only the timestamp, now store the whole registration in Redis.
- If an incoming validation would not actually change any of the fields (`fee_recipient` and `gas_limit`), then discard it right away (and not validate the signature, which is the CPU expensive step).

We are running this PR (`1cd270d`) now in prodiuction and seeing the caching working again.