### PR TITLE
Add noop block simulator

### DIFF
--- a/services/api/blocksim_ratelimiter.go
+++ b/services/api/blocksim_ratelimiter.go
@@ -186,3 +186,19 @@ func SendJSONRPCRequest(client *http.Client, req jsonrpc.JSONRPCRequest, url str
 	}
 	return res, nil, nil
 }
+
+var _ IBlockSimRateLimiter = (*NoopBlockSim)(nil)
+
+type NoopBlockSim struct{}
+
+func newNoopBlockSim() *NoopBlockSim {
+	return &NoopBlockSim{}
+}
+
+func (n *NoopBlockSim) Send(context context.Context, payload *common.BuilderBlockValidationRequest, isHighPrio, fastTrack bool) (*common.BuilderBlockValidationResponse, error, error) {
+	return nil, nil, nil
+}
+
+func (n *NoopBlockSim) CurrentCounter() int64 {
+	return 0
+}

--- a/services/api/blocksim_ratelimiter_test.go
+++ b/services/api/blocksim_ratelimiter_test.go
@@ -1,0 +1,16 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoopBlockSim(t *testing.T) {
+	n := newNoopBlockSim()
+	resp, err1, err2 := n.Send(context.Background(), nil, false, false)
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	require.Nil(t, resp)
+}


### PR DESCRIPTION
## 📝 Summary

This PR adds an alternative implementation for the block simulator which always returns nil. This is useful in testing scenarios where you want to run without a block simulator as we do in https://github.com/flashbots/builder-playground. 

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test-race`
* [ ] `go mod tidy`
* [ ] I have seen and agree to `CONTRIBUTING.md`
