### PR TITLE
User error for getPayload request with a non-Electra payload

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1422,6 +1422,12 @@ func (api *RelayAPI) handleGetPayload(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
+	if api.isElectra(headSlot) && payload.Electra == nil {
+		log.Warn("Not an electra payload.")
+		api.RespondError(w, http.StatusBadRequest, "Non-Electra payload detected and rejected. You need to update mev-boost!")
+		return
+	}
+
 	// Take time after the decoding, and add to logging
 	decodeTime := time.Now().UTC()
 	slot, err := payload.Slot()


### PR DESCRIPTION
See also https://github.com/flashbots/mev-boost-relay/issues/731

This code would return an error to the user that they need to update mev-boost.