### PR TITLE
Ignore 'parent block not found' sim error in the optimistic path

### DIFF
--- a/services/api/optimistic_test.go
+++ b/services/api/optimistic_test.go
@@ -227,6 +227,7 @@ func TestProcessOptimisticBlock(t *testing.T) {
 		wantStatus      common.BuilderStatus
 		version         spec.DataVersion
 		simulationError error
+		expectDemotion  bool
 	}{
 		{
 			description: "success_capella",
@@ -244,6 +245,7 @@ func TestProcessOptimisticBlock(t *testing.T) {
 			},
 			version:         spec.DataVersionCapella,
 			simulationError: errFake,
+			expectDemotion:  true,
 		},
 		{
 			description: "success_deneb",
@@ -261,6 +263,34 @@ func TestProcessOptimisticBlock(t *testing.T) {
 			},
 			version:         spec.DataVersionDeneb,
 			simulationError: errFake,
+			expectDemotion:  true,
+		},
+		{
+			description: "transient_simulation_error_block_too_old",
+			wantStatus: common.BuilderStatus{
+				IsOptimistic: true,
+				IsHighPrio:   true,
+			},
+			version:         spec.DataVersionDeneb,
+			simulationError: errors.New("simulation failed: block is too old"),
+		},
+		{
+			description: "transient_simulation_error_validation_window",
+			wantStatus: common.BuilderStatus{
+				IsOptimistic: true,
+				IsHighPrio:   true,
+			},
+			version:         spec.DataVersionDeneb,
+			simulationError: errors.New("simulation failed: block is outside validation window"),
+		},
+		{
+			description: "transient_simulation_error_parent_block_not_found",
+			wantStatus: common.BuilderStatus{
+				IsOptimistic: true,
+				IsHighPrio:   true,
+			},
+			version:         spec.DataVersionDeneb,
+			simulationError: errors.New("simulation failed: parent block not found"),
 		},
 	}
 	for _, tc := range cases {
@@ -298,11 +328,11 @@ func TestProcessOptimisticBlock(t *testing.T) {
 			require.NoError(t, simResult.requestErr)
 			require.True(t, simResult.wasSimulated)
 
-			// Check demotion but no refund.
+			// Check demotion status but no refund.
 			if tc.simulationError != nil {
 				mockDB, ok := backend.relay.db.(*database.MockDB)
 				require.True(t, ok)
-				require.True(t, mockDB.Demotions[pkStr])
+				require.Equal(t, tc.expectDemotion, mockDB.Demotions[pkStr])
 				require.False(t, mockDB.Refunds[pkStr])
 			}
 		})

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -719,6 +719,26 @@ func (api *RelayAPI) demoteBuilder(pubkey string, req *common.VersionedSubmitBlo
 	}
 }
 
+// transientSimErrors are substrings of block simulation errors caused by the
+// simulation node's state and not by the builders which submit such block.
+var transientSimErrors = []string{
+	"block is too old",
+	"outside validation window",
+	"parent block not found",
+}
+
+func isTransientSimError(simErr error) bool {
+	if simErr == nil {
+		return false
+	}
+	for _, substr := range transientSimErrors {
+		if strings.Contains(simErr.Error(), substr) {
+			return true
+		}
+	}
+	return false
+}
+
 // processOptimisticBlock is called on a new goroutine when a optimistic block
 // needs to be simulated.
 func (api *RelayAPI) processOptimisticBlock(opts blockSimOptions, simResultC chan *blockSimResult) {
@@ -745,9 +765,8 @@ func (api *RelayAPI) processOptimisticBlock(opts blockSimOptions, simResultC cha
 	simResultC <- &blockSimResult{reqErr == nil, blockValue, true, reqErr, simErr}
 	if reqErr != nil || simErr != nil {
 		// Skip demotion for transient sim failures that aren't the builder's fault:
-		// the block raced past the simulator's validation window before it could be checked.
-		if simErr != nil && (strings.Contains(simErr.Error(), "block is too old") || strings.Contains(simErr.Error(), "outside validation window")) {
-			opts.log.WithError(simErr).Warn("block simulation failed in processOptimisticBlock, skipping demotion (outside validation window)")
+		if isTransientSimError(simErr) {
+			opts.log.WithError(simErr).Warn("block simulation failed in processOptimisticBlock, skipping demotion (transient sim error)")
 			return
 		}
 


### PR DESCRIPTION
## 📝 Summary

Ignoring another occasional sim error when considering builder demotion

## ⛱ Motivation and Context

Seems to happen at discrete time ranges and most likely due to reorgs - should be excluded similarly
