### PR TITLE
Improve pprof in api service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build go mod download
 
 # Now adding all the code and start building
 ADD . .
-RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux go build -trimpath -ldflags "-s -X cmd.Version=$VERSION -X main.Version=$VERSION -linkmode external -extldflags '-static'" -v -o mev-boost-relay .
+RUN --mount=type=cache,target=/root/.cache/go-build GOOS=linux go build -trimpath -ldflags "-X cmd.Version=$VERSION -X main.Version=$VERSION" -v -o mev-boost-relay .
 
 FROM alpine
 RUN apk add --no-cache libstdc++ libc6-compat

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -24,7 +24,7 @@ var (
 	apiDefaultSecretKey  = common.GetEnv("SECRET_KEY", "")
 	apiDefaultLogTag     = os.Getenv("LOG_TAG")
 
-	apiDefaultPprofEnabled       = os.Getenv("PPROF") == "1"
+	apiDefaultPprofListenAddr    = os.Getenv("PPROF_ADDR")
 	apiDefaultInternalAPIEnabled = os.Getenv("ENABLE_INTERNAL_API") == "1"
 
 	// Default Builder, Data, and Proposer API as true.
@@ -32,16 +32,16 @@ var (
 	apiDefaultDataAPIEnabled     = os.Getenv("DISABLE_DATA_API") != "1"
 	apiDefaultProposerAPIEnabled = os.Getenv("DISABLE_PROPOSER_API") != "1"
 
-	apiListenAddr   string
-	apiPprofEnabled bool
-	apiSecretKey    string
-	apiBlockSimURL  string
-	apiDebug        bool
-	apiBuilderAPI   bool
-	apiDataAPI      bool
-	apiInternalAPI  bool
-	apiProposerAPI  bool
-	apiLogTag       string
+	apiListenAddr      string
+	apiPprofListenAddr string
+	apiSecretKey       string
+	apiBlockSimURL     string
+	apiDebug           bool
+	apiBuilderAPI      bool
+	apiDataAPI         bool
+	apiInternalAPI     bool
+	apiProposerAPI     bool
+	apiLogTag          string
 )
 
 func init() {
@@ -63,7 +63,8 @@ func init() {
 	apiCmd.Flags().StringVar(&apiBlockSimURL, "blocksim", apiDefaultBlockSim, "URL for block simulator")
 	apiCmd.Flags().StringVar(&network, "network", defaultNetwork, "Which network to use")
 
-	apiCmd.Flags().BoolVar(&apiPprofEnabled, "pprof", apiDefaultPprofEnabled, "enable pprof API")
+	apiCmd.Flags().StringVar(&apiPprofListenAddr, "pprof-listen-addr", apiDefaultPprofListenAddr, "listen address for pprof, empty to disable")
+
 	apiCmd.Flags().BoolVar(&apiBuilderAPI, "builder-api", apiDefaultBuilderAPIEnabled, "enable builder API (/builder/...)")
 	apiCmd.Flags().BoolVar(&apiDataAPI, "data-api", apiDefaultDataAPIEnabled, "enable data API (/data/...)")
 	apiCmd.Flags().BoolVar(&apiInternalAPI, "internal-api", apiDefaultInternalAPIEnabled, "enable internal API (/internal/...)")
@@ -165,11 +166,12 @@ var apiCmd = &cobra.Command{
 			EthNetDetails: *networkInfo,
 			BlockSimURL:   apiBlockSimURL,
 
+			PprofListenAddr: apiPprofListenAddr,
+
 			BlockBuilderAPI: apiBuilderAPI,
 			DataAPI:         apiDataAPI,
 			InternalAPI:     apiInternalAPI,
 			ProposerAPI:     apiProposerAPI,
-			PprofAPI:        apiPprofEnabled,
 		}
 
 		// Decode the private key


### PR DESCRIPTION
We want to profile the API service, and it served pprof from main http server previously, which is subject to write timeout, 10 seconds, which limits length of profiles and their usefulness.

## 📝 Summary

<!--- A general summary of your changes -->

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
