### PR TITLE
remove unnecessary fields from GetStateValidatorsResponse

### DIFF
--- a/beaconclient/beacon_client_test.go
+++ b/beaconclient/beacon_client_test.go
@@ -177,9 +177,7 @@ func TestFetchValidators(t *testing.T) {
 			Validator: ValidatorResponseValidatorData{
 				Pubkey: testPubKey,
 			},
-			Index:   0,
-			Balance: "0",
-			Status:  "",
+			Index: 0,
 		}
 
 		backend := newTestBackend(t, 3)

--- a/beaconclient/prod_beacon_instance.go
+++ b/beaconclient/prod_beacon_instance.go
@@ -135,27 +135,27 @@ func (c *ProdBeaconInstance) SubscribeToPayloadAttributesEvents(payloadAttribute
 }
 
 type GetStateValidatorsResponse struct {
-	ExecutionOptimistic bool `json:"execution_optimistic"`
-	Finalized           bool `json:"finalized"`
-	Data                []ValidatorResponseEntry
+	// ExecutionOptimistic bool `json:"execution_optimistic"`
+	// Finalized           bool `json:"finalized"`
+	Data []ValidatorResponseEntry
 }
 
 type ValidatorResponseEntry struct {
-	Index     uint64                         `json:"index,string"` // Index of validator in validator registry.
-	Balance   string                         `json:"balance"`      // Current validator balance in gwei.
-	Status    string                         `json:"status"`
+	Index uint64 `json:"index,string"` // Index of validator in validator registry.
+	// Balance   string                         `json:"balance"`      // Current validator balance in gwei.
+	// Status    string                         `json:"status"`
 	Validator ValidatorResponseValidatorData `json:"validator"`
 }
 
 type ValidatorResponseValidatorData struct {
-	Pubkey                string `json:"pubkey"`
-	WithdrawalCredentials string `json:"withdrawal_credentials"`
-	EffectiveBalance      string `json:"effective_balance"`
-	Slashed               bool   `json:"slashed"`
-	ActivationEligibility uint64 `json:"activation_eligibility_epoch,string"`
-	ActivationEpoch       uint64 `json:"activation_epoch,string"`
-	ExitEpoch             uint64 `json:"exit_epoch,string"`
-	WithdrawableEpoch     uint64 `json:"withdrawable_epoch,string"`
+	Pubkey string `json:"pubkey"`
+	// WithdrawalCredentials string `json:"withdrawal_credentials"`
+	// EffectiveBalance      string `json:"effective_balance"`
+	// Slashed               bool   `json:"slashed"`
+	// ActivationEligibility uint64 `json:"activation_eligibility_epoch,string"`
+	// ActivationEpoch       uint64 `json:"activation_epoch,string"`
+	// ExitEpoch             uint64 `json:"exit_epoch,string"`
+	// WithdrawableEpoch     uint64 `json:"withdrawable_epoch,string"`
 }
 
 // GetStateValidators loads all active and pending validators


### PR DESCRIPTION
## 📝 Summary

Unmarshalling this structure takes ~4% of all CPU time, and we actually do not need most of the fields. Remove them from struct so that native json decoder will be faster

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
