### PR TITLE
Add metric to detect late payload deliveries

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -39,12 +39,13 @@ var (
 
 	CurrentHeadSlotGauge otelapi.Int64Gauge
 
-	SubmitNewBlockCount            otelapi.Int64Counter
-	GetHeaderCount                 otelapi.Int64Counter
-	GetPayloadCount                otelapi.Int64Counter
-	GetPayloadDeliveryFailureCount otelapi.Int64Counter
-	RegisterValidatorCount         otelapi.Int64Counter
-	MissedSlotCount                otelapi.Int64Counter
+	SubmitNewBlockCount              otelapi.Int64Counter
+	GetHeaderCount                   otelapi.Int64Counter
+	GetPayloadCount                  otelapi.Int64Counter
+	GetPayloadDeliveryFailureCount   otelapi.Int64Counter
+	PayloadDeliveryExceededSlotCount otelapi.Int64Counter
+	RegisterValidatorCount           otelapi.Int64Counter
+	MissedSlotCount                  otelapi.Int64Counter
 
 	BuilderDemotionCount otelapi.Int64Counter
 
@@ -100,6 +101,7 @@ func Setup(ctx context.Context) error {
 			setupGetHeaderCount,
 			setupGetPayloadCount,
 			setupGetPayloadDeliveryFailureCount,
+			setupPayloadDeliveryExceededSlotCount,
 			setupRegisterValidatorCount,
 			setupMissedSlotCount,
 			setupSubmitNewBlockBidValue,
@@ -369,6 +371,18 @@ func setupGetPayloadDeliveryFailureCount(_ context.Context) error {
 		otelapi.WithDescription("number of getPayload requests the relay failed to fulfill despite having committed a bid, by reason"),
 	)
 	GetPayloadDeliveryFailureCount = counter
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func setupPayloadDeliveryExceededSlotCount(_ context.Context) error {
+	counter, err := meter.Int64Counter(
+		"payload_delivery_exceeded_slot",
+		otelapi.WithDescription("number of getPayload requests that started within the slot but whose block was published only after the slot ended"),
+	)
+	PayloadDeliveryExceededSlotCount = counter
 	if err != nil {
 		return err
 	}

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1498,6 +1498,7 @@ func (api *RelayAPI) innerHandleGetPayload(w http.ResponseWriter, req *http.Requ
 	ua := req.UserAgent()
 	headSlot := api.headSlot.Load()
 	receivedAt := time.Now().UTC()
+	requestStartSlot := CurrentSlot(api.genesisInfo.Data.GenesisTime, receivedAt.UnixMilli())
 	log := api.log.WithFields(logrus.Fields{
 		"method":                      "getPayload",
 		"version":                     version,
@@ -1507,6 +1508,7 @@ func (api *RelayAPI) innerHandleGetPayload(w http.ResponseWriter, req *http.Requ
 		"headSlot":                    headSlot,
 		"headSlotEpochPos":            (headSlot % common.SlotsPerEpoch) + 1,
 		"idArg":                       req.URL.Query().Get("id"),
+		"requestStartSlot":            requestStartSlot,
 		"timestampRequestStart":       receivedAt.UnixMilli(),
 		"negotiatedResponseMediaType": negotiatedResponseMediaType,
 		"proposerContentType":         proposerContentType,
@@ -1839,6 +1841,11 @@ func (api *RelayAPI) innerHandleGetPayload(w http.ResponseWriter, req *http.Requ
 		return
 	}
 
+	// For the payload_delivery_exceeded_slot metric: if the request started within
+	// the payload's slot but the block was published in a later slot, the delivery
+	// exceeded the slot.
+	requestStartedInSlot := requestStartSlot == uint64(slot)
+
 	if version == HandleGetPayloadVersionV1 {
 		timeBeforePublish := time.Now().UTC().UnixMilli()
 		log = log.WithField("timestampBeforePublishing", timeBeforePublish)
@@ -1858,6 +1865,10 @@ func (api *RelayAPI) innerHandleGetPayload(w http.ResponseWriter, req *http.Requ
 		log = log.WithField("timestampAfterPublishing", timeAfterPublish)
 		log.WithField("msNeededForPublishing", msNeededForPublishing).Info("block published through beacon node")
 		metrics.PublishBlockLatencyHistogram.Record(req.Context(), float64(msNeededForPublishing))
+		if requestStartedInSlot && CurrentSlot(api.genesisInfo.Data.GenesisTime, timeAfterPublish) > requestStartSlot {
+			log.Warn("payload delivery exceeded slot")
+			metrics.PayloadDeliveryExceededSlotCount.Add(req.Context(), 1)
+		}
 
 		// give the beacon network some time to propagate the block
 		time.Sleep(time.Duration(getPayloadResponseDelayMs) * time.Millisecond)
@@ -1896,6 +1907,10 @@ func (api *RelayAPI) innerHandleGetPayload(w http.ResponseWriter, req *http.Requ
 
 			log.Info("block published through beacon node")
 			metrics.PublishBlockLatencyHistogram.Record(context.Background(), float64(msNeededForPublishing))
+			if requestStartedInSlot && CurrentSlot(api.genesisInfo.Data.GenesisTime, timeAfterPublish) > requestStartSlot {
+				log.Warn("payload delivery exceeded slot")
+				metrics.PayloadDeliveryExceededSlotCount.Add(context.Background(), 1)
+			}
 		}()
 
 		log.Debug("responding with only accepted status code")

--- a/services/api/utils.go
+++ b/services/api/utils.go
@@ -231,6 +231,16 @@ func getPayloadAttributesKey(parentHash string, slot uint64) string {
 	return fmt.Sprintf("%s-%d", parentHash, slot)
 }
 
+// CurrentSlot returns the slot that the given unix millisecond timestamp falls
+// into. Timestamps before genesis return slot 0.
+func CurrentSlot(genesisTime uint64, timestampMs int64) uint64 {
+	genesisMs := int64(genesisTime * 1000) //nolint:gosec
+	if timestampMs < genesisMs {
+		return 0
+	}
+	return uint64(timestampMs-genesisMs) / (common.SecondsPerSlot * 1000)
+}
+
 // parseClientDeadlineMs returns the unix-millisecond deadline communicated by
 // the client via the Date-Milliseconds and X-Timeout-Ms headers, if both are
 // present and parseable.

--- a/services/api/utils_test.go
+++ b/services/api/utils_test.go
@@ -268,3 +268,45 @@ func TestGetSlotFromBuilderSSZPayload(t *testing.T) {
 		})
 	}
 }
+
+func TestCurrentSlot(t *testing.T) {
+	const genesisTime = uint64(1_606_824_023) // mainnet genesis
+	genesisMs := int64(genesisTime * 1000)
+	slotMs := int64(common.SecondsPerSlot * 1000)
+
+	for _, tc := range []struct {
+		name        string
+		timestampMs int64
+		expected    uint64
+	}{
+		{
+			name:        "before genesis",
+			timestampMs: genesisMs - 1,
+			expected:    0,
+		},
+		{
+			name:        "at genesis",
+			timestampMs: genesisMs,
+			expected:    0,
+		},
+		{
+			name:        "last ms of slot 0",
+			timestampMs: genesisMs + slotMs - 1,
+			expected:    0,
+		},
+		{
+			name:        "start of slot 1",
+			timestampMs: genesisMs + slotMs,
+			expected:    1,
+		},
+		{
+			name:        "middle of slot 100",
+			timestampMs: genesisMs + 100*slotMs + slotMs/2,
+			expected:    100,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, CurrentSlot(genesisTime, tc.timestampMs))
+		})
+	}
+}


### PR DESCRIPTION
## 📝 Summary

This adds `payload_delivery_exceeded_slot` metric which keeps track of the `PublishBlock` requests done in `getPayload`, and is incremented whenever a request starts within the right slot but block publishing ends after the slot is over.

## ⛱ Motivation and Context

This helps us track the exact behavior we had with late payload deliveries due to AWS DNS issues.
