### PR TITLE
Add configurable delay to the header requests

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -20,6 +20,7 @@ var (
 	meter otelapi.Meter
 
 	GetHeaderLatencyHistogram         otelapi.Float64Histogram
+	GetHeaderDelayHistogram           otelapi.Float64Histogram
 	GetPayloadLatencyHistogram        otelapi.Float64Histogram
 	PublishBlockLatencyHistogram      otelapi.Float64Histogram
 	RegisterValidatorLatencyHistogram otelapi.Float64Histogram
@@ -68,6 +69,7 @@ func Setup(ctx context.Context) error {
 	for _, setup := range []func(context.Context) error{
 		setupMeter, // must come first
 		setupGetHeaderLatency,
+		setupGetHeaderDelay,
 		setupGetPayloadLatency,
 		setupPublishBlockLatency,
 		setupSubmitNewBlockLatency,
@@ -133,6 +135,20 @@ func setupGetHeaderLatency(_ context.Context) error {
 		latencyBoundariesMs,
 	)
 	GetHeaderLatencyHistogram = latency
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func setupGetHeaderDelay(_ context.Context) error {
+	hist, err := meter.Float64Histogram(
+		"get_header_delay",
+		otelapi.WithDescription("duration of artificial delay applied to getHeader responses for delay-eligible user agents"),
+		otelapi.WithUnit("ms"),
+		latencyBoundariesMs,
+	)
+	GetHeaderDelayHistogram = hist
 	if err != nil {
 		return err
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -4,6 +4,7 @@ package metrics
 import (
 	"context"
 	"math"
+	"sync"
 
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	otelapi "go.opentelemetry.io/otel/metric"
@@ -65,41 +66,54 @@ var (
 	}()...)
 )
 
-func Setup(ctx context.Context) error {
-	for _, setup := range []func(context.Context) error{
-		setupMeter, // must come first
-		setupGetHeaderLatency,
-		setupGetHeaderDelay,
-		setupGetPayloadLatency,
-		setupPublishBlockLatency,
-		setupSubmitNewBlockLatency,
-		setupSubmitNewBlockReadLatency,
-		setupSubmitNewBlockDecodeLatency,
-		setupSubmitNewBlockPrechecksLatency,
-		setupSubmitNewBlockSimulationLatency,
-		setupSubmitNewBlockRedisLatency,
-		setupSubmitNewBlockRedisPayloadLatency,
-		setupSubmitNewBlockRedisTopBidLatency,
-		setupSubmitNewBlockRedisFloorLatency,
-		setupRegisterValidatorLatency,
-		setupSubmitNewBlockCount,
-		setupGetHeaderCount,
-		setupGetPayloadCount,
-		setupRegisterValidatorCount,
-		setupMissedSlotCount,
-		setupSubmitNewBlockBidValue,
-		setupSubmitNewBlockPayloadSize,
-		setupSubmitNewBlockSlotAge,
-		setupDatabaseSaveLatency,
-		setupCurrentHeadSlot,
-		setupBuilderDemotionCount,
-	} {
-		if err := setup(ctx); err != nil {
-			return err
-		}
-	}
+var (
+	setupOnce sync.Once
+	setupErr  error
+)
 
-	return nil
+// Setup initializes the prometheus exporter and metric instruments. It is safe
+// to call multiple times from the same process: subsequent calls are no-ops
+// and return the result of the first call. This guard exists because the
+// underlying prometheus exporter registers a Collector on the global default
+// registry, and a second registration causes /metrics scrapes to fail with a
+// duplicate target_info collision.
+func Setup(ctx context.Context) error {
+	setupOnce.Do(func() {
+		for _, setup := range []func(context.Context) error{
+			setupMeter, // must come first
+			setupGetHeaderLatency,
+			setupGetHeaderDelay,
+			setupGetPayloadLatency,
+			setupPublishBlockLatency,
+			setupSubmitNewBlockLatency,
+			setupSubmitNewBlockReadLatency,
+			setupSubmitNewBlockDecodeLatency,
+			setupSubmitNewBlockPrechecksLatency,
+			setupSubmitNewBlockSimulationLatency,
+			setupSubmitNewBlockRedisLatency,
+			setupSubmitNewBlockRedisPayloadLatency,
+			setupSubmitNewBlockRedisTopBidLatency,
+			setupSubmitNewBlockRedisFloorLatency,
+			setupRegisterValidatorLatency,
+			setupSubmitNewBlockCount,
+			setupGetHeaderCount,
+			setupGetPayloadCount,
+			setupRegisterValidatorCount,
+			setupMissedSlotCount,
+			setupSubmitNewBlockBidValue,
+			setupSubmitNewBlockPayloadSize,
+			setupSubmitNewBlockSlotAge,
+			setupDatabaseSaveLatency,
+			setupCurrentHeadSlot,
+			setupBuilderDemotionCount,
+		} {
+			if err := setup(ctx); err != nil {
+				setupErr = err
+				return
+			}
+		}
+	})
+	return setupErr
 }
 
 func setupMeter(ctx context.Context) error {

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -59,6 +59,8 @@ const (
 	HeaderAccept              = "Accept"
 	HeaderContentType         = "Content-Type"
 	HeaderEthConsensusVersion = "Eth-Consensus-Version"
+	HeaderDateMilliseconds    = "Date-Milliseconds"
+	HeaderTimeoutMs           = "X-Timeout-Ms"
 
 	HandleGetPayloadVersionV1 HandleGetPayloadVersion = "V1"
 	HandleGetPayloadVersionV2 HandleGetPayloadVersion = "V2"
@@ -103,6 +105,17 @@ var (
 	getHeaderRequestCutoffMs  = cli.GetEnvInt("GETHEADER_REQUEST_CUTOFF_MS", 3000)
 	getPayloadRequestCutoffMs = cli.GetEnvInt("GETPAYLOAD_REQUEST_CUTOFF_MS", 4000)
 	getPayloadResponseDelayMs = cli.GetEnvInt("GETPAYLOAD_RESPONSE_DELAY_MS", 1000)
+	// Latest point in the slot (ms after slot start) to which getHeader responses
+	// for delay-eligible user agents are deferred. Disabled with 0 by default.
+	getHeaderResponseDelayTargetMs = cli.GetEnvInt("GETHEADER_RESPONSE_DELAY_TARGET_MS", 0)
+	// Safety margin subtracted from the target return time to leave room for
+	// response serialization and network egress.
+	getHeaderResponseDelaySafetyMs = cli.GetEnvInt("GETHEADER_RESPONSE_DELAY_SAFETY_MS", 5)
+	// Comma-separated user-agent substrings that opt the client into the
+	// getHeader response delay. A request is delayed if its User-Agent contains
+	// any of these substrings. Unset (empty) by default, which disables the
+	// delay regardless of GETHEADER_RESPONSE_DELAY_TARGET_MS.
+	getHeaderDelayUserAgents = common.GetEnvStrSlice("GETHEADER_DELAY_USERAGENTS", nil)
 
 	// api settings
 	apiReadTimeoutMs       = cli.GetEnvInt("API_TIMEOUT_READ_MS", 1500)
@@ -1287,6 +1300,24 @@ func (api *RelayAPI) handleGetHeader(w http.ResponseWriter, req *http.Request) {
 		log.Info("getHeader sent too late")
 		w.WriteHeader(http.StatusNoContent)
 		return
+	}
+
+	// For delay-eligible user agents, defer the response so it can include
+	// later (and potentially higher-value) bids.
+	slotStartMs := int64(slotStartTimestamp * 1000) //nolint:gosec
+	if delay := computeGetHeaderDelay(ua, slotStartMs, time.Now().UnixMilli(), req.Header,
+		int64(getHeaderResponseDelayTargetMs), int64(getHeaderResponseDelaySafetyMs), getHeaderDelayUserAgents); delay > 0 {
+		timer := time.NewTimer(delay)
+		select {
+		case <-timer.C:
+			metrics.GetHeaderDelayHistogram.Record(
+				req.Context(),
+				float64(delay.Milliseconds()),
+			)
+		case <-req.Context().Done():
+			timer.Stop()
+			return
+		}
 	}
 
 	bid, err := api.redis.GetBestBid(slot, parentHashHex, proposerPubkeyHex)

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1305,15 +1305,21 @@ func (api *RelayAPI) handleGetHeader(w http.ResponseWriter, req *http.Request) {
 	// For delay-eligible user agents, defer the response so it can include
 	// later (and potentially higher-value) bids.
 	slotStartMs := int64(slotStartTimestamp * 1000) //nolint:gosec
-	if delay := computeGetHeaderDelay(ua, slotStartMs, time.Now().UnixMilli(), req.Header,
-		int64(getHeaderResponseDelayTargetMs), int64(getHeaderResponseDelaySafetyMs), getHeaderDelayUserAgents); delay > 0 {
+	delay := computeGetHeaderDelay(
+		ua, slotStartMs, time.Now().UnixMilli(), req.Header,
+		int64(getHeaderResponseDelayTargetMs),
+		int64(getHeaderResponseDelaySafetyMs),
+		getHeaderDelayUserAgents,
+	)
+	log = logrus.WithField("delayMs", delay.Milliseconds())
+	if delay > 0 {
 		timer := time.NewTimer(delay)
+		metrics.GetHeaderDelayHistogram.Record(
+			req.Context(),
+			float64(delay.Milliseconds()),
+		)
 		select {
 		case <-timer.C:
-			metrics.GetHeaderDelayHistogram.Record(
-				req.Context(),
-				float64(delay.Milliseconds()),
-			)
 		case <-req.Context().Done():
 			timer.Stop()
 			return

--- a/services/api/utils.go
+++ b/services/api/utils.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"mime"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	builderApi "github.com/attestantio/go-builder-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
@@ -226,6 +229,55 @@ func verifyBlockSignature(block *common.VersionedSignedBlindedBeaconBlock, domai
 
 func getPayloadAttributesKey(parentHash string, slot uint64) string {
 	return fmt.Sprintf("%s-%d", parentHash, slot)
+}
+
+// parseClientDeadlineMs returns the unix-millisecond deadline communicated by
+// the client via the Date-Milliseconds and X-Timeout-Ms headers, if both are
+// present and parseable.
+func parseClientDeadlineMs(header http.Header) (int64, bool) {
+	dateMs, err := strconv.ParseInt(header.Get(HeaderDateMilliseconds), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	timeoutMs, err := strconv.ParseInt(header.Get(HeaderTimeoutMs), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return dateMs + timeoutMs, true
+}
+
+// computeGetHeaderDelay returns how long handleGetHeader should sleep before
+// responding so that delay-eligible user agents receive their bid as late as
+// possible (and thus with the freshest, potentially highest-value bid).
+//
+// A request is delay-eligible when its user agent contains any of the
+// delayUserAgents substrings. The sleep target is capped at
+// min(slotStartMs+targetMs, clientDeadlineMs) where clientDeadlineMs comes
+// from the timing headers on the request, then reduced by safetyMs to leave
+// room for response serialization and network egress. A zero return value
+// means no delay.
+func computeGetHeaderDelay(ua string, slotStartMs, nowMs int64, header http.Header, targetMs, safetyMs int64, delayUserAgents []string) time.Duration {
+	if targetMs <= 0 || !uaMatchesAny(ua, delayUserAgents) {
+		return 0
+	}
+	capMs := slotStartMs + targetMs
+	if clientCapMs, ok := parseClientDeadlineMs(header); ok && clientCapMs < capMs {
+		capMs = clientCapMs
+	}
+	sleepUntilMs := capMs - safetyMs
+	if sleepUntilMs <= nowMs {
+		return 0
+	}
+	return time.Duration(sleepUntilMs-nowMs) * time.Millisecond
+}
+
+func uaMatchesAny(ua string, substrings []string) bool {
+	for _, s := range substrings {
+		if s != "" && strings.Contains(ua, s) {
+			return true
+		}
+	}
+	return false
 }
 
 // getHeaderContentType parses the Content-Type header and returns the media type and parameters.

--- a/services/api/utils_test.go
+++ b/services/api/utils_test.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"net/http"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/flashbots/mev-boost-relay/common"
 	"github.com/stretchr/testify/require"
@@ -30,6 +32,153 @@ func TestGetHeaderContentType(t *testing.T) {
 			contentType, _, err := getHeaderContentType(tc.header)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, contentType)
+		})
+	}
+}
+
+func TestComputeGetHeaderDelay(t *testing.T) {
+	const (
+		slotStartMs = int64(1_700_000_000_000)
+		targetMs    = int64(800)
+		safetyMs    = int64(5)
+		matchedUA   = "some-client-a/1.0.0"
+		unmatchedUA = "other-client/2.0.0"
+	)
+	uas := []string{"some-client-a", "some-client-b"}
+
+	headerWithDeadline := func(date, timeout int64) http.Header {
+		return http.Header{
+			HeaderDateMilliseconds: []string{strconv.FormatInt(date, 10)},
+			HeaderTimeoutMs:        []string{strconv.FormatInt(timeout, 10)},
+		}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		ua       string
+		nowMs    int64
+		header   http.Header
+		targetMs int64
+		safetyMs int64
+		uas      []string
+		want     time.Duration
+	}{
+		{
+			name:     "ineligible UA returns no delay",
+			ua:       unmatchedUA,
+			nowMs:    slotStartMs,
+			targetMs: targetMs,
+			safetyMs: safetyMs,
+			uas:      uas,
+			want:     0,
+		},
+		{
+			name:     "target=0 disables delay",
+			ua:       matchedUA,
+			nowMs:    slotStartMs,
+			targetMs: 0,
+			safetyMs: safetyMs,
+			uas:      uas,
+			want:     0,
+		},
+		{
+			name:     "empty UA list returns no delay",
+			ua:       matchedUA,
+			nowMs:    slotStartMs,
+			targetMs: targetMs,
+			safetyMs: safetyMs,
+			uas:      nil,
+			want:     0,
+		},
+		{
+			name:     "matched UA delayed to target minus safety",
+			ua:       matchedUA,
+			nowMs:    slotStartMs,
+			targetMs: targetMs,
+			safetyMs: safetyMs,
+			uas:      uas,
+			want:     time.Duration(targetMs-safetyMs) * time.Millisecond,
+		},
+		{
+			name:     "second substring matches",
+			ua:       "some-client-b/0.5.0",
+			nowMs:    slotStartMs + 200,
+			targetMs: targetMs,
+			safetyMs: safetyMs,
+			uas:      uas,
+			want:     time.Duration(targetMs-200-safetyMs) * time.Millisecond,
+		},
+		{
+			name:     "substring match anywhere in UA",
+			ua:       "Go-http-client/1.1 (some-client-a/1.7.0)",
+			nowMs:    slotStartMs,
+			targetMs: targetMs,
+			safetyMs: safetyMs,
+			uas:      uas,
+			want:     time.Duration(targetMs-safetyMs) * time.Millisecond,
+		},
+		{
+			name:     "empty substring entries are ignored",
+			ua:       "anything",
+			nowMs:    slotStartMs,
+			targetMs: targetMs,
+			safetyMs: safetyMs,
+			uas:      []string{""},
+			want:     0,
+		},
+		{
+			name:     "request past target returns no delay",
+			ua:       matchedUA,
+			nowMs:    slotStartMs + targetMs,
+			targetMs: targetMs,
+			safetyMs: safetyMs,
+			uas:      uas,
+			want:     0,
+		},
+		{
+			name:     "client deadline shorter than target shortens sleep",
+			ua:       matchedUA,
+			nowMs:    slotStartMs,
+			header:   headerWithDeadline(slotStartMs, 500),
+			targetMs: targetMs,
+			safetyMs: safetyMs,
+			uas:      uas,
+			want:     time.Duration(500-safetyMs) * time.Millisecond,
+		},
+		{
+			name:     "client deadline longer than target is ignored",
+			ua:       matchedUA,
+			nowMs:    slotStartMs,
+			header:   headerWithDeadline(slotStartMs, 2_000),
+			targetMs: targetMs,
+			safetyMs: safetyMs,
+			uas:      uas,
+			want:     time.Duration(targetMs-safetyMs) * time.Millisecond,
+		},
+		{
+			name:     "malformed timing headers fall back to slot cap",
+			ua:       matchedUA,
+			nowMs:    slotStartMs,
+			header:   http.Header{HeaderDateMilliseconds: []string{"oops"}, HeaderTimeoutMs: []string{"500"}},
+			targetMs: targetMs,
+			safetyMs: safetyMs,
+			uas:      uas,
+			want:     time.Duration(targetMs-safetyMs) * time.Millisecond,
+		},
+		{
+			name:     "client deadline already passed returns no delay",
+			ua:       matchedUA,
+			nowMs:    slotStartMs + 100,
+			header:   headerWithDeadline(slotStartMs, 50),
+			targetMs: targetMs,
+			safetyMs: safetyMs,
+			uas:      uas,
+			want:     0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeGetHeaderDelay(tc.ua, slotStartMs, tc.nowMs, tc.header, tc.targetMs, tc.safetyMs, tc.uas)
+			require.Equal(t, tc.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## 📝 Summary

Adding configurable target delay for configurable user agents, to be used in "get header" requests.

`Date-Milliseconds` and `X-Timeout-Ms` headers from mev-boost are also taken into account. 

Also fixing a metrics dobule-registration failure discovered during testing (occurred during mev-boost-relay version upgrade in playground).