### PR TITLE
Fix logging in get header handler

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1318,7 +1318,7 @@ func (api *RelayAPI) handleGetHeader(w http.ResponseWriter, req *http.Request) {
 		int64(getHeaderResponseDelaySafetyMs),
 		getHeaderDelayUserAgents,
 	)
-	log = logrus.WithField("delayMs", delay.Milliseconds())
+	log = log.WithField("delayMs", delay.Milliseconds())
 	if delay > 0 {
 		timer := time.NewTimer(delay)
 		metrics.GetHeaderDelayHistogram.Record(


### PR DESCRIPTION
## 📝 Summary

Fixing the addition of the extra log field in the logger

## ⛱ Motivation and Context

This causes previously added fields to be removed and possibly breaks formatting, too.