### PR TITLE
chore: Update attestantio deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alicebob/miniredis/v2 v2.34.0
 	github.com/aohorodnyk/mimeheader v0.0.6
-	github.com/attestantio/go-builder-client v0.6.5-0.20250901141559-94d1ecfeeb53
-	github.com/attestantio/go-eth2-client v0.26.1-0.20250829122455-ff89a2135a43
+	github.com/attestantio/go-builder-client v0.7.0
+	github.com/attestantio/go-eth2-client v0.27.0
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/buger/jsonparser v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -11,10 +11,10 @@ github.com/alicebob/miniredis/v2 v2.34.0 h1:mBFWMaJSNL9RwdGRyEDoAAv8OQc5UlEhLDQg
 github.com/alicebob/miniredis/v2 v2.34.0/go.mod h1:kWShP4b58T1CW0Y5dViCd5ztzrDqRWqM3nksiyXk5s8=
 github.com/aohorodnyk/mimeheader v0.0.6 h1:WCV4NQjtbqnd2N3FT5MEPesan/lfvaLYmt5v4xSaX/M=
 github.com/aohorodnyk/mimeheader v0.0.6/go.mod h1:/Gd3t3vszyZYwjNJo2qDxoftZjjVzMdkQZxkiINp3vM=
-github.com/attestantio/go-builder-client v0.6.5-0.20250901141559-94d1ecfeeb53 h1:cKIZhhu11jC390ReL4/hWxS+YXnMESoou/UIMQ6HgpM=
-github.com/attestantio/go-builder-client v0.6.5-0.20250901141559-94d1ecfeeb53/go.mod h1:66Sj0omUS6/j2G9SrBp5tpwkU+Qkds2CNbbRoaGojpY=
-github.com/attestantio/go-eth2-client v0.26.1-0.20250829122455-ff89a2135a43 h1:v5l00W4U5WuYz6+Cux0URjN/VBKCupwzG6gCgRdn6Wo=
-github.com/attestantio/go-eth2-client v0.26.1-0.20250829122455-ff89a2135a43/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
+github.com/attestantio/go-builder-client v0.7.0 h1:Kxf5eTKQlU4syv3Uzt8v3vKKm7im1W4CjRAZiPYoqTQ=
+github.com/attestantio/go-builder-client v0.7.0/go.mod h1:wGZ0U3QX8/F4lWwieJpqCPgXIl8gbfBxm8iViznrTFQ=
+github.com/attestantio/go-eth2-client v0.27.0 h1:zOXtDVnMNRwX6GjpJYgXUNsXckEx76pGRDi76i7xhSI=
+github.com/attestantio/go-eth2-client v0.27.0/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bits-and-blooms/bitset v1.22.0 h1:Tquv9S8+SGaS3EhyA+up3FXzmkhxPGjQQCkcs2uw7w4=


### PR DESCRIPTION
## 📝 Summary

[go-builder-client](https://github.com/attestantio/go-builder-client) and [go-eth2-client 
](https://github.com/attestantio/go-eth2-client) now have the fulu related changes merged to main. 

We can now use their official releases in our dependencies.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
* [x] I have seen and agree to `CONTRIBUTING.md`
