### PR TITLE
syncmap for registervalidator cache

### DIFF
--- a/datastore/syncmap.go
+++ b/datastore/syncmap.go
@@ -23,6 +23,10 @@ func (m *syncMap[K, V]) Load(key K) (V, bool) { //nolint:ireturn
 	return vv, true
 }
 
+func (m *syncMap[K, V]) LoadOrStore(key K, value V) (actual any, loaded bool) {
+	return m.m.LoadOrStore(key, value)
+}
+
 func (m *syncMap[K, V]) Store(key K, value V) {
 	m.m.Store(key, value)
 }

--- a/datastore/syncmap.go
+++ b/datastore/syncmap.go
@@ -1,0 +1,28 @@
+package datastore
+
+import "sync"
+
+type syncMap[K comparable, V any] struct {
+	m sync.Map
+}
+
+func (m *syncMap[K, V]) Load(key K) (V, bool) { //nolint:ireturn
+	var vZero V
+
+	v, ok := m.m.Load(key)
+	if !ok {
+		return vZero, false
+	}
+
+	vv, ok := v.(V)
+	if !ok {
+		// should be unreachable
+		return vZero, false
+	}
+
+	return vv, true
+}
+
+func (m *syncMap[K, V]) Store(key K, value V) {
+	m.m.Store(key, value)
+}

--- a/services/api/optimistic_test.go
+++ b/services/api/optimistic_test.go
@@ -73,7 +73,7 @@ func startTestBackend(t *testing.T) (*phase0.BLSPubKey, *bls.SecretKey, *testBac
 	pkStr := pubkey.String()
 
 	// Setup test backend.
-	backend := newTestBackend(t, 1)
+	backend := newTestBackend(t)
 	backend.relay.genesisInfo = &beaconclient.GetGenesisResponse{}
 	backend.relay.genesisInfo.Data.GenesisTime = 0
 	backend.relay.proposerDutiesMap = map[uint64]*common.BuilderGetValidatorsResponseEntry{


### PR DESCRIPTION
## 📝 Summary

Locks appear to be the current bottleneck for processing register-validator. This PR replaces them with sync.Map.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
