### PR TITLE
Quality: Silent data corruption from ignored SetString error in NewBuilderBids

### DIFF
--- a/datastore/utils.go
+++ b/datastore/utils.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/redis/go-redis/v9"
@@ -25,18 +26,21 @@ func NewBuilderBidsFromRedis(ctx context.Context, r *RedisCache, pipeliner redis
 	if err != nil {
 		return nil, err
 	}
-	return NewBuilderBids(bidValueMap), nil
+	return NewBuilderBids(bidValueMap)
 }
 
-func NewBuilderBids(bidValueMap map[string]string) *BuilderBids {
+func NewBuilderBids(bidValueMap map[string]string) (*BuilderBids, error) {
 	b := BuilderBids{
 		bidValues: make(map[string]*big.Int),
 	}
 	for builderPubkey, bidValue := range bidValueMap {
-		b.bidValues[builderPubkey] = new(big.Int)
-		b.bidValues[builderPubkey].SetString(bidValue, 10)
+		v, ok := new(big.Int).SetString(bidValue, 10)
+		if !ok {
+			return nil, fmt.Errorf("invalid bid value for builder %s: %q", builderPubkey, bidValue)
+		}
+		b.bidValues[builderPubkey] = v
 	}
-	return &b
+	return &b, nil
 }
 
 func (b *BuilderBids) getTopBid() (string, *big.Int) {


### PR DESCRIPTION
## ✨ Code Quality

### Problem
In `NewBuilderBids`, `big.Int.SetString()` returns `(value, ok)` where ok indicates success, but the return value is completely ignored. If any Redis-stored bid value contains invalid characters for base-10 parsing (e.g., malformed data, corruption, or malicious input), `SetString` will fail silently - the bid value will remain at its zero-initialized `big.Int` (0) instead of the actual value. This corrupts auction calculations since zero bids will be considered, potentially causing invalid block selections or fund loss.


**Severity**: `high`
**File**: `datastore/utils.go`

### Solution
In `NewBuilderBids`, `big.Int.SetString()` returns `(value, ok)` where ok indicates success, but the return value is completely ignored. If any Redis-stored bid value contains invalid characters for base-10 parsing (e.g., malformed data, corruption, or malicious input), `SetString` will fail silently - the bid value will remain at its zero-initialized `big.Int` (0) instead of the actual value. This corrupts auction calculations since zero bids will be considered, potentially causing invalid block selections or fund loss.


### Changes
- `datastore/utils.go` (modified)

## 📝 Summary



## ⛱ Motivation and Context



## 📚 References



---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test-race`
* [ ] `go mod tidy`
* [ ] I have seen and agree to `CONTRIBUTING.md`

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #788